### PR TITLE
[MIG] mail_tracking_mailgun: Migrated to 10.0

### DIFF
--- a/mail_tracking_mailgun/__manifest__.py
+++ b/mail_tracking_mailgun/__manifest__.py
@@ -4,14 +4,14 @@
 {
     "name": "Mail tracking for Mailgun",
     "summary": "Mail tracking and Mailgun webhooks integration",
-    "version": "9.0.1.0.0",
+    "version": "10.0.1.0.0",
     "category": "Social Network",
     "website": "https://odoo-community.org/",
     "author": "Tecnativa, "
               "Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,
-    'installable': False,
+    'installable': True,
     "depends": [
         "mail_tracking",
     ],

--- a/mail_tracking_mailgun/models/ir_mail_server.py
+++ b/mail_tracking_mailgun/models/ir_mail_server.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import json
-from openerp import models
+from odoo import models
 
 
 class IrMailServer(models.Model):
@@ -14,9 +14,7 @@ class IrMailServer(models.Model):
             tracking_email_id, headers)
         headers = headers or {}
         metadata = {
-            # NOTE: We can not use 'self.env.cr.dbname' because self is
-            # ir.mail_server object in old API (osv.osv)
-            'odoo_db': self.pool.db_name,
+            'odoo_db': self.env.cr.dbname,
             'tracking_email_id': tracking_email_id,
         }
         headers['X-Mailgun-Variables'] = json.dumps(metadata)

--- a/mail_tracking_mailgun/models/mail_tracking_email.py
+++ b/mail_tracking_mailgun/models/mail_tracking_email.py
@@ -5,7 +5,7 @@
 import hashlib
 import hmac
 from datetime import datetime
-from openerp import models, api, fields
+from odoo import models, api, fields
 
 import logging
 _logger = logging.getLogger(__name__)

--- a/mail_tracking_mailgun/tests/test_mailgun.py
+++ b/mail_tracking_mailgun/tests/test_mailgun.py
@@ -2,7 +2,7 @@
 # Copyright 2016 Antonio Espinosa - <antonio.espinosa@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openerp.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase
 
 
 class TestMailgun(TransactionCase):


### PR DESCRIPTION
Note that this will have a red runbot until #108 is merged. 

Not tested besides python test cases, I don't have a mailgun account nor a domain with an odoo server on it to test this fully. If your runbot instances stays alive long enough, we could probably test it from there once it'll build, not sure.
