### PR TITLE
Add beautier pages for unsubscription process.

### DIFF
--- a/mass_mailing_custom_unsubscribe/README.rst
+++ b/mass_mailing_custom_unsubscribe/README.rst
@@ -5,17 +5,17 @@
 Customizable unsubscription process on mass mailing emails
 ==========================================================
 
-With this module you can set a custom unsubscribe link append at bottom of mass
-mailing emails.
+With this module you can set a custom unsubscribe link appended at the bottom
+of mass mailing emails.
 
 
 Configuration
 =============
 
-To configure unsubscribe label go to *Setting > Technical > Parameters > System
-parameters* and add a 'mass_mailing.unsubscribe.label' parameter with html to
-set at bottom of mass emailing emails. Including ``%(url)s`` variable where
-unsubscribe link.
+To configure unsubscribe label go to *Settings > Technical > Parameters >
+System parameters* and add a ``mass_mailing.unsubscribe.label`` parameter
+with HTML to set at the bottom of mass emailing emails. Including ``%(url)s``
+variable where unsubscribe link.
 
 For example::
 
@@ -23,12 +23,12 @@ For example::
 
 Additionally, you can disable this link if you set this parameter to ``False``.
 
-If this parameter (``mass_mailing.unsubscribe.label``) is not set (or set to
-``''``) default 'Click to unsubscribe' link will appear. This default text is
+If this parameter (``mass_mailing.unsubscribe.label``) does not exist, the
+default 'Click to unsubscribe' link will appear, with the advantage that it is
 translatable via *Settings > Translations > Application Terms > Translated
 terms*.
 
-Also your unsubscriptors will recieve a beautier good bye page. You can
+Also your unsubscriptors will recieve a beautier goodbye page. You can
 customize it clicking here **after installing the module**:
 
 * `Unsubscription successful </page/mass_mail_unsubscription_success>`_.
@@ -46,7 +46,7 @@ Usage
 Known issues / Roadmap
 ======================
 
-* This custom html is not translatable, so as a suggestion, you can define
+* This custom HTML is not translatable, so as a suggestion, you can define
   the same text in several languages in several lines.
 
 For example:

--- a/mass_mailing_custom_unsubscribe/README.rst
+++ b/mass_mailing_custom_unsubscribe/README.rst
@@ -1,9 +1,9 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
     :alt: License: AGPL-3
 
-====================================================
-Customizable unsubscribe link on mass mailing emails
-====================================================
+==========================================================
+Customizable unsubscription process on mass mailing emails
+==========================================================
 
 With this module you can set a custom unsubscribe link append at bottom of mass
 mailing emails.
@@ -12,22 +12,27 @@ mailing emails.
 Configuration
 =============
 
-To configure unsubscribe label go to Setting > Technical > Parameters > System parameters
-and add a 'mass_mailing.unsubscribe.label' parameter with html to set at bottom
-of mass emailing emails. Including '%(url)s' variable where unsubscribe link
+To configure unsubscribe label go to *Setting > Technical > Parameters > System
+parameters* and add a 'mass_mailing.unsubscribe.label' parameter with html to
+set at bottom of mass emailing emails. Including ``%(url)s`` variable where
+unsubscribe link.
 
-For example:
+For example::
 
-.. code:: html
+    <small>You can unsubscribe <a href="%(url)s">here</a></small>
 
-  <small>You can unsubscribe <a href="%(url)s">here</a></small>
+Additionally, you can disable this link if you set this parameter to ``False``.
 
+If this parameter (``mass_mailing.unsubscribe.label``) is not set (or set to
+``''``) default 'Click to unsubscribe' link will appear. This default text is
+translatable via *Settings > Translations > Application Terms > Translated
+terms*.
 
-Additionally, you can disable this link if you set this parameter to 'False'
+Also your unsubscriptors will recieve a beautier good bye page. You can
+customize it clicking here **after installing the module**:
 
-If this parameter (mass_mailing.unsubscribe.label) is not set (or set to '')
-default 'Click to unsubscribe' link will appear. This default text is
-translatable via Settings > Translations > Application Terms > Translated terms
+* `Unsubscription successful </page/mass_mail_unsubscription_success>`_.
+* `Unsubscription failed </page/mass_mail_unsubscription_failure>`_.
 
 
 Usage
@@ -69,6 +74,7 @@ Contributors
 
 * Rafael Blasco <rafabn@antiun.com>
 * Antonio Espinosa <antonioea@antiun.com>
+* Jairo Llopis <yajo.sk8@gmail.com>
 
 Maintainer
 ----------

--- a/mass_mailing_custom_unsubscribe/__init__.py
+++ b/mass_mailing_custom_unsubscribe/__init__.py
@@ -4,4 +4,4 @@
 # For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
 
-from . import models
+from . import controllers, models

--- a/mass_mailing_custom_unsubscribe/__openerp__.py
+++ b/mass_mailing_custom_unsubscribe/__openerp__.py
@@ -21,13 +21,15 @@
 #
 ##############################################################################
 {
-    'name': "Customizable unsubscribe link on mass mailing emails",
+    'name': "Customizable unsubscription process on mass mailing emails",
     'category': 'Marketing',
-    'version': '8.0.1.0.0',
+    'version': '8.0.2.0.0',
     'depends': [
         'mass_mailing',
+        'website_crm',
     ],
     'data': [
+        'views/pages.xml',
     ],
     'author': 'Antiun Ingeniería S.L., '
               'Odoo Community Association (OCA)',

--- a/mass_mailing_custom_unsubscribe/__openerp__.py
+++ b/mass_mailing_custom_unsubscribe/__openerp__.py
@@ -23,7 +23,7 @@
 {
     'name': "Customizable unsubscription process on mass mailing emails",
     'category': 'Marketing',
-    'version': '8.0.2.0.0',
+    'version': '8.0.1.1.0',
     'depends': [
         'mass_mailing',
         'website_crm',

--- a/mass_mailing_custom_unsubscribe/controllers.py
+++ b/mass_mailing_custom_unsubscribe/controllers.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# © 2015 Antiun Ingeniería S.L. (http://www.antiun.com)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from openerp import http
+from openerp.addons.mass_mailing.controllers.main import MassMailController
+
+
+class CustomUnsuscribe(MassMailController):
+    @http.route()
+    def mailing(self, *args, **kwargs):
+        path = "/page/mass_mail_unsubscription_%s"
+        result = super(CustomUnsuscribe, self).mailing(*args, **kwargs)
+        return http.local_redirect(
+            path % ("success" if result.data == "OK" else "failure"))

--- a/mass_mailing_custom_unsubscribe/views/pages.xml
+++ b/mass_mailing_custom_unsubscribe/views/pages.xml
@@ -11,7 +11,7 @@
                 <div class="container">
                     <h1>
                         You were successfully unsubscribed from our
-                        mailing list
+                        mailing list.
                     </h1>
                     <h3 class="text-muted">
                         It's sad to see you go, but if you love
@@ -40,10 +40,10 @@
                 <div class="container">
                     <h1>
                         There was an error processing your unsubscription
-                        request
+                        request.
                     </h1>
                     <p>
-                        We apologize for the inconvinience. You can contact us
+                        We apologize for the inconvenience. You can contact us
                         and we will handle your unsubscription manually.
                     </p>
                     <p>Thanks for your patience.</p>

--- a/mass_mailing_custom_unsubscribe/views/pages.xml
+++ b/mass_mailing_custom_unsubscribe/views/pages.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<openerp>
+<data>
+
+<template name="Unsubscription worked"
+          id="website.mass_mail_unsubscription_success"
+          page="True">
+    <t t-call="website.layout">
+        <div id="wrap" class="oe_structure oe_empty">
+            <section class="jumbotron mt16 mb16">
+                <div class="container">
+                    <h1>
+                        You were successfully unsubscribed from our
+                        mailing list
+                    </h1>
+                    <h3 class="text-muted">
+                        It's sad to see you go, but if you love
+                        something, let it go.
+                    </h3>
+                    <p>
+                        However, we are open to suggestions. Please tell us
+                        why you left.
+                    </p>
+                    <p>
+                        <a class="btn btn-primary btn-lg"
+                           href="/page/website.contactus">Contact us</a>
+                    </p>
+                </div>
+            </section>
+        </div>
+    </t>
+</template>
+
+<template name="Unsubscription failed"
+          id="website.mass_mail_unsubscription_failure"
+          page="True">
+    <t t-call="website.layout">
+        <div id="wrap" class="oe_structure oe_empty">
+            <section class="jumbotron mt16 mb16">
+                <div class="container">
+                    <h1>
+                        There was an error processing your unsubscription
+                        request
+                    </h1>
+                    <p>
+                        We apologize for the inconvinience. You can contact us
+                        and we will handle your unsubscription manually.
+                    </p>
+                    <p>Thanks for your patience.</p>
+                    <p>
+                        <a class="btn btn-primary btn-lg"
+                           href="/page/website.contactus">Contact us</a>
+                    </p>
+                </div>
+            </section>
+        </div>
+    </t>
+</template>
+
+</data>
+</openerp>


### PR DESCRIPTION
Core Odoo shows `OK` or `KO` when somebody clicks the unsubscription link. That's ugly.

This patch makes this module to add an elegant good bye page in case it works and another in case it does not.

By default, that page contains a link to contact form, and thus the new dependency.
