### PR TITLE
[FIX] email_template_qweb: Decode body when encoded

### DIFF
--- a/email_template_qweb/models/mail_template.py
+++ b/email_template_qweb/models/mail_template.py
@@ -33,6 +33,8 @@ class MailTemplate(models.Model):
                             'email_template': this,
                         })
                     )
+                    # Some wizards, like when sending a sales order, need this
+                    # fix to display accents correctly
                     if isinstance(result[record_id]['body_html'], unicode):
                         result[record_id]['body_html'] = (
                             result[record_id]['body_html'].decode('utf-8')

--- a/email_template_qweb/models/mail_template.py
+++ b/email_template_qweb/models/mail_template.py
@@ -33,6 +33,10 @@ class MailTemplate(models.Model):
                             'email_template': this,
                         })
                     )
+                    if isinstance(result[record_id]['body_html'], unicode):
+                        result[record_id]['body_html'] = (
+                            result[record_id]['body_html'].decode('utf-8')
+                        )
                     result[record_id]['body'] = tools.html_sanitize(
                         result[record_id]['body_html']
                     )


### PR DESCRIPTION
If the result is of type unicode, render method encodes it in utf-8.
We need to decode it in that case so that the rendering results correct.
