### PR TITLE
[9.0][IMP] mail_tracking performance and bounce process

### DIFF
--- a/mail_tracking/__openerp__.py
+++ b/mail_tracking/__openerp__.py
@@ -5,7 +5,7 @@
 {
     "name": "Email tracking",
     "summary": "Email tracking system for all mails sent",
-    "version": "9.0.1.0.0",
+    "version": "9.0.2.0.0",
     "category": "Social Network",
     "website": "http://www.tecnativa.com",
     "author": "Tecnativa, "

--- a/mail_tracking/controllers/main.py
+++ b/mail_tracking/controllers/main.py
@@ -30,6 +30,9 @@ def _env_get(db, callback, tracking_id, event_type, **kw):
         # make sudo when reusing environment
         env = env(user=SUPERUSER_ID)
     if env:
+        # This try-except-finally is equivalent to a with statement
+        # We assure that new created cursor si commit/rollback/close
+        # in any case
         try:
             res = callback(env, tracking_id, event_type, **kw)
             if not current:

--- a/mail_tracking/controllers/main.py
+++ b/mail_tracking/controllers/main.py
@@ -11,17 +11,37 @@ _logger = logging.getLogger(__name__)
 BLANK = 'R0lGODlhAQABAIAAANvf7wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=='
 
 
-def _env_get(db):
+def _env_get(db, callback, tracking_id, event_type, **kw):
+    res = 'NOT FOUND'
     reg = False
-    try:
-        reg = registry(db)
-    except OperationalError:
-        _logger.warning("Selected BD '%s' not found", db)
-    except:  # pragma: no cover
-        _logger.warning("Selected BD '%s' connection error", db)
-    if reg:
-        return api.Environment(reg.cursor(), SUPERUSER_ID, {})
-    return False
+    current = http.request.db and db == http.request.db
+    env = current and http.request.env
+    if not env:
+        try:
+            reg = registry(db)
+        except OperationalError:
+            _logger.warning("Selected BD '%s' not found", db)
+        except:  # pragma: no cover
+            _logger.warning("Selected BD '%s' connection error", db)
+        if reg:
+            _logger.info("Creating a new environment for database '%s'", db)
+            env = api.Environment(reg.cursor(), SUPERUSER_ID, {})
+    else:
+        # make sudo when reusing environment
+        env = env(user=SUPERUSER_ID)
+    if env:
+        try:
+            res = callback(env, tracking_id, event_type, **kw)
+            if not current:
+                env.cr.commit()
+        except Exception as e:
+            if not current:
+                env.cr.rollback()
+            raise e
+        finally:
+            if not current:
+                env.cr.close()
+    return res
 
 
 class MailTrackingController(http.Controller):
@@ -35,49 +55,37 @@ class MailTrackingController(http.Controller):
             'ua_family': request.user_agent.browser or False,
         }
 
+    def _tracking_open(self, env, tracking_id, event_type, **kw):
+        tracking_email = env['mail.tracking.email'].search([
+            ('id', '=', tracking_id),
+        ])
+        if tracking_email:
+            metadata = self._request_metadata()
+            tracking_email.event_create('open', metadata)
+        else:
+            _logger.warning(
+                "MailTracking email '%s' not found", tracking_id)
+
+    def _tracking_event(self, env, tracking_id, event_type, **kw):
+        metadata = self._request_metadata()
+        return env['mail.tracking.email'].event_process(
+            http.request, kw, metadata, event_type=event_type)
+
     @http.route('/mail/tracking/all/<string:db>',
                 type='http', auth='none', csrf=False)
     def mail_tracking_all(self, db, **kw):
-        env = _env_get(db)
-        if not env:
-            return 'NOT FOUND'
-        metadata = self._request_metadata()
-        response = env['mail.tracking.email'].event_process(
-            http.request, kw, metadata)
-        env.cr.commit()
-        env.cr.close()
-        return response
+        return _env_get(db, self._tracking_event, None, None, **kw)
 
     @http.route('/mail/tracking/event/<string:db>/<string:event_type>',
                 type='http', auth='none', csrf=False)
     def mail_tracking_event(self, db, event_type, **kw):
-        env = _env_get(db)
-        if not env:
-            return 'NOT FOUND'
-        metadata = self._request_metadata()
-        response = env['mail.tracking.email'].event_process(
-            http.request, kw, metadata, event_type=event_type)
-        env.cr.commit()
-        env.cr.close()
-        return response
+        return _env_get(db, self._tracking_event, None, event_type, **kw)
 
     @http.route('/mail/tracking/open/<string:db>'
                 '/<int:tracking_email_id>/blank.gif',
                 type='http', auth='none')
     def mail_tracking_open(self, db, tracking_email_id, **kw):
-        env = _env_get(db)
-        if env:
-            tracking_email = env['mail.tracking.email'].search([
-                ('id', '=', tracking_email_id),
-            ])
-            if tracking_email:
-                metadata = self._request_metadata()
-                tracking_email.event_create('open', metadata)
-            else:
-                _logger.warning(
-                    "MailTracking email '%s' not found", tracking_email_id)
-            env.cr.commit()
-            env.cr.close()
+        _env_get(db, self._tracking_open, tracking_email_id, None, **kw)
 
         # Always return GIF blank image
         response = werkzeug.wrappers.Response()

--- a/mail_tracking/controllers/main.py
+++ b/mail_tracking/controllers/main.py
@@ -28,7 +28,7 @@ def _env_get(db, callback, tracking_id, event_type, **kw):
                 _logger.info("New environment for database '%s'", db)
                 with reg.cursor() as new_cr:
                     new_env = api.Environment(new_cr, SUPERUSER_ID, {})
-                    res = callback(env, tracking_id, event_type, **kw)
+                    res = callback(new_env, tracking_id, event_type, **kw)
                     new_env.cr.commit()
     else:
         # make sudo when reusing environment

--- a/mail_tracking/models/mail_message.py
+++ b/mail_tracking/models/mail_message.py
@@ -45,7 +45,7 @@ class MailMessage(models.Model):
             for tracking in trackings:
                 status = self._partner_tracking_status_get(tracking)
                 recipient = (
-                    tracking.partner_id.display_name or tracking.recipient)
+                    tracking.partner_id.name or tracking.recipient)
                 partner_trackings.append((
                     status, tracking.id, recipient, tracking.partner_id.id))
                 if tracking.partner_id:
@@ -60,7 +60,7 @@ class MailMessage(models.Model):
             for partner in partners:
                 # If there is partners not included, then status is 'unknown'
                 partner_trackings.append((
-                    'unknown', False, partner.display_name, partner.id))
+                    'unknown', False, partner.name, partner.id))
             res[message.id] = partner_trackings
         return res
 

--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -3,7 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import logging
-import threading
 import urlparse
 import time
 import re
@@ -24,7 +23,7 @@ class MailTrackingEmail(models.Model):
     _rec_name = 'display_name'
     _description = 'MailTracking email'
 
-    # This table is going to growth fast and to infinite, so we index:
+    # This table is going to grow fast and to infinite, so we index:
     # - name: Search in tree view
     # - time: default order fields
     # - recipient_address: Used for email_store calculation (non-store)
@@ -93,6 +92,7 @@ class MailTrackingEmail(models.Model):
         string="Tracking events", comodel_name='mail.tracking.event',
         inverse_name='tracking_email_id', readonly=True)
 
+    @api.model
     def _email_score_tracking_filter(self, domain, order='time desc',
                                      limit=10):
         """Default tracking search. Ready to be inherited."""
@@ -111,6 +111,20 @@ class MailTrackingEmail(models.Model):
             ('recipient_address', '=ilike', email)
         ]).email_score()
 
+    @api.model
+    def _email_score_weights(self):
+        """Default email score weights. Ready to be inherited"""
+        return {
+            'error': -50.0,
+            'rejected': -25.0,
+            'spam': -25.0,
+            'bounced': -25.0,
+            'soft-bounced': -10.0,
+            'unsub': -10.0,
+            'delivered': 1.0,
+            'opened': 5.0,
+        }
+
     @api.multi
     def email_score(self):
         """Default email score algorimth. Ready to be inherited
@@ -120,21 +134,13 @@ class MailTrackingEmail(models.Model):
         - Unknown reputation: Value 50.0
         - Good reputation: Value between 50.0 and 100.0
         """
+        weights = self._email_score_weights()
         score = 50.0
         for tracking in self:
-            if tracking.state in ('error',):
-                score -= 50.0
-            elif tracking.state in ('rejected', 'spam', 'bounced'):
-                score -= 25.0
-            elif tracking.state in ('soft-bounced', 'unsub'):
-                score -= 10.0
-            elif tracking.state in ('delivered',):
-                score += 1.0
-            elif tracking.state in ('opened',):
-                score += 5.0
+            score += weights.get(tracking.state, 0.0)
         if score > 100.0:
             score = 100.0
-        if score < 0.0:
+        elif score < 0.0:
             score = 0.0
         return score
 
@@ -273,7 +279,6 @@ class MailTrackingEmail(models.Model):
 
     @api.multi
     def event_create(self, event_type, metadata):
-        testing = getattr(threading.currentThread(), 'testing', False)
         event_ids = self.env['mail.tracking.event']
         for tracking_email in self:
             other_ids = tracking_email._concurrent_events(event_type, metadata)
@@ -281,9 +286,6 @@ class MailTrackingEmail(models.Model):
                 vals = tracking_email._event_prepare(event_type, metadata)
                 if vals:
                     event_ids += event_ids.sudo().create(vals)
-                    # Commit to DB to release exclusive lock
-                    if not testing:
-                        self.env.cr.commit()  # pragma: no cover
             else:
                 _logger.debug("Concurrent event '%s' discarded", event_type)
         if event_type in {'hard_bounce', 'spam', 'reject'}:

--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import logging
+import threading
 import urlparse
 import time
 import re
@@ -30,7 +31,7 @@ class MailTrackingEmail(models.Model):
     timestamp = fields.Float(
         string='UTC timestamp', readonly=True,
         digits=dp.get_precision('MailTracking Timestamp'))
-    time = fields.Datetime(string="Time", readonly=True)
+    time = fields.Datetime(string="Time", readonly=True, index=True)
     date = fields.Date(
         string="Date", readonly=True, compute="_compute_date", store=True)
     mail_message_id = fields.Many2one(
@@ -42,7 +43,7 @@ class MailTrackingEmail(models.Model):
     recipient = fields.Char(string='Recipient email', readonly=True)
     recipient_address = fields.Char(
         string='Recipient email address', readonly=True, store=True,
-        compute='_compute_recipient_address')
+        compute='_compute_recipient_address', index=True)
     sender = fields.Char(string='Sender email', readonly=True)
     state = fields.Selection([
         ('error', 'Error'),
@@ -87,58 +88,32 @@ class MailTrackingEmail(models.Model):
         string="Tracking events", comodel_name='mail.tracking.event',
         inverse_name='tracking_email_id', readonly=True)
 
-    @api.model
-    def tracking_ids_recalculate(self, model, email_field, tracking_field,
-                                 email, new_tracking=None):
-        objects = self.env[model].search([
-            (email_field, '=ilike', email),
-        ])
-        for obj in objects:
-            trackings = obj[tracking_field]
-            if new_tracking:
-                trackings |= new_tracking
-            trackings = trackings._email_score_tracking_filter()
-            if set(obj[tracking_field].ids) != set(trackings.ids):
-                if trackings:
-                    obj.write({
-                        tracking_field: [(6, False, trackings.ids)]
-                    })
-                else:
-                    obj.write({
-                        tracking_field: [(5, False, False)]
-                    })
-        return objects
+    def _email_score_tracking_filter(self, domain, order='time desc',
+                                     limit=10):
+        """Default tracking search. Ready to be inherited."""
+        return self.search(domain, limit=limit, order=order)
 
     @api.model
-    def _tracking_ids_to_write(self, email):
-        trackings = self.env['mail.tracking.email'].search([
-            ('recipient_address', '=ilike', email)
-        ])
-        trackings = trackings._email_score_tracking_filter()
-        if trackings:
-            return [(6, False, trackings.ids)]
-        else:
-            return [(5, False, False)]
-
-    @api.multi
-    def _email_score_tracking_filter(self):
-        """Default email score filter for tracking emails"""
-        # Consider only last 10 tracking emails
-        return self.sorted(key=lambda r: r.time, reverse=True)[:10]
+    def email_is_bounced(self, email):
+        return len(self._email_score_tracking_filter([
+            ('recipient_address', '=ilike', email),
+            ('state', 'in', ('error', 'rejected', 'spam', 'bounced')),
+        ])) > 0
 
     @api.model
     def email_score_from_email(self, email):
-        trackings = self.env['mail.tracking.email'].search([
+        return self._email_score_tracking_filter([
             ('recipient_address', '=ilike', email)
-        ])
-        return trackings.email_score()
+        ]).email_score()
 
     @api.multi
     def email_score(self):
-        """Default email score algorimth"""
+        """Default email score algorimth. Ready to be inherited
+
+        Must return a value beetwen 0.0 and 100.0
+        """
         score = 50.0
-        trackings = self._email_score_tracking_filter()
-        for tracking in trackings:
+        for tracking in self:
             if tracking.state in ('error',):
                 score -= 50.0
             elif tracking.state in ('rejected', 'spam', 'bounced'):
@@ -146,11 +121,13 @@ class MailTrackingEmail(models.Model):
             elif tracking.state in ('soft-bounced', 'unsub'):
                 score -= 10.0
             elif tracking.state in ('delivered',):
-                score += 5.0
+                score += 1.0
             elif tracking.state in ('opened',):
-                score += 10.0
+                score += 5.0
         if score > 100.0:
             score = 100.0
+        if score < 0.0:
+            score = 0.0
         return score
 
     @api.multi
@@ -179,14 +156,6 @@ class MailTrackingEmail(models.Model):
             email.date = fields.Date.to_string(
                 fields.Date.from_string(email.time))
 
-    @api.model
-    def create(self, vals):
-        tracking = super(MailTrackingEmail, self).create(vals)
-        self.tracking_ids_recalculate(
-            'res.partner', 'email', 'tracking_email_ids',
-            tracking.recipient_address, new_tracking=tracking)
-        return tracking
-
     def _get_mail_tracking_img(self):
         base_url = self.env['ir.config_parameter'].get_param('web.base.url')
         path_url = (
@@ -203,6 +172,13 @@ class MailTrackingEmail(models.Model):
             })
 
     @api.multi
+    def _partners_email_bounced_set(self, reason):
+        for tracking_email in self:
+            self.env['res.partner'].search([
+                ('email', '=ilike', tracking_email.recipient_address)
+            ]).email_bounced_set(tracking_email, reason)
+
+    @api.multi
     def smtp_error(self, mail_server, smtp_server, exception):
         self.sudo().write({
             'error_smtp_server': tools.ustr(smtp_server),
@@ -210,6 +186,7 @@ class MailTrackingEmail(models.Model):
             'error_description': tools.ustr(exception),
             'state': 'error',
         })
+        self.sudo()._partners_email_bounced_set('error')
         return True
 
     @api.multi
@@ -288,6 +265,7 @@ class MailTrackingEmail(models.Model):
 
     @api.multi
     def event_create(self, event_type, metadata):
+        testing = getattr(threading.currentThread(), 'testing', False)
         event_ids = self.env['mail.tracking.event']
         for tracking_email in self:
             other_ids = tracking_email._concurrent_events(event_type, metadata)
@@ -295,13 +273,13 @@ class MailTrackingEmail(models.Model):
                 vals = tracking_email._event_prepare(event_type, metadata)
                 if vals:
                     event_ids += event_ids.sudo().create(vals)
-                partners = self.tracking_ids_recalculate(
-                    'res.partner', 'email', 'tracking_email_ids',
-                    tracking_email.recipient_address)
-                if partners:
-                    partners.email_score_calculate()
+                    # Commit to DB to release exclusive lock
+                    if not testing:
+                        self.env.cr.commit()
             else:
                 _logger.debug("Concurrent event '%s' discarded", event_type)
+        if event_type in {'hard_bounce', 'spam', 'reject'}:
+            self.sudo()._partners_email_bounced_set(event_type)
         return event_ids
 
     @api.model

--- a/mail_tracking/models/mail_tracking_event.py
+++ b/mail_tracking/models/mail_tracking_event.py
@@ -23,7 +23,7 @@ class MailTrackingEvent(models.Model):
     date = fields.Date(
         string="Date", readonly=True, compute="_compute_date", store=True)
     tracking_email_id = fields.Many2one(
-        string='Message', readonly=True,
+        string='Message', readonly=True, required=True, ondelete='cascade',
         comodel_name='mail.tracking.email')
     event_type = fields.Selection(string='Event type', selection=[
         ('sent', 'Sent'),

--- a/mail_tracking/models/res_partner.py
+++ b/mail_tracking/models/res_partner.py
@@ -8,10 +8,14 @@ from openerp import models, api, fields
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
+    # tracking_emails_count and email_score are non-store fields in order
+    # to improve performance
+    # email_bounced is store=True and index=True field in order to filter
+    # in tree view for processing bounces easier
     tracking_emails_count = fields.Integer(
         string="Tracking emails count", readonly=True, store=False,
         compute="_compute_tracking_emails_count")
-    email_bounced = fields.Boolean(string="Email bounced")
+    email_bounced = fields.Boolean(string="Email bounced", index=True)
     email_score = fields.Float(
         string="Email score", readonly=True, store=False,
         compute='_compute_email_score')
@@ -35,7 +39,8 @@ class ResPartner(models.Model):
     @api.multi
     def email_bounced_set(self, tracking_email, reason):
         """Inherit this method to make any other actions to partners"""
-        return self.write({'email_bounced': True})
+        partners = self.filtered(lambda r: not r.email_bounced)
+        return partners.write({'email_bounced': True})
 
     @api.multi
     def write(self, vals):

--- a/mail_tracking/models/res_partner.py
+++ b/mail_tracking/models/res_partner.py
@@ -13,12 +13,9 @@ class ResPartner(models.Model):
     # email_bounced is store=True and index=True field in order to filter
     # in tree view for processing bounces easier
     tracking_emails_count = fields.Integer(
-        string="Tracking emails count", readonly=True,
-        compute="_compute_tracking_emails_count")
-    email_bounced = fields.Boolean(string="Email bounced", index=True)
-    email_score = fields.Float(
-        string="Email score", readonly=True,
-        compute='_compute_email_score')
+        compute='_compute_tracking_emails_count', readonly=True)
+    email_bounced = fields.Boolean(index=True)
+    email_score = fields.Float(compute='_compute_email_score', readonly=True)
 
     @api.multi
     @api.depends('email')

--- a/mail_tracking/models/res_partner.py
+++ b/mail_tracking/models/res_partner.py
@@ -13,11 +13,11 @@ class ResPartner(models.Model):
     # email_bounced is store=True and index=True field in order to filter
     # in tree view for processing bounces easier
     tracking_emails_count = fields.Integer(
-        string="Tracking emails count", readonly=True, store=False,
+        string="Tracking emails count", readonly=True,
         compute="_compute_tracking_emails_count")
     email_bounced = fields.Boolean(string="Email bounced", index=True)
     email_score = fields.Float(
-        string="Email score", readonly=True, store=False,
+        string="Email score", readonly=True,
         compute='_compute_email_score')
 
     @api.multi

--- a/mail_tracking/tests/test_mail_tracking.py
+++ b/mail_tracking/tests/test_mail_tracking.py
@@ -120,6 +120,13 @@ class TestMailTracking(TransactionCase):
         self.assertEqual(mail.email_from, tracking.sender)
         res = controller.mail_tracking_open(db, tracking.id)
         self.assertEqual(image, res.response[0])
+        # Two events: sent and open
+        self.assertEqual(2, len(tracking.tracking_event_ids))
+        # Fake event: tracking_email_id = False
+        res = controller.mail_tracking_open(db, False)
+        self.assertEqual(image, res.response[0])
+        # Two events again because no tracking_email_id found for False
+        self.assertEqual(2, len(tracking.tracking_event_ids))
 
     def test_concurrent_open(self):
         mail, tracking = self.mail_send(self.recipient.email)
@@ -199,31 +206,38 @@ class TestMailTracking(TransactionCase):
             self.assertEqual('error', tracking.state)
             self.assertEqual('Warning', tracking.error_type)
             self.assertEqual('Test error', tracking.error_description)
+            self.assertTrue(self.recipient.email_bounced)
 
     def test_partner_email_change(self):
         mail, tracking = self.mail_send(self.recipient.email)
         tracking.event_create('open', {})
         orig_score = self.recipient.email_score
+        orig_count = self.recipient.tracking_emails_count
         orig_email = self.recipient.email
         self.recipient.email = orig_email + '2'
         self.assertEqual(50.0, self.recipient.email_score)
+        self.assertEqual(0, self.recipient.tracking_emails_count)
         self.recipient.email = orig_email
         self.assertEqual(orig_score, self.recipient.email_score)
+        self.assertEqual(orig_count, self.recipient.tracking_emails_count)
 
     def test_process_hard_bounce(self):
         mail, tracking = self.mail_send(self.recipient.email)
         tracking.event_create('hard_bounce', {})
         self.assertEqual('bounced', tracking.state)
+        self.assertTrue(self.recipient.email_score < 50.0)
 
     def test_process_soft_bounce(self):
         mail, tracking = self.mail_send(self.recipient.email)
         tracking.event_create('soft_bounce', {})
         self.assertEqual('soft-bounced', tracking.state)
+        self.assertTrue(self.recipient.email_score < 50.0)
 
     def test_process_delivered(self):
         mail, tracking = self.mail_send(self.recipient.email)
         tracking.event_create('delivered', {})
         self.assertEqual('delivered', tracking.state)
+        self.assertTrue(self.recipient.email_score > 50.0)
 
     def test_process_deferral(self):
         mail, tracking = self.mail_send(self.recipient.email)
@@ -234,26 +248,38 @@ class TestMailTracking(TransactionCase):
         mail, tracking = self.mail_send(self.recipient.email)
         tracking.event_create('spam', {})
         self.assertEqual('spam', tracking.state)
+        self.assertTrue(self.recipient.email_score < 50.0)
 
     def test_process_unsub(self):
         mail, tracking = self.mail_send(self.recipient.email)
         tracking.event_create('unsub', {})
         self.assertEqual('unsub', tracking.state)
+        self.assertTrue(self.recipient.email_score < 50.0)
 
     def test_process_reject(self):
         mail, tracking = self.mail_send(self.recipient.email)
         tracking.event_create('reject', {})
         self.assertEqual('rejected', tracking.state)
+        self.assertTrue(self.recipient.email_score < 50.0)
 
     def test_process_open(self):
         mail, tracking = self.mail_send(self.recipient.email)
         tracking.event_create('open', {})
         self.assertEqual('opened', tracking.state)
+        self.assertTrue(self.recipient.email_score > 50.0)
 
     def test_process_click(self):
         mail, tracking = self.mail_send(self.recipient.email)
         tracking.event_create('click', {})
         self.assertEqual('opened', tracking.state)
+        self.assertTrue(self.recipient.email_score > 50.0)
+
+    def test_process_several_bounce(self):
+        for i in range(1, 10):
+            mail, tracking = self.mail_send(self.recipient.email)
+            tracking.event_create('hard_bounce', {})
+            self.assertEqual('bounced', tracking.state)
+        self.assertEqual(0.0, self.recipient.email_score)
 
     def test_db(self):
         db = self.env.cr.dbname

--- a/mail_tracking/tests/test_mail_tracking.py
+++ b/mail_tracking/tests/test_mail_tracking.py
@@ -5,10 +5,10 @@
 import mock
 import base64
 import time
+from openerp import http
 from openerp.tests.common import TransactionCase
 from ..controllers.main import MailTrackingController, BLANK
 
-mock_request = 'openerp.http.request'
 mock_send_email = ('openerp.addons.base.ir.ir_mail_server.'
                    'ir_mail_server.send_email')
 
@@ -22,11 +22,9 @@ class FakeUserAgent(object):
         return 'Test suite'
 
 
-# One test case per method
 class TestMailTracking(TransactionCase):
-    # Use case : Prepare some data for current test case
-    def setUp(self):
-        super(TestMailTracking, self).setUp()
+    def setUp(self, *args, **kwargs):
+        super(TestMailTracking, self).setUp(*args, **kwargs)
         self.sender = self.env['res.partner'].create({
             'name': 'Test sender',
             'email': 'sender@example.com',
@@ -37,12 +35,22 @@ class TestMailTracking(TransactionCase):
             'email': 'recipient@example.com',
             'notify_email': 'always',
         })
-        self.request = {
+        self.last_request = http.request
+        http.request = type('obj', (object,), {
+            'db': self.env.cr.dbname,
+            'env': self.env,
+            'endpoint': type('obj', (object,), {
+                'routing': [],
+            }),
             'httprequest': type('obj', (object,), {
                 'remote_addr': '123.123.123.123',
                 'user_agent': FakeUserAgent(),
             }),
-        }
+        })
+
+    def tearDown(self, *args, **kwargs):
+        http.request = self.last_request
+        return super(TestMailTracking, self).tearDown(*args, **kwargs)
 
     def test_message_post(self):
         # This message will generate a notification for recipient
@@ -110,10 +118,8 @@ class TestMailTracking(TransactionCase):
         mail, tracking = self.mail_send(self.recipient.email)
         self.assertEqual(mail.email_to, tracking.recipient)
         self.assertEqual(mail.email_from, tracking.sender)
-        with mock.patch(mock_request) as mock_func:
-            mock_func.return_value = type('obj', (object,), self.request)
-            res = controller.mail_tracking_open(db, tracking.id)
-            self.assertEqual(image, res.response[0])
+        res = controller.mail_tracking_open(db, tracking.id)
+        self.assertEqual(image, res.response[0])
 
     def test_concurrent_open(self):
         mail, tracking = self.mail_send(self.recipient.email)
@@ -252,11 +258,9 @@ class TestMailTracking(TransactionCase):
     def test_db(self):
         db = self.env.cr.dbname
         controller = MailTrackingController()
-        with mock.patch(mock_request) as mock_func:
-            mock_func.return_value = type('obj', (object,), self.request)
-            not_found = controller.mail_tracking_all('not_found_db')
-            self.assertEqual('NOT FOUND', not_found.response[0])
-            none = controller.mail_tracking_all(db)
-            self.assertEqual('NONE', none.response[0])
-            none = controller.mail_tracking_event(db, 'open')
-            self.assertEqual('NONE', none.response[0])
+        not_found = controller.mail_tracking_all('not_found_db')
+        self.assertEqual('NOT FOUND', not_found.response[0])
+        none = controller.mail_tracking_all(db)
+        self.assertEqual('NONE', none.response[0])
+        none = controller.mail_tracking_event(db, 'open')
+        self.assertEqual('NONE', none.response[0])

--- a/mail_tracking/views/res_partner_view.xml
+++ b/mail_tracking/views/res_partner_view.xml
@@ -24,7 +24,22 @@
         <field name="email" position="after">
             <field name="email_score" widget="progressbar"
                    attrs="{'invisible': [('email', '=', False)]}"/>
+           <field name="email_bounced"
+                  attrs="{'invisible': [('email', '=', False)]}"/>
         </field>
+    </field>
+</record>
+
+<record model="ir.ui.view" id="view_res_partner_filter">
+    <field name="name">Filter bounced partners</field>
+    <field name="model">res.partner</field>
+    <field name="inherit_id" ref="base.view_res_partner_filter"/>
+    <field name="arch" type="xml">
+        <filter name="type_company" position="after">
+            <separator/>
+            <filter string="Email bounced" name="email_bounced"
+                    domain="[('email', '!=' , False), ('email_bounced', '=', True)]"/>
+        </filter>
     </field>
 </record>
 


### PR DESCRIPTION
Port to v9 of PR: https://github.com/OCA/social/pull/97

This PR fix some performance issues:
- [Fixed] In some cases `self.env.cr` is not closed properly.
- Add `index=True` to `time` and `recipient_address` fields of `mail.tracking.email` model
- Many2many relation between partners (and mail contacts) and mail tracking emails deleted
- `email_score` is now a non-stored computed field

Also includes some new features for processing bounced emails easier:
- Adds a menu for listing mass mailing emails and events
- Add a boolean field `email_bounced` to partners and mail contacts. To easy filter them and do manual operations: call the partner, remove the partner, opt-out, ... Also prepare easy inherited methods for programming automatic operations in customer addon.
