### PR TITLE
[8.0][FIX][website_snippet_bg_color][website_snippet_responsive] Allow to pick color for almost-background element.

### DIFF
--- a/website_mail_snippet_bg_color/views/snippets.xml
+++ b/website_mail_snippet_bg_color/views/snippets.xml
@@ -10,8 +10,7 @@
     <xpath expr="//div[@id='snippet_options']">
         <div
             data-snippet-option-id='bg_color_picker'
-            data-selector="[data-oe-field='body_html'] > div,
-                           .oe_snippet_body,
+            data-selector="[data-oe-field='body_html'] > *,
                            .bg_color_picker"
             data-selector-siblings="[data-oe-field='body_html'] > *"
             data-selector-children="[data-oe-field='body_html']">

--- a/website_mail_snippet_responsive/views/templates.xml
+++ b/website_mail_snippet_responsive/views/templates.xml
@@ -20,6 +20,7 @@
             style="padding:0px; width:100%; background-color:#ececec; color:rgb(0,0,0); line-height:20px; font-family:Arial,sans-serif; font-size:9pt">
             <table
                 style="width: 100%; max-width: 570px; border-collapse: collapse; background: inherit; color: inherit; background: #FFFFFF"
+                class="bg_color_picker"
                 cellpadding="0"
                 cellspacing="0"
                 align="center"


### PR DESCRIPTION
Right now only able to pick for the backest element in responsive snippets. This allows it for the previous one.

Also allow other elements than divs to be colored.

@dgzurita @rafaelbn 
