### PR TITLE
[8.0][IMP][mail_tracking] Allow to define a custom mail_tracking base url

### DIFF
--- a/mail_tracking/__openerp__.py
+++ b/mail_tracking/__openerp__.py
@@ -5,7 +5,7 @@
 {
     "name": "Email tracking",
     "summary": "Email tracking system for all mails sent",
-    "version": "8.0.3.0.0",
+    "version": "8.0.3.0.1",
     "category": "Social Network",
     "website": "http://www.tecnativa.com",
     "author": "Tecnativa, "

--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -171,7 +171,9 @@ class MailTrackingEmail(models.Model):
                 fields.Date.from_string(email.time))
 
     def _get_mail_tracking_img(self):
-        base_url = self.env['ir.config_parameter'].get_param('web.base.url')
+        m_config = self.env['ir.config_parameter']
+        base_url = (m_config.get_param('mail_tracking.base.url') or
+                    m_config.get_param('web.base.url'))
         path_url = (
             'mail/tracking/open/%(db)s/%(tracking_email_id)s/blank.gif' % {
                 'db': self.env.cr.dbname,


### PR DESCRIPTION
This minor change allows to change the base url used for mail_tracking image, but if not defined it will fallbacks to `web.base.url`.
In some cases, this base URL must be different to `web.base.url`
