### PR TITLE
[ADD] new module base_mail_bcc 

### DIFF
--- a/base_mail_bcc/README.rst
+++ b/base_mail_bcc/README.rst
@@ -6,7 +6,7 @@
 BCC all emails
 ==============
 
-This module extends the email meachnism to allow for sending a blind carbon copy (BCC) 
+This module extends the email mechanism to allow for sending a blind carbon copy (BCC)
 of all outgoing emails to configurable e-mail addresses.
 
 Configuration
@@ -15,7 +15,7 @@ Configuration
 To configure this module, you need to:
 
 * Go to Settings > Parameters > System Parameters
-* Create a new entry with key `mail.always_bcc_to` and set the desired e-mail addresses for BCC as value. This value must be comma-separated list of valid e-mail addresses.
+* Create a new entry with key `base_mail_bcc.bcc_to` and set the desired e-mail addresses for BCC as value. This value must be a comma-separated list of valid e-mail addresses.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot

--- a/base_mail_bcc/README.rst
+++ b/base_mail_bcc/README.rst
@@ -1,0 +1,58 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==============
+BCC all emails
+==============
+
+This module extends the email meachnism to allow for sending a blind carbon copy (BCC) 
+of all outgoing emails to configurable e-mail addresses.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+* Go to Settings > Parameters > System Parameters
+* Create a new entry with key `mail.always_bcc_to` and set the desired e-mail addresses for BCC as value. This value must be comma-separated list of valid e-mail addresses.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/205/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/social/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Thomas Rehn <thomas.rehn@initos.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/base_mail_bcc/__init__.py
+++ b/base_mail_bcc/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2014-2016 Thomas Rehn (initOS GmbH)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/base_mail_bcc/__openerp__.py
+++ b/base_mail_bcc/__openerp__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# © 2014-2016 Thomas Rehn (initOS GmbH)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "BCC all emails",
+    "version": "8.0.1.0.0",
+    "depends": ["base"],
+    'author': 'initOS GmbH, Odoo Community Association (OCA)',
+    "category": "Uncategorized",
+    'license': 'AGPL-3',
+    'data': [
+    ],
+    'demo': ['demo/mail_bcc_demo.xml'],
+    'test': [
+    ],
+    'installable': True,
+    'auto_install': False,
+}

--- a/base_mail_bcc/__openerp__.py
+++ b/base_mail_bcc/__openerp__.py
@@ -6,7 +6,7 @@
     "version": "8.0.1.0.0",
     "depends": ["base"],
     'author': 'initOS GmbH, Odoo Community Association (OCA)',
-    "category": "Uncategorized",
+    "category": "Tools",
     'license': 'AGPL-3',
     'data': [
     ],

--- a/base_mail_bcc/demo/mail_bcc_demo.xml
+++ b/base_mail_bcc/demo/mail_bcc_demo.xml
@@ -2,7 +2,7 @@
 <openerp>
     <data noupdate="1">
         <record id="mail_bcc" model="ir.config_parameter">
-            <field name="key">mail.always_bcc_to</field>
+            <field name="key">base_mail_bcc.bcc_to</field>
             <field name="value">root@example.com</field>
         </record>
     </data>

--- a/base_mail_bcc/demo/mail_bcc_demo.xml
+++ b/base_mail_bcc/demo/mail_bcc_demo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+        <record id="mail_bcc" model="ir.config_parameter">
+            <field name="key">mail.always_bcc_to</field>
+            <field name="value">root@example.com</field>
+        </record>
+    </data>
+</openerp>

--- a/base_mail_bcc/models/__init__.py
+++ b/base_mail_bcc/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2014-2016 Thomas Rehn (initOS GmbH)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import ir_mail_server

--- a/base_mail_bcc/models/ir_mail_server.py
+++ b/base_mail_bcc/models/ir_mail_server.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# © 2014-2016 Thomas Rehn (initOS GmbH)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import models
+from email.Utils import COMMASPACE
+
+
+class IrMailServer(models.Model):
+    _inherit = "ir.mail_server"
+
+    def send_email(self, cr, uid, message, mail_server_id=None,
+                   smtp_server=None, smtp_port=None, smtp_user=None,
+                   smtp_password=None, smtp_encryption=None,
+                   smtp_debug=False, context=None):
+
+        "Add global bcc email addresses"
+
+        # These are added here in send_email instead of build_email
+        #  because build_email is independent from the database and does not
+        #  have a cursor as parameter.
+
+        ir_config_parameter = self.pool.get("ir.config_parameter")
+        config_email_bcc = ir_config_parameter.get_param(cr, uid,
+                                                         "mail.always_bcc_to")
+
+        if config_email_bcc:
+            config_email_bcc = config_email_bcc.encode('ascii')
+            existing_bcc = []
+            if message['Bcc']:
+                existing_bcc.append(message['Bcc'])
+                del message['Bcc']
+            message['Bcc'] = COMMASPACE.join(
+                existing_bcc + config_email_bcc.split(',')
+            )
+
+        return super(IrMailServer, self)\
+            .send_email(cr, uid, message, mail_server_id, smtp_server,
+                        smtp_port, smtp_user, smtp_password, smtp_encryption,
+                        smtp_debug, context)

--- a/base_mail_bcc/models/ir_mail_server.py
+++ b/base_mail_bcc/models/ir_mail_server.py
@@ -22,7 +22,7 @@ class IrMailServer(models.Model):
 
         ir_config_parameter = self.pool.get("ir.config_parameter")
         config_email_bcc = ir_config_parameter.get_param(cr, uid,
-                                                         "mail.always_bcc_to")
+                                                         "base_mail_bcc.bcc_to")
 
         if config_email_bcc:
             config_email_bcc = config_email_bcc.encode('ascii')

--- a/base_mail_bcc/models/ir_mail_server.py
+++ b/base_mail_bcc/models/ir_mail_server.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # © 2014-2017 Thomas Rehn (initOS GmbH)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from email.Utils import COMMASPACE
 
 from openerp import models, api
-from email.Utils import COMMASPACE
 
 
 class IrMailServer(models.Model):

--- a/base_mail_bcc/models/ir_mail_server.py
+++ b/base_mail_bcc/models/ir_mail_server.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2014-2016 Thomas Rehn (initOS GmbH)
+# © 2014-2017 Thomas Rehn (initOS GmbH)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp import models, api
@@ -10,7 +10,9 @@ class IrMailServer(models.Model):
     _inherit = "ir.mail_server"
 
     @api.model
-    def send_email(self, message, **kwargs):
+    def send_email(self, message, mail_server_id=None, smtp_server=None,
+                   smtp_port=None, smtp_user=None, smtp_password=None,
+                   smtp_encryption=None, smtp_debug=False):
         """"Add global bcc email addresses"""
 
         # These are added here in send_email instead of build_email
@@ -31,4 +33,9 @@ class IrMailServer(models.Model):
                 existing_bcc + config_email_bcc.split(',')
             )
 
-        return super(IrMailServer, self).send_email(message, **kwargs)
+        return super(IrMailServer, self).send_email(
+            message, mail_server_id=mail_server_id, smtp_server=smtp_server,
+            smtp_port=smtp_port, smtp_user=smtp_user,
+            smtp_password=smtp_password, smtp_encryption=smtp_encryption,
+            smtp_debug=smtp_debug
+        )

--- a/base_mail_bcc/models/ir_mail_server.py
+++ b/base_mail_bcc/models/ir_mail_server.py
@@ -2,27 +2,24 @@
 # © 2014-2016 Thomas Rehn (initOS GmbH)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openerp import models
+from openerp import models, api
 from email.Utils import COMMASPACE
 
 
 class IrMailServer(models.Model):
     _inherit = "ir.mail_server"
 
-    def send_email(self, cr, uid, message, mail_server_id=None,
-                   smtp_server=None, smtp_port=None, smtp_user=None,
-                   smtp_password=None, smtp_encryption=None,
-                   smtp_debug=False, context=None):
-
-        "Add global bcc email addresses"
+    @api.model
+    def send_email(self, message, **kwargs):
+        """"Add global bcc email addresses"""
 
         # These are added here in send_email instead of build_email
         #  because build_email is independent from the database and does not
         #  have a cursor as parameter.
 
-        ir_config_parameter = self.pool.get("ir.config_parameter")
-        config_email_bcc = ir_config_parameter.get_param(cr, uid,
-                                                         "base_mail_bcc.bcc_to")
+        ir_config_parameter = self.env["ir.config_parameter"]
+        config_email_bcc = ir_config_parameter.\
+            get_param("base_mail_bcc.bcc_to")
 
         if config_email_bcc:
             config_email_bcc = config_email_bcc.encode('ascii')
@@ -34,7 +31,4 @@ class IrMailServer(models.Model):
                 existing_bcc + config_email_bcc.split(',')
             )
 
-        return super(IrMailServer, self)\
-            .send_email(cr, uid, message, mail_server_id, smtp_server,
-                        smtp_port, smtp_user, smtp_password, smtp_encryption,
-                        smtp_debug, context)
+        return super(IrMailServer, self).send_email(message, **kwargs)

--- a/base_mail_bcc/tests/__init__.py
+++ b/base_mail_bcc/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# © 2017 initOS GmbH <https://www.initos.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import test_base_mail_bcc

--- a/base_mail_bcc/tests/test_base_mail_bcc.py
+++ b/base_mail_bcc/tests/test_base_mail_bcc.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# © 2017 initOS GmbH <https://www.initos.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import mock
+
+from openerp.tests.common import TransactionCase
+
+
+class TestBaseMailBcc(TransactionCase):
+    def test_base_mail_bcc(self):
+        ir_mail_server = self.env['ir.mail_server']
+        message = ir_mail_server.build_email(
+            email_from='admin@example.com',
+            email_to='admin@example.com',
+            subject='An example E-Mail',
+            body='With an example body',
+        )
+        with mock.patch("smtplib.SMTP"):
+            ir_mail_server.send_email(message)

--- a/base_mail_bcc/tests/test_base_mail_bcc.py
+++ b/base_mail_bcc/tests/test_base_mail_bcc.py
@@ -12,6 +12,7 @@ class TestBaseMailBcc(TransactionCase):
         message = ir_mail_server.build_email(
             email_from='admin@example.com',
             email_to='admin@example.com',
+            email_bcc='unused@example.com',
             subject='An example E-Mail',
             body='With an example body',
         )


### PR DESCRIPTION
This PR adds a new module to configure a e-mail addresses to which all outgoing e-mail are sent in BCC. There are various modules around for this purpose, but none of these is in the OCA.

Note that this is a v8 port of https://github.com/OCA/server-tools/pull/59  (v7) which seems to be unwanted in the other repository.
