### PR TITLE
[9.0][FIX][mail_tracking] Sender label is repeated in search fields

### DIFF
--- a/mail_tracking/views/mail_tracking_email_view.xml
+++ b/mail_tracking/views/mail_tracking_email_view.xml
@@ -82,7 +82,7 @@
             <field name="display_name" string="Email"
                    filter_domain="['|', ('sender', 'ilike', self), ('recipient', 'ilike', self)]"/>
             <field name="sender" string="Sender"/>
-            <field name="recipient" string="Sender"/>
+            <field name="recipient" string="Recipient"/>
             <field name="name" string="Subject"/>
             <field name="time" string="Time"/>
             <field name="date" string="Date"/>


### PR DESCRIPTION
A typo fix caused by a fast copy&paste