### PR TITLE
[FIX] Author of mail.notification when using notification templates

### DIFF
--- a/mail_notification_email_template/models/mail_notification.py
+++ b/mail_notification_email_template/models/mail_notification.py
@@ -33,6 +33,7 @@ class MailNotification(models.Model):
                 continue
             custom_values = {
                 'references': message.parent_id.message_id,
+                'author_id': message.author_id.id
             }
             if message.res_id and hasattr(
                 self.env[message.model], 'message_get_email_values'


### PR DESCRIPTION
This fixes issue #94 where notifications created with e-mail templates were from user Administrator.

With this fix, the mail.message created when sending the e-mail is from the user that created the message instead of Administrator.
