### PR TITLE
[8.0][mail_forward] Custom migration

### DIFF
--- a/mail_forward/__openerp__.py
+++ b/mail_forward/__openerp__.py
@@ -5,7 +5,7 @@
 {
     "name": "Message Forward",
     "summary": "Add option to forward messages",
-    "version": "8.0.7.0.0",
+    "version": "8.0.7.0.1",
     "category": "Social Network",
     "website": "https://grupoesoc.es",
     "author": "Grupo ESOC Ingeniería de Servicios, "

--- a/mail_forward/migrations/8.0.7.0.1/pre-migrate.py
+++ b/mail_forward/migrations/8.0.7.0.1/pre-migrate.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# © 2016 Grupo ESOC Ingeniería de Servicios, S.L.U. - Jairo Llopis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+try:
+    from openerp.addons import migratk
+
+    @migratk.manage
+    def migrate(cr, version):
+        """Update database from previous versions, before updating module."""
+        mail_forward = migratk.Migrator(cr, "mail_forward")
+        mail_forward._table_constraint_remove(
+            "mail_forward_compose_message",
+            "mail_forward_compose_message_original_wizard_id_fkey")
+        mail_forward.model_remove("mail_forward.compose.message", False)
+
+except ImportError:
+    # If you get here, it means that you don't need the migration
+    def migrate(cr, version):
+        pass


### PR DESCRIPTION
This is a little migration script I need because in [Grupo ESOC](https://grupoesoc.es) we had a slightly different version of this module before publishing to OCA, and now there's a conflict this solves.

This also serves as an example migration for https://github.com/OCA/server-tools/pull/369, since it uses that toolkit for doing it. But to avoid conflicts with others, as you can see, all is inside a `try...except` that will just allow anyone to run the migration without hassle.

Thanks for your understanding.
