### PR TITLE
[8.0][IMP][mail_tracking] Track click events.

### DIFF
--- a/mail_tracking/README.rst
+++ b/mail_tracking/README.rst
@@ -95,6 +95,7 @@ Contributors
 
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
 * Antonio Espinosa <antonio.espinosa@tecnativa.com>
+* Iván Todorovich <ivan.todorovich@gmail.com>
 
 Maintainer
 ----------

--- a/mail_tracking/__openerp__.py
+++ b/mail_tracking/__openerp__.py
@@ -5,7 +5,7 @@
 {
     "name": "Email tracking",
     "summary": "Email tracking system for all mails sent",
-    "version": "8.0.3.0.1",
+    "version": "8.0.4.0.0",
     "category": "Social Network",
     "website": "http://www.tecnativa.com",
     "author": "Tecnativa, "

--- a/mail_tracking/models/mail_mail.py
+++ b/mail_tracking/models/mail_mail.py
@@ -39,5 +39,5 @@ class MailMail(models.Model):
             vals = self._tracking_email_prepare(mail, partner, email)
             tracking_email = m_tracking.sudo().create(vals)
         if tracking_email:
-            email = tracking_email.tracking_img_add(email)
+            email = tracking_email.tracking_email_add(email)
         return email

--- a/mail_tracking/tests/test_mail_tracking.py
+++ b/mail_tracking/tests/test_mail_tracking.py
@@ -126,6 +126,13 @@ class TestMailTracking(TransactionCase):
         self.assertEqual(image, res.response[0])
         # Two events again because no tracking_email_id found for False
         self.assertEqual(2, len(tracking.tracking_event_ids))
+        # Click event on links should redirect
+        http.request.httprequest.url = \
+            'http://www.odoo.com/?url=http://www.google.com.ar'
+        res = controller.mail_tracking_click(db, tracking.id)
+        self.assertEqual('301', res.status)
+        self.assertEqual('http://www.google.com.ar', res.headers['Location'])
+        self.assertEqual(3, len(tracking.tracking_event_ids))
 
     def test_concurrent_open(self):
         mail, tracking = self.mail_send(self.recipient.email)


### PR DESCRIPTION
Implements tracking click events on links, as discussed in https://github.com/OCA/social/issues/122

@antespi I took you suggestion, except for this one:

> Create a new table in order to save the relation of link to an unique token.


Instead, it replaces `href` values from anchor tags like this: `tracking_email_url/?url=original_href`
Then it routes those requests and redirects to the original URL, saving that event.
Inspired by how google does it for search result links