### PR TITLE
[8.0][ADD] Sendgrid modules for transactional e-mails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ virtualenv:
   system_site_packages: true
 
 install:
+  - pip install sendgrid
   - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly

--- a/mail_sendgrid/README.rst
+++ b/mail_sendgrid/README.rst
@@ -1,0 +1,103 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+========
+SendGrid
+========
+
+This module integrates
+`SendGrid <https://sendgrid.com/>`_ with Odoo. It can send transactional emails
+through SendGrid, using templates defined on the
+`SendGrid web interface <https://sendgrid.com/templates>`_. It also supports
+substitution of placeholder variables in these templates. The list of available
+templates can be fetched automatically.
+E-mails sent through SendGrid will be tracked using Sendgrid Webhook Events.
+
+Installation
+============
+You need to install python-sendgrid v3 API in order to install the module.
+
+Configuration
+=============
+
+You can add the following system parameters to configure the usage of SendGrid:
+
+* ``mail_sendgrid.substitution_prefix`` Any symbol or character used as a 
+  prefix for `SendGrid Substitution Tags <https://sendgrid.com/docs/API_Reference/SMTP_API/substitution_tags.html>`_.
+  ``{`` is used by default.
+* ``mail_sendgrid.substitution_suffix`` Any symbol or character used as a 
+  suffix for `SendGrid Substitution Tags <https://sendgrid.com/docs/API_Reference/SMTP_API/substitution_tags.html>`_.
+  ``}`` is used by default.
+* ``mail_sendgrid.send_method`` Use value 'sendgrid' to override the traditional SMTP server used to send e-mails with sendgrid.
+  Use any other value to disable traditional e-mail sending. By default, SendGrid will co-exist with traditional system
+  (two buttons for sending either normally or with SendGrid).
+
+In order to use this module, the following variables have to be defined in the
+server command-line options (or in a configuration file):
+
+- ``sendgrid_api_key`` A valid API key obtained from the
+  `SendGrid web interface <https://app.sendgrid.com/settings/api_keys>`_ with
+  full access for the ``Mail Send`` permission and read access for the
+  ``Template Engine`` permission.
+
+Optionally, the following configuration variables can be set as well:
+
+- ``sendgrid_test_address`` Destination email address for testing purposes.
+  You can use ``odoo@sink.sendgrid.net``, which is an address that
+  will simply receive and discard all incoming email.
+
+For tracking events to work, make sure you configure your Sendgrid Account with the correct Event Notification Url.
+You can do it under 'Settings -> Mail Settings -> Event Notification '.
+Set the URL to ``http://your-odoo-server.com/sendgrid/events``
+
+Usage
+=====
+
+If you designed templates in Sendgrid that you wan't to use with Odoo:
+    * Go to 'Settings -> Email -> SendGrid Templates'
+    * Create a new Template
+    * Click the "Update" button : this will automatically import all your templates
+
+In e-mail templates 'Settings -> Email -> Templates', you can attach a SendGrid template for any language.
+You can substitute Sendgrid keywords with placeholders or static text like in the body of the e-mail.
+The preview wizard now renders your e-mail with the SendGrid template applied.
+
+From e-mails, use the "Send (SendGrid)" button to send the e-mail using Sendgrid.
+
+Known issues / Roadmap
+======================
+
+* Extend the features from SendGrid
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/social/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/social/issues/new?body=module:%20mail_sendgrid%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Emanuel Cino <ecino@compassion.ch>
+* Roman Zoller <rzcomp@gmail.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/mail_sendgrid/__init__.py
+++ b/mail_sendgrid/__init__.py
@@ -1,0 +1,14 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Roman Zoller
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+from . import models
+from . import wizards
+from . import controllers

--- a/mail_sendgrid/__openerp__.py
+++ b/mail_sendgrid/__openerp__.py
@@ -1,0 +1,51 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#       ______ Releasing children from poverty      _
+#      / ____/___  ____ ___  ____  ____ ___________(_)___  ____
+#     / /   / __ \/ __ `__ \/ __ \/ __ `/ ___/ ___/ / __ \/ __ \
+#    / /___/ /_/ / / / / / / /_/ / /_/ (__  |__  ) / /_/ / / / /
+#    \____/\____/_/ /_/ /_/ .___/\__,_/____/____/_/\____/_/ /_/
+#                        /_/
+#                            in Jesus' name
+#
+#    Copyright (C) 2015-2016 Compassion CH (http://www.compassion.ch)
+#    @author: Roman Zoller, Emanuel Cino
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+{
+    'name': 'SendGrid',
+    'version': '8.0.3.0.0',
+    'category': 'Other',
+    'author': 'Compassion CH',
+    'website': 'http://www.compassion.ch',
+    'depends': ['base', 'email_template', 'mail_tracking'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/sendgrid_email_view.xml',
+        'views/sendgrid_template_view.xml',
+        'views/mail_compose_message_view.xml',
+        'views/email_template_view.xml',
+    ],
+    'demo': [],
+    'installable': True,
+    'auto_install': False,
+    'external_dependencies': {
+        'python': ['sendgrid'],
+    },
+}

--- a/mail_sendgrid/controllers/__init__.py
+++ b/mail_sendgrid/controllers/__init__.py
@@ -1,0 +1,13 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino <ecino@compassion.ch>
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+from . import sendgrid_event_webhook
+from . import json_request

--- a/mail_sendgrid/controllers/json_request.py
+++ b/mail_sendgrid/controllers/json_request.py
@@ -1,0 +1,55 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino <ecino@compassion.ch>
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+import logging
+import simplejson
+
+from openerp.http import JsonRequest, Root, Response
+
+_logger = logging.getLogger(__name__)
+
+# Monkeypatch type of request rooter to use RESTJsonRequest
+old_get_request = Root.get_request
+
+
+def get_request(self, httprequest):
+    if (httprequest.mimetype == "application/json" and
+            httprequest.environ['PATH_INFO'].startswith('/sendgrid')):
+        return RESTJsonRequest(httprequest)
+    return old_get_request(self, httprequest)
+
+Root.get_request = get_request
+
+
+class RESTJsonRequest(JsonRequest):
+    """ Special RestJson Handler to enable receiving lists in JSON
+        body
+    """
+    def __init__(self, *args):
+        try:
+            super(RESTJsonRequest, self).__init__(*args)
+        except AttributeError:
+            # The JSON may contain a list
+            self.params = dict()
+            self.context = dict(self.session.context)
+
+    def _json_response(self, result=None, error=None):
+        response = {}
+        if error is not None:
+            response['error'] = error
+        if result is not None:
+            response['result'] = result
+
+        mime = 'application/json'
+        body = simplejson.dumps(response)
+
+        return Response(
+            body, headers=[('Content-Type', mime),
+                           ('Content-Length', len(body))])

--- a/mail_sendgrid/controllers/sendgrid_event_webhook.py
+++ b/mail_sendgrid/controllers/sendgrid_event_webhook.py
@@ -1,0 +1,117 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino <ecino@compassion.ch>
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+import logging
+
+from openerp import http, fields
+from openerp.http import request
+from werkzeug.useragents import UserAgent
+
+
+STATUS_OK = 200
+
+_logger = logging.getLogger(__name__)
+
+
+class EventWebhook(http.Controller):
+    """ Add SendGrid related fields so that they dispatch in all
+    subclasses of mail.message object
+    """
+
+    # Map Sendgrid Events to mail_tracking event_type
+    event_mapping = {
+        # 'processed': 'sent', - not used
+        'dropped': 'reject',
+        'bounce': 'hard_bounce',
+        'deferred': 'deferral',
+        'delivered': 'delivered',
+        'open': 'open',
+        'click': 'click',
+        'spamreport': 'spam',
+        'unsubscribe': 'unsub',
+        'group_unsubscribe': 'unsub',
+    }
+
+    @http.route('/sendgrid/events', type='json', auth='public', methods=[
+        'POST'])
+    def handler_sendgrid(self):
+        message_data = request.jsonrequest
+        _logger.info("SENDGRID Webhook received: %s" % str(message_data))
+        if message_data and isinstance(message_data, list):
+            message_data.sort(key=lambda m: m.get('timestamp'))
+            for notification in message_data:
+                event = notification.get('event')
+                recipient = notification.get('email')
+                message_id = notification.get('odoo_id')
+                t_email = request.env['mail.tracking.email'].sudo().search([
+                    ('mail_id.message_id', '=', message_id),
+                    ('recipient', '=ilike', recipient)
+                ], limit=1)
+                if not t_email:
+                    _logger.error("Sendgrid e-mail not found: %s" % message_id)
+                    continue
+
+                t_vals = {
+                    'recipient': recipient,
+                    'timestamp': notification.get('timestamp'),
+                    'time': fields.Datetime.now(),
+                    'tracking_email_id': t_email.id,
+                    'ip': notification.get('ip'),
+                    'smtp_server': notification.get('smtp-id'),
+                    'url': notification.get('url')
+                }
+                if notification.get('useragent'):
+                    user_agent = UserAgent(notification.get('useragent'))
+                    t_vals.update({
+                        'user_agent': user_agent.string,
+                        'os_family': user_agent.platform,
+                        'ua_family': user_agent.browser,
+                        'mobile': user_agent.platform in [
+                            'android', 'iphone', 'ipad']
+                    })
+                m_vals = {}
+                event_type = self.event_mapping.get(event)
+                if not event_type:
+                    # Skip unmapped events
+                    continue
+
+                if event == 'dropped':
+                    m_vals.update({
+                        'error_description': notification.get('reason'),
+                    })
+                    t_vals['error_type'] = notification.get('reason')
+                elif event == 'bounce':
+                    bounce_type = notification.get('type')
+                    if bounce_type == 'blocked':
+                        event_type = 'spam'
+                    t_vals.update({
+                        'error_type': notification.get('type'),
+                        'error_description': notification.get('reason'),
+                    })
+                    m_vals.update({
+                        'error_type': notification.get('status'),
+                        'bounce_type': bounce_type,
+                        'bounce_description': notification.get('reason'),
+                    })
+                elif event == 'deferred':
+                    m_vals.update({
+                        'error_smtp_server': notification.get('response'),
+                    })
+
+                # Create tracking event
+                t_email.event_create(event_type, t_vals)
+                # Write email tracking modifications
+                if m_vals:
+                    t_email.write(m_vals)
+
+            return {'status': 200}
+
+        else:
+            return {'status': 400, 'message': 'wrong request'}

--- a/mail_sendgrid/models/__init__.py
+++ b/mail_sendgrid/models/__init__.py
@@ -1,0 +1,17 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Roman Zoller
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+from . import mail_mail
+from . import substitution
+from . import sendgrid_template
+from . import email_template
+from . import email_lang_template
+from . import email_tracking

--- a/mail_sendgrid/models/email_lang_template.py
+++ b/mail_sendgrid/models/email_lang_template.py
@@ -1,0 +1,29 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+from openerp import models, fields
+
+
+class LanguageTemplate(models.Model):
+    """ This class is the relation between and email_template object
+    and a sendgrid_template. It allows to specify a different
+    sendgrid_template for any selected language.
+    """
+    _name = 'sendgrid.email.lang.template'
+
+    email_template_id = fields.Many2one('email.template', 'E-mail Template')
+    lang = fields.Selection('_lang_get', 'Language', required=True)
+    sendgrid_template_id = fields.Many2one(
+        'sendgrid.template', 'Sendgrid Template', required=True)
+
+    def _lang_get(self):
+        languages = self.env['res.lang'].search([])
+        return [(language.code, language.name) for language in languages]

--- a/mail_sendgrid/models/email_template.py
+++ b/mail_sendgrid/models/email_template.py
@@ -1,0 +1,58 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Roman Zoller
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+from openerp import models, fields, api
+
+
+class EmailTemplate(models.Model):
+    _inherit = 'email.template'
+
+    ##########################################################################
+    #                                 FIELDS                                 #
+    ##########################################################################
+    substitution_ids = fields.One2many(
+        'sendgrid.substitution', 'email_template_id', 'Substitutions')
+    sendgrid_template_ids = fields.One2many(
+        'sendgrid.email.lang.template', 'email_template_id',
+        'Sendgrid Templates')
+    sendgrid_localized_template = fields.Many2one(
+        'sendgrid.template', compute='_compute_localized_template')
+
+    def _compute_localized_template(self):
+        lang = self.env.context.get('lang')
+        for template in self:
+            lang_template = template.sendgrid_template_ids.filtered(
+                lambda t: t.lang == lang)
+            if lang_template and len(lang_template) == 1:
+                template.sendgrid_localized_template = \
+                    lang_template.sendgrid_template_id
+
+    @api.multi
+    def update_substitutions(self):
+        self.ensure_one()
+        new_substitutions = list()
+        for language_template in self.sendgrid_template_ids:
+            sendgrid_template = language_template.sendgrid_template_id
+            lang = language_template.lang
+            substitutions = self.substitution_ids.filtered(
+                lambda s: s.lang == lang)
+            keywords = sendgrid_template.get_keywords()
+            # Add new keywords from the sendgrid template
+            for key in keywords:
+                if key not in substitutions.mapped('key'):
+                    substitution_vals = {
+                        'key': key,
+                        'lang': lang,
+                        'email_template_id': self.id
+                    }
+                    new_substitutions.append((0, 0, substitution_vals))
+
+        return self.write({'substitution_ids': new_substitutions})

--- a/mail_sendgrid/models/email_tracking.py
+++ b/mail_sendgrid/models/email_tracking.py
@@ -1,0 +1,25 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino <ecino@compassion.ch>
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+from openerp import models, fields, api
+
+
+class MailTrackingEmail(models.Model):
+    """ Count the user clicks on links inside e-mails sent.
+    """
+    _inherit = 'mail.tracking.email'
+
+    click_count = fields.Integer(compute='_compute_clicks', store=True)
+
+    @api.depends('tracking_event_ids')
+    def _compute_clicks(self):
+        for mail in self:
+            mail.click_count = len(mail.tracking_event_ids.filtered(
+                lambda event: event.event_type == 'click'))

--- a/mail_sendgrid/models/mail_mail.py
+++ b/mail_sendgrid/models/mail_mail.py
@@ -15,7 +15,7 @@ import time
 
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Email, Attachment, CustomArg, Content, \
-    Personalization, Substitution, Mail
+    Personalization, Substitution, Mail, Header
 
 from openerp import models, fields, api, exceptions, tools, _
 from openerp.tools.config import config
@@ -155,6 +155,18 @@ class OdooMail(models.Model):
         if self.reply_to:
             s_mail.set_reply_to(Email(self.reply_to))
         s_mail.add_custom_arg(CustomArg('odoo_id', self.message_id))
+
+        headers = {
+            'Message-Id': self.message_id
+        }
+        if self.headers:
+            try:
+                headers.update(eval(self.headers))
+            except Exception:
+                pass
+        for h_name, h_val in headers.iteritems():
+            s_mail.add_header(Header(h_name, h_val))
+
         html = self.body_html or ' '
 
         p = re.compile(r'<.*?>')  # Remove HTML markers

--- a/mail_sendgrid/models/mail_mail.py
+++ b/mail_sendgrid/models/mail_mail.py
@@ -1,0 +1,230 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015-2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Roman Zoller, Emanuel Cino <ecino@compassion.ch>
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+import base64
+import logging
+import re
+import time
+
+from sendgrid import SendGridAPIClient
+from sendgrid.helpers.mail import Email, Attachment, CustomArg, Content, \
+    Personalization, Substitution, Mail
+
+from openerp import models, fields, api, exceptions, tools, _
+from openerp.tools.config import config
+
+
+STATUS_OK = 202
+
+_logger = logging.getLogger(__name__)
+
+
+class MailMessage(models.Model):
+    """ Add SendGrid related fields so that they dispatch in all
+    subclasses of mail.message object
+    """
+    _inherit = 'mail.message'
+
+    ##########################################################################
+    #                                 FIELDS                                 #
+    ##########################################################################
+    body_text = fields.Text(help='Text only version of the body')
+    sent_date = fields.Datetime(copy=False)
+    substitution_ids = fields.Many2many(
+        'sendgrid.substitution', string='Substitutions', copy=True)
+    sendgrid_template_id = fields.Many2one(
+        'sendgrid.template', 'Sendgrid Template')
+    send_method = fields.Char(compute='_compute_send_method')
+
+    ##########################################################################
+    #                             FIELDS METHODS                             #
+    ##########################################################################
+    @api.multi
+    def _compute_send_method(self):
+        """ Check whether to use traditional send method, sendgrid or disable.
+        """
+        send_method = self.env['ir.config_parameter'].get_param(
+            'mail_sendgrid.send_method', 'traditional')
+        for email in self:
+            email.send_method = send_method
+
+
+class OdooMail(models.Model):
+    """ Email message sent through SendGrid """
+    _inherit = 'mail.mail'
+
+    ##########################################################################
+    #                                 FIELDS                                 #
+    ##########################################################################
+    tracking_email_ids = fields.One2many(
+        'mail.tracking.email', 'mail_id', string='Registered events',
+        readonly=True)
+    click_count = fields.Integer(
+        compute='_compute_tracking', store=True, readonly=True)
+    opened = fields.Boolean(
+        compute='_compute_tracking', store=True, readonly=True)
+    tracking_event_ids = fields.One2many(
+        'mail.tracking.event', compute='_compute_events')
+
+    @api.depends('tracking_email_ids', 'tracking_email_ids.click_count',
+                 'tracking_email_ids.state')
+    def _compute_tracking(self):
+        for email in self:
+            email.click_count = sum(email.tracking_email_ids.mapped(
+                'click_count'))
+            opened = len(email.tracking_email_ids.filtered(
+                lambda t: t.state == 'opened'))
+            email.opened = opened > 0
+
+    def _compute_events(self):
+        for email in self:
+            email.tracking_event_ids = email.tracking_email_ids.mapped(
+                'tracking_event_ids')
+
+    ##########################################################################
+    #                             PUBLIC METHODS                             #
+    ##########################################################################
+    @api.multi
+    def send(self, auto_commit=False, raise_exception=False):
+        """ Override send to select the method to send the e-mail. """
+        traditional = self.filtered(lambda e: e.send_method == 'traditional')
+        sendgrid = self.filtered(lambda e: e.send_method == 'sendgrid')
+        super(OdooMail, traditional).send(auto_commit, raise_exception)
+        sendgrid.send_sendgrid()
+        unknown = self - traditional - sendgrid
+        if unknown:
+            _logger.warning(
+                "Traditional e-mails are disabled. Please remove system "
+                "parameter mail_sendgrid.send_method if you want to send "
+                "e-mails through your configured SMTP.")
+            unknown.write({'state': 'exception'})
+        return True
+
+    @api.multi
+    def send_sendgrid(self):
+        """ Use sendgrid transactional e-mails : e-mails are sent one by
+        one. """
+        api_key = config.get('sendgrid_api_key')
+        if not api_key:
+            raise exceptions.Warning(
+                'ConfigError',
+                _('Missing sendgrid_api_key in conf file'))
+
+        sg = SendGridAPIClient(apikey=api_key)
+        for email in self.filtered(lambda em: em.state == 'outgoing'):
+            try:
+                response = sg.client.mail.send.post(
+                    request_body=email._prepare_sendgrid_data())
+            except Exception as e:
+                _logger.error(e.message)
+                continue
+
+            status = response.status_code
+            msg = response.body
+
+            if status == STATUS_OK:
+                _logger.info(str(msg))
+                email._track_sendgrid_emails()
+                email.write({
+                    'sent_date': fields.Datetime.now(),
+                    'state': 'sent'
+                })
+                # Commit changes since e-mail was sent
+                self.env.cr.commit()
+            else:
+                _logger.error("Failed to send email: {}".format(str(msg)))
+
+    ##########################################################################
+    #                             PRIVATE METHODS                            #
+    ##########################################################################
+    def _prepare_sendgrid_data(self):
+        self.ensure_one()
+        s_mail = Mail()
+        s_mail.set_from(Email(self.email_from))
+        if self.reply_to:
+            s_mail.set_reply_to(Email(self.reply_to))
+        s_mail.add_custom_arg(CustomArg('odoo_id', self.message_id))
+        html = self.body_html or ' '
+
+        p = re.compile(r'<.*?>')  # Remove HTML markers
+        text_only = self.body_text or p.sub('', html.replace('<br/>', '\n'))
+
+        s_mail.add_content(Content("text/plain", text_only))
+        s_mail.add_content(Content("text/html", html))
+
+        test_address = config.get('sendgrid_test_address')
+
+        # We use only one personalization for transactional e-mail
+        personalization = Personalization()
+        subject = self.subject and self.subject.encode(
+            "utf_8") or "(No subject)"
+        personalization.set_subject(subject)
+        addresses = list()
+        if not test_address:
+            if self.email_to and self.email_to not in addresses:
+                personalization.add_to(Email(self.email_to))
+                addresses.append(self.email_to)
+            for recipient in self.recipient_ids:
+                if recipient.email not in addresses:
+                    personalization.add_to(Email(recipient.email))
+                    addresses.append(recipient.email)
+            if self.email_cc and self.email_cc not in addresses:
+                personalization.add_cc(Email(self.email_cc))
+        else:
+            _logger.info('Sending email to test address {}'.format(
+                test_address))
+            personalization.add_to(Email(test_address))
+            self.email_to = test_address
+
+        if self.sendgrid_template_id:
+            s_mail.set_template_id(self.sendgrid_template_id.remote_id)
+
+        for substitution in self.substitution_ids:
+            personalization.add_substitution(Substitution(
+                substitution.key, substitution.value.encode('utf-8')))
+
+        s_mail.add_personalization(personalization)
+
+        for attachment in self.attachment_ids:
+            s_attachment = Attachment()
+            # Datas are not encoded properly for sendgrid
+            s_attachment.set_content(base64.b64encode(base64.b64decode(
+                attachment.datas)))
+            s_attachment.set_filename(attachment.name)
+            s_mail.add_attachment(s_attachment)
+
+        return s_mail.get()
+
+    def _track_sendgrid_emails(self):
+        """ Create tracking e-mails after successfully sent with Sendgrid. """
+        self.ensure_one()
+        m_tracking = self.env['mail.tracking.email'].sudo()
+        track_vals = self._prepare_sendgrid_tracking()
+        for recipient in tools.email_split_and_format(self.email_to):
+            track_vals['recipient'] = recipient
+            m_tracking += m_tracking.create(track_vals)
+        for partner in self.recipient_ids:
+            track_vals.update({
+                'partner_id': partner.id,
+                'recipient': partner.email,
+            })
+            m_tracking += m_tracking.create(track_vals)
+        return m_tracking
+
+    def _prepare_sendgrid_tracking(self):
+        ts = time.time()
+        return {
+            'name': self.subject,
+            'timestamp': '%.6f' % ts,
+            'time': fields.Datetime.now(),
+            'mail_id': self.id,
+            'mail_message_id': self.mail_message_id.id,
+            'sender': self.email_from,
+        }

--- a/mail_sendgrid/models/mail_mail.py
+++ b/mail_sendgrid/models/mail_mail.py
@@ -121,7 +121,7 @@ class OdooMail(models.Model):
         for email in self.filtered(lambda em: em.state == 'outgoing'):
             try:
                 response = sg.client.mail.send.post(
-                    request_body=email._prepare_sendgrid_data())
+                    request_body=email._prepare_sendgrid_data().get())
             except Exception as e:
                 _logger.error(e.message)
                 continue
@@ -145,6 +145,10 @@ class OdooMail(models.Model):
     #                             PRIVATE METHODS                            #
     ##########################################################################
     def _prepare_sendgrid_data(self):
+        """
+        Prepare and creates the Sendgrid Email object
+        :return: sendgrid.helpers.mail.Email object
+        """
         self.ensure_one()
         s_mail = Mail()
         s_mail.set_from(Email(self.email_from))
@@ -200,7 +204,7 @@ class OdooMail(models.Model):
             s_attachment.set_filename(attachment.name)
             s_mail.add_attachment(s_attachment)
 
-        return s_mail.get()
+        return s_mail
 
     def _track_sendgrid_emails(self):
         """ Create tracking e-mails after successfully sent with Sendgrid. """

--- a/mail_sendgrid/models/sendgrid_template.py
+++ b/mail_sendgrid/models/sendgrid_template.py
@@ -1,0 +1,95 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Roman Zoller
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+import json
+import sendgrid
+import re
+
+from openerp import models, fields, api, exceptions, _
+from openerp.tools.config import config
+
+
+class SendgridTemplate(models.Model):
+    """ Reference to a template available on the SendGrid user account. """
+    _name = 'sendgrid.template'
+
+    ##########################################################################
+    #                                 FIELDS                                 #
+    ##########################################################################
+    name = fields.Char()
+    remote_id = fields.Char(readonly=True)
+    html_content = fields.Html(readonly=True)
+    plain_content = fields.Text(readonly=True)
+    detected_keywords = fields.Char(compute='_compute_keywords')
+
+    def _compute_keywords(self):
+        for template in self:
+            if template.html_content:
+                keywords = template.get_keywords()
+                self.detected_keywords = ';'.join(keywords)
+
+    @api.one
+    def update(self):
+        api_key = config.get('sendgrid_api_key')
+        if not api_key:
+            raise exceptions.Warning(
+                'ConfigError',
+                _('Missing sendgrid_api_key in conf file'))
+
+        sg = sendgrid.SendGridAPIClient(apikey=api_key)
+        template_client = sg.client.templates
+        msg = template_client.get().body
+        result = json.loads(msg)
+
+        for template in result.get("templates", list()):
+            id = template["id"]
+            msg = template_client._(id).get().body
+            template_versions = json.loads(msg)['versions']
+            for version in template_versions:
+                if version['active']:
+                    template_vals = version
+                    break
+            else:
+                continue
+
+            vals = {
+                "remote_id": id,
+                "name": template["name"],
+                "html_content": template_vals["html_content"],
+                "plain_content": template_vals["plain_content"],
+            }
+            record = self.search([('remote_id', '=', id)])
+            if record:
+                record.write(vals)
+            else:
+                self.create(vals)
+        return True
+
+    def get_keywords(self):
+        """ Search in the Sendgrid template for keywords included with the
+        following syntax: {keyword_name} and returns the list of keywords.
+        keyword_name shouldn't be longer than 20 characters and only contain
+        alphanumeric characters (underscore is allowed).
+        You can replace the substitution prefix and suffix by adding values
+        in the system parameters
+            - mail_sendgrid.substitution_prefix
+            - mail_sendgrid.substitution_suffix
+        """
+        self.ensure_one()
+        params = self.env['ir.config_parameter']
+        prefix = params.search([
+            ('key', '=', 'mail_sendgrid.substitution_prefix')
+        ]).value or '{'
+        suffix = params.search([
+            ('key', '=', 'mail_sendgrid.substitution_suffix')
+        ]) or '}'
+        pattern = prefix + '\w{0,20}' + suffix
+        return list(set(re.findall(pattern, self.html_content)))

--- a/mail_sendgrid/models/substitution.py
+++ b/mail_sendgrid/models/substitution.py
@@ -1,0 +1,28 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Roman Zoller, Emanuel Cino
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+from openerp import models, fields
+
+
+class Substitution(models.Model):
+    """ Substitution values for a SendGrid email message """
+    _name = 'sendgrid.substitution'
+
+    ##########################################################################
+    #                                 FIELDS                                 #
+    ##########################################################################
+    key = fields.Char()
+    lang = fields.Char()
+    email_template_id = fields.Many2one(
+        'email.template', ondelete='cascade')
+    email_id = fields.Many2one(
+        'mail.mail', ondelete='cascade')
+    value = fields.Char()

--- a/mail_sendgrid/security/ir.model.access.csv
+++ b/mail_sendgrid/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sendgrid_substitution,Full access on sendgrid_substitution,model_sendgrid_substitution,base.group_user,1,1,1,1
+access_sendgrid_template,Full access on sendgrid_template,model_sendgrid_template,base.group_user,1,1,1,1
+access_sendgrid_lang_template,Full access on sendgrid_lang_template,model_sendgrid_email_lang_template,base.group_user,1,1,1,1

--- a/mail_sendgrid/views/email_template_view.xml
+++ b/mail_sendgrid/views/email_template_view.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <!-- Form view -->
+        <record id="view_email_template_sendgrid_form" model="ir.ui.view">
+            <field name="name">email.template.sendgrid.form</field>
+            <field name="model">email.template</field>
+            <field name="inherit_id" ref="email_template.email_template_form"/>
+            <field name="arch" type="xml">
+                <page string="Email Configuration" position="after">
+                    <page string="SendGrid">
+                        <group>
+                            <field name="sendgrid_template_ids">
+                                <tree editable="top">
+                                    <field name="lang"/>
+                                    <field name="sendgrid_template_id"/>
+                                </tree>
+                            </field>
+                            <button name="update_substitutions" string="Get substitutions from templates" type="object" colspan="2"/>
+                            <field name="substitution_ids">
+                                <tree editable="top">
+                                    <field name="key"/>
+                                    <field name="lang"/>
+                                    <field name="value"/>
+                                </tree>
+                            </field>
+                        </group>
+                    </page>
+                </page>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/mail_sendgrid/views/mail_compose_message_view.xml
+++ b/mail_sendgrid/views/mail_compose_message_view.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <!-- Add sendgrid preview in compose mail wizard -->
+        <record model="ir.ui.view" id="email_compose_message_sendgrid_form">
+            <field name="name">mail.compose.sendgrid.form</field>
+            <field name="model">mail.compose.message</field>
+            <field name="inherit_id" ref="mail.email_compose_message_wizard_form"/>
+            <field name="arch" type="xml">
+                <field name="body" position="replace">
+                    <notebook>
+                        <page string="Html">
+                            <field name="body"/>
+                        </page>
+                        <page string="SendGrid Preview">
+                            <field name="body_sendgrid"/>
+                        </page>
+                    </notebook>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/mail_sendgrid/views/sendgrid_email_view.xml
+++ b/mail_sendgrid/views/sendgrid_email_view.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <!-- Extension of mail.mail form view -->
+        <record model="ir.ui.view" id="email_form_view">
+            <field name="name">mail.mail.sendgrid</field>
+            <field name="model">mail.mail</field>
+            <field name="inherit_id" ref="mail.view_mail_form"/>
+            <field name="arch" type="xml">
+                <button name="send" position="replace">
+                    <field name="send_method" invisible="1"/>
+                    <button name="send" string="Send Now" type="object" class="oe_highlight" attrs="{'invisible': ['|', ('send_method', 'not in', ['sendgrid','traditional']), ('state', '!=', 'outgoing')]}"/>
+                    <button name="send_sendgrid" string="Send (SendGrid)" type="object" class="oe_highlight" attrs="{'invisible': ['|', ('send_method', '=', 'sendgrid'), ('state', '!=', 'outgoing')]}"/>
+                </button>
+                <field name="body_html" position="attributes">
+                    <attribute name="widget">html</attribute>
+                </field>
+                <page string="Attachments" position="after">
+                    <page string="SendGrid">
+                        <group>
+                            <field name="sendgrid_template_id"/>
+                            <field name="sent_date" readonly="1"/>
+                            <field name="opened" readonly="1"/>
+                            <field name="click_count" readonly="1"/>
+                            <field name="body_text"/>
+                        </group>
+                        <field name="substitution_ids" widget="one2many_list"/>
+                        <field name="tracking_event_ids">
+                            <tree default_order="time desc">
+                                <field name="tracking_email_id"/>
+                                <field name="time"/>
+                                <field name="event_type"/>
+                                <field name="url"/>
+                            </tree>
+                        </field>
+                    </page>
+                </page>
+            </field>
+        </record>
+
+        <!-- Extension of mail.mail tree view -->
+        <record model="ir.ui.view" id="sendgrid_email_tree_view">
+            <field name="name">mail.mail.sendgrid.tree</field>
+            <field name="model">mail.mail</field>
+            <field name="inherit_id" ref="mail.view_mail_tree"/>
+            <field name="arch" type="xml">
+                <field name="date" position="after">
+                    <field name="opened"/>
+                    <field name="click_count"/>
+                </field>
+            </field>
+        </record>
+
+        <!-- Extension of mail.mail search view -->
+        <record model="ir.ui.view" id="sendgrid_email_search_view">
+            <field name="name">mail.mail.sendgrid.search</field>
+            <field name="model">mail.mail</field>
+            <field name="inherit_id" ref="mail.view_mail_search"/>
+            <field name="arch" type="xml">
+                <xpath expr="//filter[@name='received']" position="after">
+                    <filter name="opened" string="Opened" domain="[('opened','=',True)]"/>
+                    <filter name="clicked" string="Clicked" domain="[('click_count','>',0)]"/>
+                </xpath>
+            </field>
+        </record>
+
+        <!-- Substitution line view -->
+        <record id="view_sendgrid_substitution_line_tree" model="ir.ui.view">
+            <field name="name">sendgrid.substitution.tree</field>
+            <field name="model">sendgrid.substitution</field>
+            <field name="arch" type="xml">
+                <tree string="Template substitutions" editable="bottom">
+                    <field name="key"/>
+                    <field name="value"/>
+                </tree>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/mail_sendgrid/views/sendgrid_template_view.xml
+++ b/mail_sendgrid/views/sendgrid_template_view.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <!-- Tree view -->
+        <record id="view_sendgrid_template_tree" model="ir.ui.view">
+            <field name="name">sendgrid.template.tree</field>
+            <field name="model">sendgrid.template</field>
+            <field name="arch" type="xml">
+                <tree string="Templates">
+                    <field name="remote_id"/>
+                    <field name="name"/>
+                </tree>
+            </field>
+        </record>
+
+        <!-- Form view -->
+        <record id="view_sendgrid_template_form" model="ir.ui.view">
+            <field name="name">sendgrid.template.form</field>
+            <field name="model">sendgrid.template</field>
+            <field name="arch" type="xml">
+                <form string="Template">
+                    <header>
+                        <button name="update" string="Update" type="object"/>
+                    </header>
+                    <sheet>
+                        <group>
+                            <field name="name"/>
+                            <field name="remote_id"/>
+                            <field name="detected_keywords"/>
+                        </group>
+                        <notebook>
+                            <page string="Html">
+                                <field name="html_content"/>
+                            </page>
+                            <page string="Plain text">
+                                <field name="plain_content"/>
+                            </page>
+                        </notebook>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <!-- Action opening the tree view -->
+        <record id="open_view_sendgrid_template_tree" model="ir.actions.act_window">
+            <field name="name">Template</field>
+            <field name="res_model">sendgrid.template</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form,tree</field>
+            <field name="view_id" ref="view_sendgrid_template_tree"/>
+        </record>
+
+        <!-- Add menu entry in Settings/Email -->
+        <menuitem name="SendGrid Templates" id="menu_sendgrid_template"
+                  parent="base.menu_email"
+                  sequence="8"
+                  action="open_view_sendgrid_template_tree"/>
+    </data>
+</openerp>

--- a/mail_sendgrid/wizards/__init__.py
+++ b/mail_sendgrid/wizards/__init__.py
@@ -1,0 +1,13 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+from . import mail_compose_message
+from . import email_template_preview

--- a/mail_sendgrid/wizards/email_template_preview.py
+++ b/mail_sendgrid/wizards/email_template_preview.py
@@ -1,0 +1,30 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino <ecino@compassion.ch>
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+from openerp import models, api
+
+
+class EmailTemplatePreview(models.TransientModel):
+    """ Put the preview inside sendgrid template """
+    _inherit = 'email_template.preview'
+
+    @api.multi
+    def on_change_res_id(self, res_id):
+        result = super(EmailTemplatePreview, self).on_change_res_id(res_id)
+        body_html = result['value']['body_html']
+        template_id = self.env.context.get('template_id')
+        template = self.env['email.template'].browse(template_id)
+        sendgrid_template = template.sendgrid_localized_template
+        if sendgrid_template:
+            body_html = sendgrid_template.html_content.replace(
+                '<%body%>', body_html)
+            result['value']['body_html'] = body_html
+        return result

--- a/mail_sendgrid/wizards/mail_compose_message.py
+++ b/mail_sendgrid/wizards/mail_compose_message.py
@@ -1,0 +1,57 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino <ecino@compassion.ch>
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+from openerp import models, fields, api
+
+
+class EmailComposeMessage(models.TransientModel):
+    """ Email message sent through SendGrid """
+    _inherit = 'mail.compose.message'
+
+    body_sendgrid = fields.Html(compute='_compute_sendgrid_view')
+
+    @api.depends('body')
+    def _compute_sendgrid_view(self):
+        for wizard in self:
+            template = wizard.template_id
+            sendgrid_template = template.sendgrid_localized_template
+            res_id = self.env.context.get('active_id')
+            render_body = self.render_template_batch(
+                wizard.body, wizard.model, [res_id], post_process=True)[res_id]
+            if sendgrid_template and wizard.body:
+                wizard.body_sendgrid = sendgrid_template.html_content.replace(
+                    '<%body%>', render_body)
+            else:
+                wizard.body_sendgrid = render_body
+
+    @api.model
+    def render_message_batch(self, wizard, res_ids):
+        """ Attach sendgrid template to e-mail and render substitutions """
+        template_values = super(
+            EmailComposeMessage, self).render_message_batch(wizard, res_ids)
+        template = wizard.template_id
+        substitutions = template.substitution_ids.filtered(
+            lambda s: s.lang == self.env.context.get('lang'))
+        sendgrid_template_id = template.sendgrid_localized_template.id
+
+        for substitution in substitutions:
+            substitution_values = template.render_template_batch(
+                substitution.value, template.model, res_ids)
+            for res_id in res_ids:
+                template_values[res_id].setdefault(
+                    'substitution_ids', list()).append((0, 0, {
+                        'key': substitution.key,
+                        'value': substitution_values[res_id]}))
+
+        for value in template_values.itervalues():
+            value['sendgrid_template_id'] = sendgrid_template_id
+
+        return template_values

--- a/mail_sendgrid_mass_mailing/README.rst
+++ b/mail_sendgrid_mass_mailing/README.rst
@@ -1,0 +1,61 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+=========================
+SendGrid for mass mailing
+=========================
+
+Links mass mailing and mail statistics objects with Sendgrid.
+Note that the mass mailing campaign will be sent with Sendgrid transactional
+e-emails (not to mix up with Sendgrid marketing campaigns)
+
+Installation
+============
+This addon will be automatically installed when 'mail_sendgrid' and
+'mass_mailing' are both installed.
+
+Usage
+=====
+
+From mass mailing, you can use Sendgrid templates.
+
+- If you select a Sendgrid template, the campaign will be sent through
+  Sendgrid. Otherwise it will use what you set in your system preference
+  (see module sendgrid).
+- You can force usage of a language for the template.
+
+Known issues / Roadmap
+======================
+
+* Use Sendgrid marketing campaigns API
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/social/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/social/issues/new?body=module:%20mail_sendgrid_mass_mailing%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Emanuel Cino <ecino@compassion.ch>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/mail_sendgrid_mass_mailing/__init__.py
+++ b/mail_sendgrid_mass_mailing/__init__.py
@@ -1,0 +1,13 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+from . import models
+from . import wizards

--- a/mail_sendgrid_mass_mailing/__openerp__.py
+++ b/mail_sendgrid_mass_mailing/__openerp__.py
@@ -1,0 +1,44 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#       ______ Releasing children from poverty      _
+#      / ____/___  ____ ___  ____  ____ ___________(_)___  ____
+#     / /   / __ \/ __ `__ \/ __ \/ __ `/ ___/ ___/ / __ \/ __ \
+#    / /___/ /_/ / / / / / / /_/ / /_/ (__  |__  ) / /_/ / / / /
+#    \____/\____/_/ /_/ /_/ .___/\__,_/____/____/_/\____/_/ /_/
+#                        /_/
+#                            in Jesus' name
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    @author: Emanuel Cino <ecino@compassion.ch>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+{
+    'name': 'Mass Mailing with SendGrid',
+    'version': '8.0.1.0.0',
+    'category': 'Social Network',
+    'author': 'Compassion CH',
+    'website': 'http://www.compassion.ch',
+    'depends': ['mail_sendgrid', 'mass_mailing'],
+    'data': [
+        'views/mass_mailing_view.xml'
+    ],
+    'demo': [],
+    'installable': True,
+    'auto_install': True,
+}

--- a/mail_sendgrid_mass_mailing/models/__init__.py
+++ b/mail_sendgrid_mass_mailing/models/__init__.py
@@ -1,0 +1,14 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+from . import mass_mailing
+from . import mail_mail
+from . import email_tracking

--- a/mail_sendgrid_mass_mailing/models/email_tracking.py
+++ b/mail_sendgrid_mass_mailing/models/email_tracking.py
@@ -1,0 +1,39 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino <ecino@compassion.ch>
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+from openerp import models, fields, api
+
+
+class MailTrackingEvent(models.Model):
+    """ Push events to campaign_statistics
+    """
+    _inherit = 'mail.tracking.event'
+
+    @api.model
+    def process_delivered(self, tracking_email, metadata):
+        res = super(MailTrackingEvent, self).process_delivered(
+            tracking_email, metadata)
+        mail_mail_stats = self.sudo().env['mail.mail.statistics'].search([
+            ('mail_mail_id_int', '=', tracking_email.mail_id_int)])
+        mail_mail_stats.write({
+            'sent': fields.Datetime.now()
+        })
+        return res
+
+    @api.model
+    def process_reject(self, tracking_email, metadata):
+        res = super(MailTrackingEvent, self).process_reject(
+            tracking_email, metadata)
+        mail_mail_stats = self.sudo().env['mail.mail.statistics'].search([
+            ('mail_mail_id_int', '=', tracking_email.mail_id_int)])
+        mail_mail_stats.write({
+            'exception': fields.Datetime.now()
+        })
+        return res

--- a/mail_sendgrid_mass_mailing/models/mail_mail.py
+++ b/mail_sendgrid_mass_mailing/models/mail_mail.py
@@ -1,0 +1,32 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino <ecino@compassion.ch>
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+from openerp import models
+
+
+class MailMail(models.Model):
+    _inherit = "mail.mail"
+
+    def _prepare_sendgrid_tracking(self):
+        track_vals = super(MailMail, self)._prepare_sendgrid_tracking()
+        track_vals.update({
+            'mail_id_int': self.id,
+            'mass_mailing_id': self.mailing_id.id,
+            'mail_stats_id': self.statistics_ids[:1].id
+            if self.statistics_ids else False
+        })
+        return track_vals
+
+    def _track_sendgrid_emails(self):
+        """ Push tracking_email in mass_mail_statistic """
+        tracking_emails = super(MailMail, self)._track_sendgrid_emails()
+        for tracking in tracking_emails.filtered('mail_stats_id'):
+            tracking.mail_stats_id.mail_tracking_id = tracking.id
+        return tracking_emails

--- a/mail_sendgrid_mass_mailing/models/mail_mail.py
+++ b/mail_sendgrid_mass_mailing/models/mail_mail.py
@@ -8,6 +8,7 @@
 #    The licence is in the file __openerp__.py
 #
 ##############################################################################
+from sendgrid.helpers.mail.mail import TrackingSettings, SubscriptionTracking
 from openerp import models
 
 
@@ -30,3 +31,27 @@ class MailMail(models.Model):
         for tracking in tracking_emails.filtered('mail_stats_id'):
             tracking.mail_stats_id.mail_tracking_id = tracking.id
         return tracking_emails
+
+    def _prepare_sendgrid_data(self):
+        """
+        Add unsubscribe options in mass mailings
+        :return: Sendgrid Email
+        """
+        s_mail = super(MailMail, self)._prepare_sendgrid_data()
+        tracking_settings = TrackingSettings()
+        if self.mailing_id.enable_unsubscribe:
+            sub_settings = SubscriptionTracking(
+                enable=True,
+                text=self.mailing_id.unsubscribe_text,
+                html=self.mailing_id.unsubscribe_text,
+            )
+            if self.mailing_id.unsubscribe_tag:
+                sub_settings.set_substitution_tag(
+                    self.mailing_id.unsubscribe_tag)
+            tracking_settings.set_subscription_tracking(sub_settings)
+        else:
+            tracking_settings.set_subscription_tracking(SubscriptionTracking(
+                enable=False))
+
+        s_mail.set_tracking_settings(tracking_settings)
+        return s_mail

--- a/mail_sendgrid_mass_mailing/models/mass_mailing.py
+++ b/mail_sendgrid_mass_mailing/models/mass_mailing.py
@@ -29,6 +29,11 @@ class MassMailing(models.Model):
     # Trick to save html when taken from the e-mail template
     html_copy = fields.Html(
         compute='_compute_sendgrid_view', inverse='_inverse_html_copy')
+    enable_unsubscribe = fields.Boolean()
+    unsubscribe_text = fields.Char(
+        default='If you would like to unsubscribe and stop receiving these '
+                'emails <% clickhere %>.')
+    unsubscribe_tag = fields.Char()
 
     @api.depends('body_html')
     def _compute_sendgrid_view(self):

--- a/mail_sendgrid_mass_mailing/models/mass_mailing.py
+++ b/mail_sendgrid_mass_mailing/models/mass_mailing.py
@@ -1,0 +1,129 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+from openerp import api, models, fields
+from openerp.exceptions import Warning
+
+
+class MassMailing(models.Model):
+    """ Add a direct link to an e-mail template in order to retrieve all
+    Sendgrid configuration into the e-mails. Add ability to force a
+    template language.
+    """
+    _inherit = 'mail.mass_mailing'
+
+    email_template_id = fields.Many2one(
+        'email.template', 'Sengdrid Template',
+    )
+    lang = fields.Many2one(
+        comodel_name="res.lang", string="Force language")
+    body_sendgrid = fields.Html(compute='_compute_sendgrid_view')
+    # Trick to save html when taken from the e-mail template
+    html_copy = fields.Html(
+        compute='_compute_sendgrid_view', inverse='_inverse_html_copy')
+
+    @api.depends('body_html')
+    def _compute_sendgrid_view(self):
+        for wizard in self:
+            template = wizard.email_template_id.with_context(
+                lang=self.lang.code or self.env.context['lang'])
+            sendgrid_template = template.sendgrid_localized_template
+            if sendgrid_template and wizard.body_html:
+                res_id = self.env[wizard.mailing_model].search(eval(
+                    wizard.mailing_domain), limit=1).id
+                if res_id:
+                    body = template.render_template_batch(
+                        wizard.body_html, template.model, [res_id],
+                        post_process=True)[res_id]
+                    wizard.body_sendgrid = \
+                        sendgrid_template.html_content.replace('<%body%>',
+                                                               body)
+            else:
+                wizard.body_sendgrid = wizard.body_html
+            wizard.html_copy = wizard.body_html
+
+    def _inverse_html_copy(self):
+        for wizard in self:
+            wizard.body_html = wizard.html_copy
+
+    @api.onchange('email_template_id')
+    def onchange_email_template_id(self):
+        if self.email_template_id:
+            template = self.email_template_id.with_context(
+                lang=self.lang.code or self.env.context['lang'])
+            if template.email_from:
+                self.email_from = template.email_from
+            self.name = template.subject
+            self.body_html = template.body_html
+
+    @api.onchange('lang')
+    def onchange_lang(self):
+        if self.lang and self.mailing_model == 'res.partner':
+            domain = eval(self.mailing_domain)
+            lang_tuple = False
+            for tuple in domain:
+                if tuple[0] == 'lang':
+                    lang_tuple = tuple
+                    break
+            if lang_tuple:
+                domain.remove(lang_tuple)
+            domain.append(('lang', '=', self.lang.code))
+            self.mailing_domain = str(domain)
+            self.onchange_email_template_id()
+
+    @api.multi
+    def action_test_mailing(self):
+        wizard = self
+        if self.email_template_id:
+            wizard = self.with_context(
+                lang=self.lang.code or self.env.context['lang'])
+        return super(MassMailing, wizard).action_test_mailing()
+
+    @api.multi
+    def send_mail(self):
+        self.ensure_one()
+        if self.email_template_id:
+            # use E-mail Template
+            res_ids = self.get_recipients(self)
+            if not res_ids:
+                raise Warning('Please select recipients.')
+            template = self.email_template_id
+            composer_values = {
+                'template_id': template.id,
+                'composition_mode': 'mass_mail',
+                'model': template.model,
+                'author_id': self.env.user.partner_id.id,
+                'res_id': res_ids[0],
+                'attachment_ids': [(4, attachment.id) for attachment in
+                                   self.attachment_ids],
+                'email_from': self.email_from,
+                'body': self.body_html,
+                'subject': self.name,
+                'record_name': False,
+                'mass_mailing_id': self.id,
+                'mailing_list_ids': [(4, l.id) for l in
+                                     self.contact_list_ids],
+                'no_auto_thread': self.reply_to_mode != 'thread',
+            }
+            if self.reply_to_mode == 'email':
+                composer_values['reply_to'] = self.reply_to
+            composer = self.env['mail.compose.message'].with_context(
+                lang=self.lang.code or self.env.context['lang'],
+                active_ids=res_ids)
+            emails = composer.mass_mailing_sendgrid(res_ids, composer_values)
+            self.write({
+                'state': 'done',
+                'sent_date': fields.Datetime.now(),
+            })
+            return emails
+        else:
+            # Traditional sending
+            return super(MassMailing, self).send_mail()

--- a/mail_sendgrid_mass_mailing/views/mass_mailing_view.xml
+++ b/mail_sendgrid_mass_mailing/views/mass_mailing_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <!-- Form view -->
+        <record id="view_email_template_sendgrid_form" model="ir.ui.view">
+            <field name="name">mass.mailing.sendgrid.form</field>
+            <field name="model">mail.mass_mailing</field>
+            <field name="inherit_id" ref="mass_mailing.view_mail_mass_mailing_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='mailing_model']/.." position="after">
+                    <field name="email_template_id" domain="[('model', '=', mailing_model), ('sendgrid_template_ids', '!=', False)]"/>
+                    <field name="lang" attrs="{'invisible': [('email_template_id', '=', False)]}"/>
+                </xpath>
+                <xpath expr="//page[@string='Mail Body']" position="after">
+                    <page string="Sendgrid Preview" attrs="{'invisible': [('email_template_id', '=', False)]}">
+                        <field name="html_copy" invisible="1"/>
+                        <field name="body_sendgrid" widget="html"/>
+                    </page>
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/mail_sendgrid_mass_mailing/views/mass_mailing_view.xml
+++ b/mail_sendgrid_mass_mailing/views/mass_mailing_view.xml
@@ -17,6 +17,13 @@
                         <field name="body_sendgrid" widget="html"/>
                     </page>
                 </xpath>
+                <xpath expr="//page[@string='Options']/group">
+                    <group string="Sendgrid Unsubscribe">
+                        <field name="enable_unsubscribe"/>
+                        <field name="unsubscribe_text" attrs="{'invisible': [('enable_unsubscribe', '=', False)]}"/>
+                        <field name="unsubscribe_tag" attrs="{'invisible': [('enable_unsubscribe', '=', False)]}"/>
+                    </group>
+                </xpath>
             </field>
         </record>
 

--- a/mail_sendgrid_mass_mailing/wizards/__init__.py
+++ b/mail_sendgrid_mass_mailing/wizards/__init__.py
@@ -1,0 +1,13 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+from . import mail_compose_message
+from . import test_mailing

--- a/mail_sendgrid_mass_mailing/wizards/mail_compose_message.py
+++ b/mail_sendgrid_mass_mailing/wizards/mail_compose_message.py
@@ -1,0 +1,35 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino <ecino@compassion.ch>
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+from openerp import models, api
+
+
+class EmailComposeMessage(models.TransientModel):
+    _inherit = 'mail.compose.message'
+
+    @api.model
+    def mass_mailing_sendgrid(self, res_ids, composer_values):
+        """ Helper to generate a new e-mail given a template and objects.
+
+        :param res_ids: ids of the resource objects
+        :param composer_values: values for the composer wizard
+        :return: browse records of created e-mails (one per resource object)
+        """
+        if not isinstance(res_ids, list):
+            res_ids = [res_ids]
+        wizard = self.create(composer_values)
+        all_mail_values = wizard.get_mail_values(wizard, res_ids)
+        email_obj = self.env['mail.mail']
+        emails = email_obj
+        for res_id in res_ids:
+            mail_values = all_mail_values[res_id]
+            emails += email_obj.create(mail_values)
+        return emails

--- a/mail_sendgrid_mass_mailing/wizards/test_mailing.py
+++ b/mail_sendgrid_mass_mailing/wizards/test_mailing.py
@@ -1,0 +1,50 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino <ecino@compassion.ch>
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+from openerp import models, api, tools
+
+
+class TestMassMailing(models.TransientModel):
+    _inherit = 'mail.mass_mailing.test'
+
+    @api.multi
+    def send_mail_test(self):
+        """ Send with Sendgrid if needed.
+        """
+        self.ensure_one()
+        mailing = self.mass_mailing_id
+        template = mailing.email_template_id
+        if template:
+            # Send with SendGrid (and use E-mail Template)
+            test_emails = tools.email_split(self.email_to)
+            emails = self.env['mail.mail']
+            for test_mail in test_emails:
+                emails += emails.create({
+                    'email_from': mailing.email_from,
+                    'reply_to': mailing.reply_to,
+                    'email_to': test_mail,
+                    'subject': mailing.name,
+                    'body_html': mailing.body_html,
+                    'sendgrid_template_id':
+                        template.sendgrid_localized_template.id,
+                    'notification': True,
+                    'mailing_id': mailing.id,
+                    'attachment_ids': [(4, attachment.id) for attachment in
+                                       mailing.attachment_ids],
+                })
+            emails.send_sendgrid()
+            mailing.write({
+                'state': 'test',
+            })
+        else:
+            super(TestMassMailing, self).send_mail_test()
+
+        return True


### PR DESCRIPTION
Two modules for connecting e-mails and mass_mailing with [Sendgrid](http://sendgrid.net)

This enables the use of Sendgrid transactional e-mails with templates and Sendgrid Event Notifications hook for tracking all e-mails sent.

Note: we don't have any tests because it requires an API Key (cannot be used without).
