### PR TITLE
[8.0][IMP][mail_tracking] Speed installation time and discard concurrent events

### DIFF
--- a/mail_tracking/__init__.py
+++ b/mail_tracking/__init__.py
@@ -5,4 +5,4 @@
 
 from . import models
 from . import controllers
-from .hooks import post_init_hook
+from .hooks import pre_init_hook

--- a/mail_tracking/__openerp__.py
+++ b/mail_tracking/__openerp__.py
@@ -5,7 +5,7 @@
 {
     "name": "Email tracking",
     "summary": "Email tracking system for all mails sent",
-    "version": "8.0.2.0.0",
+    "version": "8.0.2.0.1",
     "category": "Social Network",
     "website": "http://www.tecnativa.com",
     "author": "Tecnativa, "
@@ -28,5 +28,5 @@
     "qweb": [
         "static/src/xml/mail_tracking.xml",
     ],
-    "post_init_hook": "post_init_hook",
+    "pre_init_hook": "pre_init_hook",
 }

--- a/mail_tracking/models/mail_message.py
+++ b/mail_tracking/models/mail_message.py
@@ -46,7 +46,7 @@ class MailMessage(models.Model):
                     tracking_email = self.env['mail.tracking.email'].search([
                         ('mail_message_id', '=', mail_message_id),
                         ('partner_id', '=', partner_id),
-                    ])
+                    ], limit=1)
                     status = self._partner_tracking_status_get(tracking_email)
                     partner_trackings[str(partner_id)] = (
                         status, tracking_email.id)

--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -13,8 +13,8 @@ import openerp.addons.decimal_precision as dp
 
 _logger = logging.getLogger(__name__)
 
-EVENT_OPEN_DELTA = 10
-EVENT_CLICK_DELTA = 5
+EVENT_OPEN_DELTA = 10  # seconds
+EVENT_CLICK_DELTA = 5  # seconds
 
 
 class MailTrackingEmail(models.Model):
@@ -293,7 +293,7 @@ class MailTrackingEmail(models.Model):
                 if partners:
                     partners.email_score_calculate()
             else:
-                _logger.info("Concurrent event '%s' discarded", event_type)
+                _logger.debug("Concurrent event '%s' discarded", event_type)
         return event_ids
 
     @api.model

--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -13,6 +13,9 @@ import openerp.addons.decimal_precision as dp
 
 _logger = logging.getLogger(__name__)
 
+EVENT_OPEN_DELTA = 10
+EVENT_CLICK_DELTA = 5
+
 
 class MailTrackingEmail(models.Model):
     _name = "mail.tracking.email"
@@ -104,7 +107,7 @@ class MailTrackingEmail(models.Model):
                     obj.write({
                         tracking_field: [(5, False, False)]
                     })
-        return True
+        return objects
 
     @api.model
     def _tracking_ids_to_write(self, email):
@@ -256,13 +259,41 @@ class MailTrackingEmail(models.Model):
             _logger.info('Unknown event type: %s' % event_type)
         return False
 
+    def _concurrent_events(self, event_type, metadata):
+        m_event = self.env['mail.tracking.event']
+        self.ensure_one()
+        concurrent_event_ids = False
+        if event_type in {'open', 'click'}:
+            ts = metadata.get('timestamp', time.time())
+            delta = EVENT_OPEN_DELTA if event_type == 'open' \
+                else EVENT_CLICK_DELTA
+            domain = [
+                ('timestamp', '>=', ts - delta),
+                ('timestamp', '<=', ts + delta),
+                ('tracking_email_id', '=', self.id),
+                ('event_type', '=', event_type),
+            ]
+            if event_type == 'click':
+                domain.append(('url', '=', metadata.get('url', False)))
+            concurrent_event_ids = m_event.search(domain)
+        return concurrent_event_ids
+
     @api.multi
     def event_create(self, event_type, metadata):
         event_ids = self.env['mail.tracking.event']
         for tracking_email in self:
-            vals = tracking_email._event_prepare(event_type, metadata)
-            if vals:
-                event_ids += event_ids.sudo().create(vals)
+            other_ids = tracking_email._concurrent_events(event_type, metadata)
+            if not other_ids:
+                vals = tracking_email._event_prepare(event_type, metadata)
+                if vals:
+                    event_ids += event_ids.sudo().create(vals)
+                partners = self.tracking_ids_recalculate(
+                    'res.partner', 'email', 'tracking_email_ids',
+                    tracking_email.recipient_address)
+                if partners:
+                    partners.email_score_calculate()
+            else:
+                _logger.info("Concurrent event '%s' discarded", event_type)
         return event_ids
 
     @api.model

--- a/mail_tracking/models/res_partner.py
+++ b/mail_tracking/models/res_partner.py
@@ -19,6 +19,12 @@ class ResPartner(models.Model):
 
     @api.multi
     def email_score_calculate(self):
+        # This is not a compute method because is causing a inter-block
+        # in mail_tracking_email PostgreSQL table
+        # We suspect that tracking_email write to state field block that
+        # table and then inside write ORM try to read from DB
+        # tracking_email_ids because it's not in cache.
+        # PostgreSQL blocks read because we have not committed yet the write
         for partner in self:
             partner.email_score = partner.tracking_email_ids.email_score()
 

--- a/mail_tracking/models/res_partner.py
+++ b/mail_tracking/models/res_partner.py
@@ -15,13 +15,12 @@ class ResPartner(models.Model):
         string="Tracking emails count", store=True, readonly=True,
         compute="_compute_tracking_emails_count")
     email_score = fields.Float(
-        string="Email score",
-        compute="_compute_email_score", store=True, readonly=True)
+        string="Email score", readonly=True, default=50.0)
 
-    @api.one
-    @api.depends('tracking_email_ids.state')
-    def _compute_email_score(self):
-        self.email_score = self.tracking_email_ids.email_score()
+    @api.multi
+    def email_score_calculate(self):
+        for partner in self:
+            partner.email_score = partner.tracking_email_ids.email_score()
 
     @api.one
     @api.depends('tracking_email_ids')

--- a/mail_tracking_mass_mailing/__init__.py
+++ b/mail_tracking_mass_mailing/__init__.py
@@ -3,4 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models
-from .hooks import post_init_hook
+from .hooks import pre_init_hook

--- a/mail_tracking_mass_mailing/__openerp__.py
+++ b/mail_tracking_mass_mailing/__openerp__.py
@@ -5,7 +5,7 @@
 {
     "name": "Mail tracking for mass mailing",
     "summary": "Improve mass mailing email tracking",
-    "version": "8.0.1.0.0",
+    "version": "8.0.1.0.1",
     "category": "Social Network",
     "website": "http://www.tecnativa.com",
     "author": "Tecnativa, "
@@ -24,5 +24,5 @@
         "views/mail_mass_mailing_view.xml",
         "views/mail_mass_mailing_contact_view.xml",
     ],
-    "post_init_hook": "post_init_hook",
+    "pre_init_hook": "pre_init_hook",
 }

--- a/mail_tracking_mass_mailing/hooks.py
+++ b/mail_tracking_mass_mailing/hooks.py
@@ -3,14 +3,18 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import logging
-from openerp.addons.mail_tracking.hooks import column_add_with_value
+try:
+    from openerp.addons.mail_tracking.hooks import column_add_with_value
+except ImportError:
+    column_add_with_value = False
 
 _logger = logging.getLogger(__name__)
 
 
 def pre_init_hook(cr):
-    _logger.info("Creating mail.mass_mailing.contact.email_score column "
-                 "with value 50.0")
-    column_add_with_value(
-        cr, 'mail_mass_mailing_contact', 'email_score', 'double precision',
-        50.0)
+    if column_add_with_value:
+        _logger.info("Creating mail.mass_mailing.contact.email_score column "
+                     "with value 50.0")
+        column_add_with_value(
+            cr, 'mail_mass_mailing_contact', 'email_score', 'double precision',
+            50.0)

--- a/mail_tracking_mass_mailing/hooks.py
+++ b/mail_tracking_mass_mailing/hooks.py
@@ -3,26 +3,14 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import logging
-from openerp import api, SUPERUSER_ID
+from openerp.addons.mail_tracking.hooks import column_add_with_value
 
 _logger = logging.getLogger(__name__)
 
 
-def post_init_hook(cr, registry):
-    with api.Environment.manage():
-        env = api.Environment(cr, SUPERUSER_ID, {})
-        # Recalculate all mass_mailing contacts tracking_email_ids
-        contacts = env['mail.mass_mailing.contact'].search([
-            ('email', '!=', False),
-        ])
-        emails = contacts.mapped('email')
-        _logger.info(
-            "Recalculating 'tracking_email_ids' in "
-            "'mail.mass_mailing.contact' model for %d email addresses",
-            len(emails))
-        for n, email in enumerate(emails):
-            env['mail.tracking.email'].tracking_ids_recalculate(
-                'mail.mass_mailing.contact', 'email', 'tracking_email_ids',
-                email)
-            if n % 500 == 0:  # pragma: no cover
-                _logger.info("   Recalculated %d of %d", n, len(emails))
+def pre_init_hook(cr):
+    _logger.info("Creating mail.mass_mailing.contact.email_score column "
+                 "with value 50.0")
+    column_add_with_value(
+        cr, 'mail_mass_mailing_contact', 'email_score', 'double precision',
+        50.0)

--- a/mail_tracking_mass_mailing/models/mail_mail_statistics.py
+++ b/mail_tracking_mass_mailing/models/mail_mail_statistics.py
@@ -14,5 +14,3 @@ class MailMailStatistics(models.Model):
     tracking_event_ids = fields.One2many(
         string="Tracking events", comodel_name='mail.tracking.event',
         related='mail_tracking_id.tracking_event_ids', readonly=True)
-    tracking_state = fields.Selection(
-        string="State", related='mail_tracking_id.state', store=True)

--- a/mail_tracking_mass_mailing/models/mail_mass_mailing_contact.py
+++ b/mail_tracking_mass_mailing/models/mail_mass_mailing_contact.py
@@ -12,13 +12,12 @@ class MailMassMailingContact(models.Model):
         string="Tracking emails", comodel_name="mail.tracking.email",
         readonly=True)
     email_score = fields.Float(
-        string="Email score",
-        compute="_compute_email_score", store=True, readonly=True)
+        string="Email score", readonly=True, default=50.0)
 
-    @api.one
-    @api.depends('tracking_email_ids', 'tracking_email_ids.state')
-    def _compute_email_score(self):
-        self.email_score = self.tracking_email_ids.email_score()
+    @api.multi
+    def email_score_calculate(self):
+        for contact in self:
+            contact.email_score = contact.tracking_email_ids.email_score()
 
     @api.multi
     def write(self, vals):

--- a/mail_tracking_mass_mailing/models/mail_tracking_email.py
+++ b/mail_tracking_mass_mailing/models/mail_tracking_email.py
@@ -39,3 +39,14 @@ class MailTrackingEmail(models.Model):
             'mail.mass_mailing.contact', 'email', 'tracking_email_ids',
             tracking.recipient_address, new_tracking=tracking)
         return tracking
+
+    @api.multi
+    def event_create(self, event_type, metadata):
+        res = super(MailTrackingEmail, self).event_create(event_type, metadata)
+        for tracking_email in self:
+            contacts = self.tracking_ids_recalculate(
+                'mail.mass_mailing.contact', 'email', 'tracking_email_ids',
+                tracking_email.recipient_address)
+            if contacts:
+                contacts.email_score_calculate()
+        return res

--- a/mail_tracking_mass_mailing/models/mail_tracking_event.py
+++ b/mail_tracking_mass_mailing/models/mail_tracking_event.py
@@ -15,3 +15,35 @@ class MailTrackingEvent(models.Model):
         mail_mail_stats = self.sudo().env['mail.mail.statistics']
         mail_mail_stats.set_opened(mail_mail_ids=[tracking_email.mail_id_int])
         return res
+
+    def _tracking_set_bounce(self, tracking_email, metadata):
+        mail_mail_stats = self.sudo().env['mail.mail.statistics']
+        mail_mail_stats.set_bounced(mail_mail_ids=[tracking_email.mail_id_int])
+
+    @api.model
+    def process_hard_bounce(self, tracking_email, metadata):
+        res = super(MailTrackingEvent, self).process_hard_bounce(
+            tracking_email, metadata)
+        self._tracking_set_bounce(tracking_email, metadata)
+        return res
+
+    @api.model
+    def process_soft_bounce(self, tracking_email, metadata):
+        res = super(MailTrackingEvent, self).process_soft_bounce(
+            tracking_email, metadata)
+        self._tracking_set_bounce(tracking_email, metadata)
+        return res
+
+    @api.model
+    def process_reject(self, tracking_email, metadata):
+        res = super(MailTrackingEvent, self).process_reject(
+            tracking_email, metadata)
+        self._tracking_set_bounce(tracking_email, metadata)
+        return res
+
+    @api.model
+    def process_spam(self, tracking_email, metadata):
+        res = super(MailTrackingEvent, self).process_spam(
+            tracking_email, metadata)
+        self._tracking_set_bounce(tracking_email, metadata)
+        return res

--- a/mail_tracking_mass_mailing/tests/test_mass_mailing.py
+++ b/mail_tracking_mass_mailing/tests/test_mass_mailing.py
@@ -72,7 +72,6 @@ class TestMassMailing(TransactionCase):
             }
             tracking_email.event_create('open', metadata)
             self.assertTrue(stat.opened)
-            self.assertEqual(stat.tracking_state, 'opened')
 
     def _tracking_email_bounce(self, event_type, state):
         self.mailing.send_mail()
@@ -89,7 +88,6 @@ class TestMassMailing(TransactionCase):
             }
             tracking_email.event_create(event_type, metadata)
             self.assertTrue(stat.bounced)
-            self.assertEqual(stat.tracking_state, state)
 
     def test_tracking_email_hard_bounce(self):
             self._tracking_email_bounce('hard_bounce', 'bounced')

--- a/mail_tracking_mass_mailing/tests/test_mass_mailing.py
+++ b/mail_tracking_mass_mailing/tests/test_mass_mailing.py
@@ -74,6 +74,35 @@ class TestMassMailing(TransactionCase):
             self.assertTrue(stat.opened)
             self.assertEqual(stat.tracking_state, 'opened')
 
+    def _tracking_email_bounce(self, event_type, state):
+        self.mailing.send_mail()
+        for stat in self.mailing.statistics_ids:
+            if stat.mail_mail_id:
+                stat.mail_mail_id.send()
+            tracking_email = self.env['mail.tracking.email'].search([
+                ('mail_id_int', '=', stat.mail_mail_id_int),
+            ])
+            # And now mark the email as bounce
+            metadata = {
+                'bounce_type': '499',
+                'bounce_description': 'Unable to connect to MX servers',
+            }
+            tracking_email.event_create(event_type, metadata)
+            self.assertTrue(stat.bounced)
+            self.assertEqual(stat.tracking_state, state)
+
+    def test_tracking_email_hard_bounce(self):
+            self._tracking_email_bounce('hard_bounce', 'bounced')
+
+    def test_tracking_email_soft_bounce(self):
+            self._tracking_email_bounce('soft_bounce', 'soft-bounced')
+
+    def test_tracking_email_reject(self):
+            self._tracking_email_bounce('reject', 'rejected')
+
+    def test_tracking_email_spam(self):
+            self._tracking_email_bounce('spam', 'spam')
+
     def test_contact_tracking_emails(self):
         self.mailing.send_mail()
         for stat in self.mailing.statistics_ids:

--- a/mail_tracking_mass_mailing/views/mail_mail_statistics_view.xml
+++ b/mail_tracking_mass_mailing/views/mail_mail_statistics_view.xml
@@ -9,9 +9,6 @@
     <field name="model">mail.mail.statistics</field>
     <field name="inherit_id" ref="mass_mailing.view_mail_mail_statistics_form"/>
     <field name="arch" type="xml">
-        <field name="res_id" position="after">
-            <field name="tracking_state"/>
-        </field>
         <xpath expr="//form" position="inside">
             <group>
                 <field name="mail_tracking_id" />
@@ -31,17 +28,6 @@
                 </field>
             </div>
         </xpath>
-    </field>
-</record>
-
-<record model="ir.ui.view" id="view_mail_mail_statistics_tree">
-    <field name="name">Add partner and state columns</field>
-    <field name="model">mail.mail.statistics</field>
-    <field name="inherit_id" ref="mass_mailing.view_mail_mail_statistics_tree"/>
-    <field name="arch" type="xml">
-        <field name="sent" position="before">
-            <field name="tracking_state"/>
-        </field>
     </field>
 </record>
 


### PR DESCRIPTION
Several improvements after using mail_tracking_\* addons in production environment:
- Remove post_init_hook: When installing these addons there's no mail_tracking_mail objects in DB, so there's no point to relate them to any res.partner
- Add pre_init_hook: Create and set a value to compute + store columns (and email_score column), before installing this addon
- Remove compute and api.depends on email_score fields
- Do not save concurrent open or click events: 
  - If there's two concurrent open events (events received with a delta time less than 10 seconds) only the first one will be saved, the second one will be discarded
  - If there's two concurrent click events (events received with a delta time less than 5 seconds, and referred to the same URL) only the first one will be saved, the second one will be discarded.
- Propagate bounce event to mass_mailing stats
- Improvements on mail_tracking_mailgun proposed by @Yajo after merging

@Tecnativa
