### PR TITLE
[9.0][IMP][mail_tracking] Track click events

### DIFF
--- a/mail_tracking/README.rst
+++ b/mail_tracking/README.rst
@@ -95,6 +95,7 @@ Contributors
 
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
 * Antonio Espinosa <antonio.espinosa@tecnativa.com>
+* Iván Todorovich <ivan.todorovich@gmail.com>
 
 Maintainer
 ----------

--- a/mail_tracking/__openerp__.py
+++ b/mail_tracking/__openerp__.py
@@ -5,7 +5,7 @@
 {
     "name": "Email tracking",
     "summary": "Email tracking system for all mails sent",
-    "version": "9.0.2.1.0",
+    "version": "9.0.3.0.0",
     "category": "Social Network",
     "website": "http://www.tecnativa.com",
     "author": "Tecnativa, "

--- a/mail_tracking/models/mail_mail.py
+++ b/mail_tracking/models/mail_mail.py
@@ -33,4 +33,4 @@ class MailMail(models.Model):
         email = super(MailMail, self).send_get_email_dict(partner=partner)
         vals = self._tracking_email_prepare(partner, email)
         tracking_email = self.env['mail.tracking.email'].sudo().create(vals)
-        return tracking_email.tracking_img_add(email)
+        return tracking_email.tracking_email_add(email)

--- a/mail_tracking/tests/test_mail_tracking.py
+++ b/mail_tracking/tests/test_mail_tracking.py
@@ -127,6 +127,13 @@ class TestMailTracking(TransactionCase):
         self.assertEqual(image, res.response[0])
         # Two events again because no tracking_email_id found for False
         self.assertEqual(2, len(tracking.tracking_event_ids))
+        # Click event on links should redirect
+        http.request.httprequest.url = \
+            'http://www.odoo.com/?url=http://www.google.com.ar'
+        res = controller.mail_tracking_click(db, tracking.id)
+        self.assertEqual('301', res.status)
+        self.assertEqual('http://www.google.com.ar', res.headers['Location'])
+        self.assertEqual(3, len(tracking.tracking_event_ids))
 
     def test_concurrent_open(self):
         mail, tracking = self.mail_send(self.recipient.email)


### PR DESCRIPTION
Same as https://github.com/OCA/social/pull/123 but adapted to 9.0

I'm still working on 8.0, so this is just a fast migration from looking at the code. I have not tested it on a local instance.

----

In https://github.com/OCA/social/issues/122, @pedrobaeza **suggested:**

> In Odoo v9, it must use the existing link tracker from Odoo.

This is not done, since I don't have a running 9.0 instance and I don't have the time to investigate it any further. It should be left as a future improvement.

----

ping @antespi since he reviewed https://github.com/OCA/social/pull/123