### PR TITLE
[FIX] Bad default model_id

### DIFF
--- a/mail_notification_email_template/models/mail_message_subtype.py
+++ b/mail_notification_email_template/models/mail_message_subtype.py
@@ -9,6 +9,6 @@ class MailMessageSubtype(models.Model):
 
     template_id = fields.Many2one(
         'email.template', string='Notification template',
-        domain=[('model_id.model', '=', 'mail.message.subtype')],
+        domain=[('model_id.model', '=', 'mail.notification')],
         help='This template will be used to render notifications sent out '
         'for this subtype')

--- a/mail_notification_email_template/views/mail_message_subtype.xml
+++ b/mail_notification_email_template/views/mail_message_subtype.xml
@@ -6,7 +6,7 @@
             <field name="inherit_id" ref="mail.view_mail_message_subtype_form" />
             <field name="arch" type="xml">
                 <field name="description" position="after">
-                    <field name="template_id" context="{'default_model_id': %(mail.model_mail_message_subtype)d}" />
+                    <field name="template_id" context="{'default_model_id': %(mail.model_mail_notification)d}" />
                 </field>
             </field>
         </record>

--- a/mail_notification_email_template/views/mail_message_subtype.xml
+++ b/mail_notification_email_template/views/mail_message_subtype.xml
@@ -6,7 +6,7 @@
             <field name="inherit_id" ref="mail.view_mail_message_subtype_form" />
             <field name="arch" type="xml">
                 <field name="description" position="after">
-                    <field name="template_id" context="{'default_model_id': %(mail.model_mail_notification)d}" />
+                    <field name="template_id" context="{'default_model_id': %(mail.model_mail_message_subtype)d}" />
                 </field>
             </field>
         </record>


### PR DESCRIPTION
When we create a new template email from the record, the default model_id is fill with wrong model (see domain on mail_message_subtype.py)
