### PR TITLE
Improve default e-mail notification template

### DIFF
--- a/mail_notification_email_template/data/email_template.xml
+++ b/mail_notification_email_template/data/email_template.xml
@@ -4,10 +4,21 @@
         <record id="template" model="email.template">
             <field name="name">Template for discussion notifications</field>
             <field name="model_id" ref="mail.model_mail_notification" />
-            <field name="subject">${object.message_id.subject|safe}</field>
+            <field name="subject"><![CDATA[
+                <% set message = object.message_id %>
+                <% set thread = message.message_ancestor_id %>
+                <% if message.subject: %>
+                    ${message.subject|safe}
+                <% else: %>
+                    ${thread.subject and 'RE: ' + thread.subject or object.record.name|safe}
+                <% endif %>
+                ]]>
+            </field>
             <field name="body_html"><![CDATA[
-                <h2>Dear ${object.partner_id.name},</h2>
-                <p>there's a new message on <a href="${object.record_access_link}">${object.record.name}</a>:</p>
+                % if object.partner_id.user_ids:
+                    <h2>Dear ${object.partner_id.name},</h2>
+                    <p>there's a new message on <a href="${object.record_access_link or object.env['ir.config_parameter'].get_param('web.base.url')}">${object.record.name or 'Your Odoo Inbox'}</a>:</p>
+                % endif
                 ${object.message_id.body|safe}
                 ]]>
             </field>

--- a/mail_notification_email_template/models/mail_notification.py
+++ b/mail_notification_email_template/models/mail_notification.py
@@ -14,6 +14,8 @@ class MailNotification(models.Model):
         ],
         compute='_compute_record')
     record_access_link = fields.Char(compute='_compute_record')
+    message_ancestor_id = fields.Many2one(
+        'mail.message', compute='_compute_ancestor')
 
     @api.multi
     def _notify_email(self, message_id, force_send=False, user_signature=True):
@@ -68,3 +70,13 @@ class MailNotification(models.Model):
             )
             for a in etree.HTML(link_html or '<html/>').xpath('//a[@href]'):
                 this.record_access_link = a.get('href')
+
+    @api.multi
+    def _compute_ancestor(self):
+        for notification in self:
+            previous = notification.message_id
+            ancestor = previous.parent_id
+            while ancestor:
+                previous = ancestor
+                ancestor = ancestor.parent_id
+            notification.message_ancestor_id = ancestor or previous


### PR DESCRIPTION
I propose some modifications for default e-mail notification template :

1. When posting directly in a thread, genereated messages have no subject. Therefore, instead of letting the subject empty, we take the first message's subject in the thread (new ancestor field) and use it for subject (RE: ancestor_subject)
2. When sending a notification to a partner that don't have access to Odoo (not a User), we hide the record access link and only display the message body.
3. If no record_access_link is available, display base URL with "Your Odoo Inbox" (happens when a message is directly sent to a user and not attached to a record)