### PR TITLE
[8.0][FIX][mail_tracking] Use event recipient address to find partners and contacts to bounce

### DIFF
--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -195,11 +195,16 @@ class MailTrackingEmail(models.Model):
             })
 
     @api.multi
-    def _partners_email_bounced_set(self, reason):
-        for tracking_email in self:
+    def _partners_email_bounced_set(self, reason, event=None):
+        recipients = []
+        if event and event.recipient_address:
+            recipients.append(event.recipient_address)
+        else:
+            recipients = list(filter(None, self.mapped('recipient_address')))
+        for recipient in recipients:
             self.env['res.partner'].search([
-                ('email', '=ilike', tracking_email.recipient_address)
-            ]).email_bounced_set(tracking_email, reason)
+                ('email', '=ilike', recipient)
+            ]).email_bounced_set(self, reason, event=event)
 
     @api.multi
     def smtp_error(self, mail_server, smtp_server, exception):
@@ -293,11 +298,13 @@ class MailTrackingEmail(models.Model):
             if not other_ids:
                 vals = tracking_email._event_prepare(event_type, metadata)
                 if vals:
-                    event_ids += event_ids.sudo().create(vals)
+                    event = event_ids.sudo().create(vals)
+                    if event_type in {'hard_bounce', 'spam', 'reject'}:
+                        self.sudo()._partners_email_bounced_set(
+                            event_type, event=event)
+                    event_ids += event
             else:
                 _logger.debug("Concurrent event '%s' discarded", event_type)
-        if event_type in {'hard_bounce', 'spam', 'reject'}:
-            self.sudo()._partners_email_bounced_set(event_type)
         return event_ids
 
     @api.model

--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -298,11 +298,12 @@ class MailTrackingEmail(models.Model):
             if not other_ids:
                 vals = tracking_email._event_prepare(event_type, metadata)
                 if vals:
-                    event = event_ids.sudo().create(vals)
+                    events = event_ids.sudo().create(vals)
                     if event_type in {'hard_bounce', 'spam', 'reject'}:
-                        self.sudo()._partners_email_bounced_set(
-                            event_type, event=event)
-                    event_ids += event
+                        for event in events:
+                            self.sudo()._partners_email_bounced_set(
+                                event_type, event=event)
+                    event_ids += events
             else:
                 _logger.debug("Concurrent event '%s' discarded", event_type)
         return event_ids

--- a/mail_tracking/models/mail_tracking_event.py
+++ b/mail_tracking/models/mail_tracking_event.py
@@ -2,6 +2,7 @@
 # © 2016 Antonio Espinosa - <antonio.espinosa@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import re
 import time
 from datetime import datetime
 
@@ -16,6 +17,9 @@ class MailTrackingEvent(models.Model):
     _description = 'MailTracking event'
 
     recipient = fields.Char(string="Recipient", readonly=True)
+    recipient_address = fields.Char(
+        string='Recipient email address', readonly=True, store=True,
+        compute='_compute_recipient_address', index=True)
     timestamp = fields.Float(
         string='UTC timestamp', readonly=True,
         digits=dp.get_precision('MailTracking Timestamp'))
@@ -50,6 +54,19 @@ class MailTrackingEvent(models.Model):
     error_type = fields.Char(string='Error type', readonly=True)
     error_description = fields.Char(string='Error description', readonly=True)
     error_details = fields.Text(string='Error details', readonly=True)
+
+    @api.multi
+    @api.depends('recipient')
+    def _compute_recipient_address(self):
+        for email in self:
+            if email.recipient:
+                matches = re.search(r'<(.*@.*)>', email.recipient)
+                if matches:
+                    email.recipient_address = matches.group(1).lower()
+                else:
+                    email.recipient_address = email.recipient.lower()
+            else:
+                email.recipient_address = False
 
     @api.multi
     @api.depends('time')

--- a/mail_tracking/models/res_partner.py
+++ b/mail_tracking/models/res_partner.py
@@ -36,7 +36,7 @@ class ResPartner(models.Model):
             partner.tracking_emails_count = count
 
     @api.multi
-    def email_bounced_set(self, tracking_email, reason):
+    def email_bounced_set(self, tracking_emails, reason, event=None):
         """Inherit this method to make any other actions to partners"""
         partners = self.filtered(lambda r: not r.email_bounced)
         return partners.write({'email_bounced': True})

--- a/mail_tracking_mass_mailing/models/mail_mass_mailing_contact.py
+++ b/mail_tracking_mass_mailing/models/mail_mass_mailing_contact.py
@@ -21,8 +21,9 @@ class MailMassMailingContact(models.Model):
                 email_score_from_email(contact.email)
 
     @api.multi
-    def email_bounced_set(self, tracking_email, reason):
-        return self.write({'email_bounced': True})
+    def email_bounced_set(self, tracking_emails, reason, event=None):
+        contacts = self.filtered(lambda r: not r.email_bounced)
+        return contacts.write({'email_bounced': True})
 
     @api.multi
     def write(self, vals):

--- a/mail_tracking_mass_mailing/models/mail_tracking_email.py
+++ b/mail_tracking_mass_mailing/models/mail_tracking_email.py
@@ -32,11 +32,16 @@ class MailTrackingEmail(models.Model):
         return tracking
 
     @api.multi
-    def _contacts_email_bounced_set(self, reason):
-        for tracking_email in self:
+    def _contacts_email_bounced_set(self, reason, event=None):
+        recipients = []
+        if event and event.recipient_address:
+            recipients.append(event.recipient_address)
+        else:
+            recipients = list(filter(None, self.mapped('recipient_address')))
+        for recipient in recipients:
             self.env['mail.mass_mailing.contact'].search([
-                ('email', '=ilike', tracking_email.recipient_address)
-            ]).email_bounced_set(tracking_email, reason)
+                ('email', '=ilike', recipient)
+            ]).email_bounced_set(self, reason, event=event)
 
     @api.multi
     def smtp_error(self, mail_server, smtp_server, exception):


### PR DESCRIPTION
There are use cases when Odoo send an email to a recipient (To:) and copy to others (Cc:). In these cases, events like bounces indicates the recipient address who is actually bounce. And sometimes it is not the original one (To:)

Current implementation:
- Mark as bounce partners with original email recipient address (To:)

Desire implementation:
- Mark as bounce the partner with the recipient address indicated in bounce event (if available)

This PR affects to ```mail_tracking``` and ```mail_tracking_mass_mailing``` addons