### PR TITLE
[8.0][FIX][website_mail_snippet_fixed] Clean before saving.

### DIFF
--- a/website_mail_snippet_fixed/__openerp__.py
+++ b/website_mail_snippet_fixed/__openerp__.py
@@ -4,10 +4,12 @@
 {
     "name": "Fixed-Width Layout Snippets for Writing Emails",
     "summary": "560px width extra building blocks",
-    "version": "8.0.1.0.0",
+    "version": "8.0.1.0.1",
     "category": "Marketing",
-    "website": "http://www.antiun.com",
-    "author": "Antiun Ingeniería S.L., Odoo Community Association (OCA)",
+    "website": "https://www.tecnativa.com",
+    "author": "Antiun Ingeniería S.L., "
+              "Tecnativa, "
+              "Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,
     "installable": True,
@@ -18,6 +20,7 @@
         "website_mail_snippet_vertical_resize_base",
     ],
     "data": [
+        "views/assets.xml",
         "views/templates.xml",
         "views/snippet_1_col.xml",
         "views/snippet_2_cols.xml",

--- a/website_mail_snippet_fixed/static/src/js/fixed_560px.js
+++ b/website_mail_snippet_fixed/static/src/js/fixed_560px.js
@@ -1,0 +1,26 @@
+/* Copyright 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+(function ($) {
+    "use strict";
+    openerp.website.snippet.options.fixed_560px =
+    openerp.website.snippet.Option.extend({
+        // Remove attributes added by Odoo at drop time, to avoid him to try
+        // to overwrite the snippet view itself instead of just replacing the
+        // email/template body.
+        clean_for_save: function () {
+            this._super();
+            var bad_attrs = [
+                "data-oe-field",
+                "data-oe-id",
+                "data-oe-model",
+                "data-oe-source-id",
+                "data-oe-xpath",
+                "data-original-title",
+            ];
+            for (var n in bad_attrs) {
+                var att = bad_attrs[n];
+                this.$target.find("[" + att + "]").removeAttr(att);
+            }
+        },
+    });
+})(jQuery);

--- a/website_mail_snippet_fixed/views/assets.xml
+++ b/website_mail_snippet_fixed/views/assets.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<openerp>
+<data>
+
+<template id="assets_editor" inherit_id="website.assets_editor">
+    <xpath expr=".">
+        <script type="text/javascript"
+                src="/website_mail_snippet_fixed/static/src/js/fixed_560px.js"/>
+    </xpath>
+</template>
+
+</data>
+</openerp>

--- a/website_mail_snippet_fixed/views/templates.xml
+++ b/website_mail_snippet_fixed/views/templates.xml
@@ -21,6 +21,12 @@
             <t t-call="website_mail_snippet_fixed.560px_section"/>
         </div>
     </xpath>
+
+    <xpath expr="//*[@id='snippet_options']" position="inside">
+        <div
+            data-snippet-option-id='fixed_560px'
+            data-selector=".fixed_560px"/>
+    </xpath>
 </template>
 
 <template id="560px_section"/>
@@ -37,7 +43,7 @@
                 class="oe_snippet_thumbnail_title"/>
         </div>
         <div
-            class="oe_snippet_body"
+            class="oe_snippet_body fixed_560px"
             style="padding:0px; width:100%; background-color:#ececec; color:rgb(0,0,0); line-height:20px; font-family:Arial,sans-serif; font-size:9pt">
             <table
                 style="width: 560px; border-collapse: collapse; background: inherit; color: inherit; background: #FFFFFF"


### PR DESCRIPTION
Before this patch, when a user dragged a fixed snippet on the email body, the result had some attributes that are internally used in Odoo to know if you are replacing a part of a view, and which.

This made that editing the placeholders changed directly the snippet template itself.

On other cases, when this addon was removed and then reinstalled, it made that previous templates raise a MissingError when saving any changes on them.

Chances are that if you have (maybe unnoticedly) hit this bug, you have some snippet XMLID from this addon marked as `noupdate=1`, so the recommended upgrade path is to uninstall this addon and reinstall it.

@Tecnativa
