### PR TITLE
[FIX] Save and search recipient_address in lowercase

### DIFF
--- a/mail_tracking/__openerp__.py
+++ b/mail_tracking/__openerp__.py
@@ -5,7 +5,7 @@
 {
     "name": "Email tracking",
     "summary": "Email tracking system for all mails sent",
-    "version": "8.0.3.0.1",
+    "version": "8.0.4.0.0",
     "category": "Social Network",
     "website": "http://www.tecnativa.com",
     "author": "Tecnativa, "

--- a/mail_tracking/migrations/8.0.4.0.0/pre-migrate.py
+++ b/mail_tracking/migrations/8.0.4.0.0/pre-migrate.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+def migrate(cr, version):
+    """Update database from previous versions, before updating module."""
+    cr.execute("UPDATE res_partner SET email=lower(email)")

--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -152,11 +152,12 @@ class MailTrackingEmail(models.Model):
     @api.depends('recipient')
     def _compute_recipient_address(self):
         for email in self:
-            matches = re.search(r'<(.*@.*)>', email.recipient)
-            if matches:
-                email.recipient_address = matches.group(1).lower()
-            elif email.recipient:
-                email.recipient_address = email.recipient.lower()
+            if email.recipient:
+                matches = re.search(r'<(.*@.*)>', email.recipient)
+                if matches:
+                    email.recipient_address = matches.group(1).lower()
+                else:
+                    email.recipient_address = email.recipient.lower()
             else:
                 email.recipient_address = False
 

--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -100,16 +100,20 @@ class MailTrackingEmail(models.Model):
 
     @api.model
     def email_is_bounced(self, email):
-        return len(self._email_score_tracking_filter([
-            ('recipient_address', '=ilike', email),
-            ('state', 'in', ('error', 'rejected', 'spam', 'bounced')),
-        ])) > 0
+        if email:
+            return len(self._email_score_tracking_filter([
+                ('recipient_address', '=', email.lower()),
+                ('state', 'in', ('error', 'rejected', 'spam', 'bounced')),
+            ])) > 0
+        return False
 
     @api.model
     def email_score_from_email(self, email):
-        return self._email_score_tracking_filter([
-            ('recipient_address', '=ilike', email)
-        ]).email_score()
+        if email:
+            return self._email_score_tracking_filter([
+                ('recipient_address', '=', email.lower())
+            ]).email_score()
+        return 0.
 
     @api.model
     def _email_score_weights(self):
@@ -150,9 +154,11 @@ class MailTrackingEmail(models.Model):
         for email in self:
             matches = re.search(r'<(.*@.*)>', email.recipient)
             if matches:
-                email.recipient_address = matches.group(1)
+                email.recipient_address = matches.group(1).lower()
+            elif email.recipient:
+                email.recipient_address = email.recipient.lower()
             else:
-                email.recipient_address = email.recipient
+                email.recipient_address = False
 
     @api.multi
     @api.depends('name', 'recipient')

--- a/mail_tracking/models/res_partner.py
+++ b/mail_tracking/models/res_partner.py
@@ -28,10 +28,12 @@ class ResPartner(models.Model):
     @api.depends('email')
     def _compute_tracking_emails_count(self):
         for partner in self:
-            partner.tracking_emails_count = self.env['mail.tracking.email'].\
-                search_count([
-                    ('recipient_address', '=ilike', partner.email)
+            count = 0
+            if partner.email:
+                count = self.env['mail.tracking.email'].search_count([
+                    ('recipient_address', '=', partner.email.lower())
                 ])
+            partner.tracking_emails_count = count
 
     @api.multi
     def email_bounced_set(self, tracking_email, reason):

--- a/mail_tracking/models/res_partner.py
+++ b/mail_tracking/models/res_partner.py
@@ -45,6 +45,7 @@ class ResPartner(models.Model):
     def write(self, vals):
         email = vals.get('email')
         if email is not None:
+            vals['email'] = email.lower() if email else False
             vals['email_bounced'] = (
                 bool(email) and
                 self.env['mail.tracking.email'].email_is_bounced(email))


### PR DESCRIPTION
```recipient_address``` is an indexed field, but in all searchings we've been using ```=ilike```, then PostgreSQL can't use index for searching.
With this PR we save ```recipient_address``` in lowercase and search it using ```=```
This improve performance when calculating email_score, for instance.

Backport from https://github.com/OCA/social/pull/124