### PR TITLE
Return with context, solves #90.

### DIFF
--- a/mail_footer_notified_partners/models/mail_followers.py
+++ b/mail_footer_notified_partners/models/mail_followers.py
@@ -57,7 +57,7 @@ class MailNotification(models.Model):
             ctx.update({
                 'partners_to_notify': partners_to_notify,
             })
-        return super(MailNotification, self)._notify(
+        return super(MailNotification, self.with_context(ctx))._notify(
             message_id,
             partners_to_notify=partners_to_notify,
-            force_send=force_send, user_signature=user_signature, context=ctx)
+            force_send=force_send, user_signature=user_signature)


### PR DESCRIPTION
In response to issue #90 .
With api.model the footer didn't get populated with followers as it was supposed to. This commit restores the functionality, but using @api.multi to avoid the obsolete @api.one.
