### PR TITLE
[FIX][mail_tracking] display_name of tracking_emails with no subject

### DIFF
--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -167,7 +167,7 @@ class MailTrackingEmail(models.Model):
     @api.depends('name', 'recipient')
     def _compute_display_name(self):
         for email in self:
-            parts = [email.name]
+            parts = [email.name or '']
             if email.recipient:
                 parts.append(email.recipient)
             email.display_name = ' - '.join(parts)


### PR DESCRIPTION
There was a bug preventing a mail_tracking object to be displayed if the related e-mail has no subject.
