### PR TITLE
[8.0][IMP] Performance issues in mail_tracking addons

### DIFF
--- a/mail_tracking/__openerp__.py
+++ b/mail_tracking/__openerp__.py
@@ -5,7 +5,7 @@
 {
     "name": "Email tracking",
     "summary": "Email tracking system for all mails sent",
-    "version": "8.0.2.0.2",
+    "version": "8.0.3.0.0",
     "category": "Social Network",
     "website": "http://www.tecnativa.com",
     "author": "Tecnativa, "

--- a/mail_tracking/controllers/main.py
+++ b/mail_tracking/controllers/main.py
@@ -30,6 +30,9 @@ def _env_get(db, callback, tracking_id, event_type, **kw):
         # make sudo when reusing environment
         env = env(user=SUPERUSER_ID)
     if env:
+        # This try-except-finally is equivalent to a with statement
+        # We assure that new created cursor si commit/rollback/close
+        # in any case
         try:
             res = callback(env, tracking_id, event_type, **kw)
             if not current:

--- a/mail_tracking/controllers/main.py
+++ b/mail_tracking/controllers/main.py
@@ -28,7 +28,7 @@ def _env_get(db, callback, tracking_id, event_type, **kw):
                 _logger.info("New environment for database '%s'", db)
                 with reg.cursor() as new_cr:
                     new_env = api.Environment(new_cr, SUPERUSER_ID, {})
-                    res = callback(env, tracking_id, event_type, **kw)
+                    res = callback(new_env, tracking_id, event_type, **kw)
                     new_env.cr.commit()
     else:
         # make sudo when reusing environment

--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -24,6 +24,11 @@ class MailTrackingEmail(models.Model):
     _rec_name = 'display_name'
     _description = 'MailTracking email'
 
+    # This table is going to growth fast and to infinite, so we index:
+    # - name: Search in tree view
+    # - time: default order fields
+    # - recipient_address: Used for email_store calculation (non-store)
+    # - state: Search and group_by in tree view
     name = fields.Char(string="Subject", readonly=True, index=True)
     display_name = fields.Char(
         string="Display name", readonly=True, store=True,
@@ -111,6 +116,9 @@ class MailTrackingEmail(models.Model):
         """Default email score algorimth. Ready to be inherited
 
         Must return a value beetwen 0.0 and 100.0
+        - Bad reputation: Value between 0 and 50.0
+        - Unknown reputation: Value 50.0
+        - Good reputation: Value between 50.0 and 100.0
         """
         score = 50.0
         for tracking in self:
@@ -274,7 +282,7 @@ class MailTrackingEmail(models.Model):
                     event_ids += event_ids.sudo().create(vals)
                     # Commit to DB to release exclusive lock
                     if not testing:
-                        self.env.cr.commit()
+                        self.env.cr.commit()  # pragma: no cover
             else:
                 _logger.debug("Concurrent event '%s' discarded", event_type)
         if event_type in {'hard_bounce', 'spam', 'reject'}:

--- a/mail_tracking/models/mail_tracking_event.py
+++ b/mail_tracking/models/mail_tracking_event.py
@@ -23,7 +23,7 @@ class MailTrackingEvent(models.Model):
     date = fields.Date(
         string="Date", readonly=True, compute="_compute_date", store=True)
     tracking_email_id = fields.Many2one(
-        string='Message', readonly=True,
+        string='Message', readonly=True, required=True, ondelete='cascade',
         comodel_name='mail.tracking.email')
     event_type = fields.Selection(string='Event type', selection=[
         ('sent', 'Sent'),

--- a/mail_tracking/models/res_partner.py
+++ b/mail_tracking/models/res_partner.py
@@ -8,10 +8,14 @@ from openerp import models, api, fields
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
+    # tracking_emails_count and email_score are non-store fields in order
+    # to improve performance
+    # email_bounced is store=True and index=True field in order to filter
+    # in tree view for processing bounces easier
     tracking_emails_count = fields.Integer(
         string="Tracking emails count", readonly=True, store=False,
         compute="_compute_tracking_emails_count")
-    email_bounced = fields.Boolean(string="Email bounced")
+    email_bounced = fields.Boolean(string="Email bounced", index=True)
     email_score = fields.Float(
         string="Email score", readonly=True, store=False,
         compute='_compute_email_score')
@@ -35,7 +39,8 @@ class ResPartner(models.Model):
     @api.multi
     def email_bounced_set(self, tracking_email, reason):
         """Inherit this method to make any other actions to partners"""
-        return self.write({'email_bounced': True})
+        partners = self.filtered(lambda r: not r.email_bounced)
+        return partners.write({'email_bounced': True})
 
     @api.multi
     def write(self, vals):

--- a/mail_tracking/models/res_partner.py
+++ b/mail_tracking/models/res_partner.py
@@ -13,12 +13,9 @@ class ResPartner(models.Model):
     # email_bounced is store=True and index=True field in order to filter
     # in tree view for processing bounces easier
     tracking_emails_count = fields.Integer(
-        string="Tracking emails count", readonly=True,
-        compute="_compute_tracking_emails_count")
-    email_bounced = fields.Boolean(string="Email bounced", index=True)
-    email_score = fields.Float(
-        string="Email score", readonly=True,
-        compute='_compute_email_score')
+        compute='_compute_tracking_emails_count', readonly=True)
+    email_bounced = fields.Boolean(index=True)
+    email_score = fields.Float(compute='_compute_email_score', readonly=True)
 
     @api.multi
     @api.depends('email')

--- a/mail_tracking/models/res_partner.py
+++ b/mail_tracking/models/res_partner.py
@@ -13,11 +13,11 @@ class ResPartner(models.Model):
     # email_bounced is store=True and index=True field in order to filter
     # in tree view for processing bounces easier
     tracking_emails_count = fields.Integer(
-        string="Tracking emails count", readonly=True, store=False,
+        string="Tracking emails count", readonly=True,
         compute="_compute_tracking_emails_count")
     email_bounced = fields.Boolean(string="Email bounced", index=True)
     email_score = fields.Float(
-        string="Email score", readonly=True, store=False,
+        string="Email score", readonly=True,
         compute='_compute_email_score')
 
     @api.multi

--- a/mail_tracking/views/res_partner_view.xml
+++ b/mail_tracking/views/res_partner_view.xml
@@ -25,7 +25,22 @@
         <field name="email" position="after">
             <field name="email_score" widget="progressbar"
                    attrs="{'invisible': [('email', '=', False)]}"/>
+           <field name="email_bounced"
+                  attrs="{'invisible': [('email', '=', False)]}"/>
         </field>
+    </field>
+</record>
+
+<record model="ir.ui.view" id="view_res_partner_filter">
+    <field name="name">Filter bounced partners</field>
+    <field name="model">res.partner</field>
+    <field name="inherit_id" ref="base.view_res_partner_filter"/>
+    <field name="arch" type="xml">
+        <filter name="type_company" position="after">
+            <separator/>
+            <filter string="Email bounced" name="email_bounced"
+                    domain="[('email', '!=' , False), ('email_bounced', '=', True)]"/>
+        </filter>
     </field>
 </record>
 

--- a/mail_tracking_mass_mailing/hooks.py
+++ b/mail_tracking_mass_mailing/hooks.py
@@ -5,7 +5,7 @@
 import logging
 try:
     from openerp.addons.mail_tracking.hooks import column_add_with_value
-except ImportError:  # pragma: no cover
+except ImportError:
     column_add_with_value = False
 
 _logger = logging.getLogger(__name__)

--- a/mail_tracking_mass_mailing/hooks.py
+++ b/mail_tracking_mass_mailing/hooks.py
@@ -5,7 +5,7 @@
 import logging
 try:
     from openerp.addons.mail_tracking.hooks import column_add_with_value
-except ImportError:
+except ImportError:  # pragma: no cover
     column_add_with_value = False
 
 _logger = logging.getLogger(__name__)

--- a/mail_tracking_mass_mailing/models/mail_tracking_event.py
+++ b/mail_tracking_mass_mailing/models/mail_tracking_event.py
@@ -2,11 +2,15 @@
 # © 2016 Antonio Espinosa - <antonio.espinosa@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp import models, api
+from openerp import api, fields, models
 
 
 class MailTrackingEvent(models.Model):
     _inherit = "mail.tracking.event"
+
+    mass_mailing_id = fields.Many2one(
+        string="Mass mailing", comodel_name='mail.mass_mailing', readonly=True,
+        related='tracking_email_id.mass_mailing_id', store=True)
 
     @api.model
     def process_open(self, tracking_email, metadata):

--- a/mail_tracking_mass_mailing/tests/test_mass_mailing.py
+++ b/mail_tracking_mass_mailing/tests/test_mass_mailing.py
@@ -8,8 +8,8 @@ from openerp.exceptions import Warning as UserError
 
 # One test case per method
 class TestMassMailing(TransactionCase):
-    def setUp(self):
-        super(TestMassMailing, self).setUp()
+    def setUp(self, *args, **kwargs):
+        super(TestMassMailing, self).setUp(*args, **kwargs)
         self.list = self.env['mail.mass_mailing.list'].create({
             'name': 'Test mail tracking',
         })
@@ -90,24 +90,24 @@ class TestMassMailing(TransactionCase):
             self.assertTrue(stat.bounced)
 
     def test_tracking_email_hard_bounce(self):
-            self._tracking_email_bounce('hard_bounce', 'bounced')
+        self._tracking_email_bounce('hard_bounce', 'bounced')
 
     def test_tracking_email_soft_bounce(self):
-            self._tracking_email_bounce('soft_bounce', 'soft-bounced')
+        self._tracking_email_bounce('soft_bounce', 'soft-bounced')
 
     def test_tracking_email_reject(self):
-            self._tracking_email_bounce('reject', 'rejected')
+        self._tracking_email_bounce('reject', 'rejected')
 
     def test_tracking_email_spam(self):
-            self._tracking_email_bounce('spam', 'spam')
+        self._tracking_email_bounce('spam', 'spam')
 
     def test_contact_tracking_emails(self):
-        self.mailing.send_mail()
-        for stat in self.mailing.statistics_ids:
-            if stat.mail_mail_id:
-                stat.mail_mail_id.send()
-        self.assertEqual(len(self.contact_a.tracking_email_ids), 1)
+        self._tracking_email_bounce('hard_bounce', 'bounced')
+        self.assertTrue(self.contact_a.email_bounced)
+        self.assertTrue(self.contact_a.email_score < 50.0)
         self.contact_a.email = 'other_contact_a@example.com'
-        self.assertEqual(len(self.contact_a.tracking_email_ids), 0)
+        self.assertFalse(self.contact_a.email_bounced)
+        self.assertTrue(self.contact_a.email_score == 50.0)
         self.contact_a.email = 'contact_a@example.com'
-        self.assertEqual(len(self.contact_a.tracking_email_ids), 1)
+        self.assertTrue(self.contact_a.email_bounced)
+        self.assertTrue(self.contact_a.email_score < 50.0)

--- a/mail_tracking_mass_mailing/tests/test_mass_mailing.py
+++ b/mail_tracking_mass_mailing/tests/test_mass_mailing.py
@@ -2,11 +2,14 @@
 # © 2016 Antonio Espinosa - <antonio.espinosa@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import mock
 from openerp.tests.common import TransactionCase
 from openerp.exceptions import Warning as UserError
 
+mock_send_email = ('openerp.addons.base.ir.ir_mail_server.'
+                   'ir_mail_server.send_email')
 
-# One test case per method
+
 class TestMassMailing(TransactionCase):
     def setUp(self, *args, **kwargs):
         super(TestMassMailing, self).setUp(*args, **kwargs)
@@ -49,6 +52,21 @@ class TestMassMailing(TransactionCase):
     def test_avoid_resend_disable(self):
         self.mailing.avoid_resend = False
         self.resend_mass_mailing(1, 3)
+
+    def test_smtp_error(self):
+        with mock.patch(mock_send_email) as mock_func:
+            mock_func.side_effect = Warning('Test error')
+            self.mailing.send_mail()
+            for stat in self.mailing.statistics_ids:
+                if stat.mail_mail_id:
+                    stat.mail_mail_id.send()
+                tracking = self.env['mail.tracking.email'].search([
+                    ('mail_id_int', '=', stat.mail_mail_id_int),
+                ])
+                self.assertEqual('error', tracking.state)
+                self.assertEqual('Warning', tracking.error_type)
+                self.assertEqual('Test error', tracking.error_description)
+            self.assertTrue(self.contact_a.email_bounced)
 
     def test_tracking_email_link(self):
         self.mailing.send_mail()

--- a/mail_tracking_mass_mailing/views/mail_mass_mailing_contact_view.xml
+++ b/mail_tracking_mass_mailing/views/mail_mass_mailing_contact_view.xml
@@ -10,8 +10,21 @@
     <field name="inherit_id" ref="mass_mailing.view_mail_mass_mailing_contact_tree"/>
     <field name="arch" type="xml">
         <field name="opt_out" position="after">
+            <field name="email_bounced"/>
             <field name="email_score" widget="progressbar"/>
         </field>
+    </field>
+</record>
+
+<record model="ir.ui.view" id="view_mail_mass_mailing_contact_search">
+    <field name="name">Filter bounced contacts</field>
+    <field name="model">mail.mass_mailing.contact</field>
+    <field name="inherit_id" ref="mass_mailing.view_mail_mass_mailing_contact_search"/>
+    <field name="arch" type="xml">
+        <filter name="not_opt_out" position="after">
+            <filter string="Email bounced" name="email_bounced"
+                    domain="[('email_bounced', '=', True)]"/>
+        </filter>
     </field>
 </record>
 

--- a/mail_tracking_mass_mailing/views/mail_mass_mailing_view.xml
+++ b/mail_tracking_mass_mailing/views/mail_mass_mailing_view.xml
@@ -15,5 +15,32 @@
     </field>
 </record>
 
+<record model="ir.actions.act_window" id="action_view_mail_tracking_email">
+    <field name="name">Mail tracking emails</field>
+    <field name="res_model">mail.tracking.email</field>
+    <field name="view_type">form</field>
+    <field name="view_mode">tree,form</field>
+    <field name="domain">[('mass_mailing_id', '!=', False)]</field>
+</record>
+
+<record model="ir.actions.act_window" id="action_view_mail_tracking_event">
+    <field name="name">Mail tracking events</field>
+    <field name="res_model">mail.tracking.event</field>
+    <field name="view_type">form</field>
+    <field name="view_mode">tree,form</field>
+    <field name="domain">[('mass_mailing_id', '!=', False)]</field>
+</record>
+
+<menuitem name="Mail tracking" id="mail_tracking_menu"
+          parent="base.marketing_menu" sequence="50"/>
+
+<menuitem name="Emails" id="mail_tracking_email_menu"
+          parent="mail_tracking_menu" sequence="1"
+          action="action_view_mail_tracking_email"/>
+
+<menuitem name="Events" id="mail_tracking_event_menu"
+          parent="mail_tracking_menu" sequence="2"
+          action="action_view_mail_tracking_event"/>
+
 </data>
 </openerp>


### PR DESCRIPTION
This PR fix some performance issues:
- [Fixed] In some cases `self.env.cr` is not closed properly.
- Add `index=True` to `time` and `recipient_address` fields of `mail.tracking.email` model
- Many2many relation between partners (and mail contacts) and mail tracking emails deleted
- `email_score` is now a non-stored computed field

Also includes some new features for processing bounced emails easier:
- Adds a menu for listing mass mailing emails and events
- Add a boolean field `email_bounced` to partners and mail contacts. To easy filter them and do manual operations: call the partner, remove the partner, opt-out, ... Also prepare easy inherited methods for programming automatic operations in customer addon.
