### PR TITLE
[FIX][9.0] partner buttons view on enterprise

### DIFF
--- a/mail_tracking/views/res_partner_view.xml
+++ b/mail_tracking/views/res_partner_view.xml
@@ -13,7 +13,7 @@
                     context="{'search_default_recipient': email,
                               'default_recipient': email}"
                     type="action"
-                    class="oe_stat_button oe_inline"
+                    class="oe_stat_button"
                     icon="fa-envelope-o"
                     attrs="{'invisible': [('email', '=', False)]}">
                 <field name="tracking_emails_count"


### PR DESCRIPTION
Class 'class="oe_stat_button oe_inline"' is no more used on buttons of partner view, only 'class="oe_stat_button"' (no more oe_inline). This cause an error on enterprise view when too many buttons (find image attached)
![seleccion_004](https://cloud.githubusercontent.com/assets/3016656/21195447/95293180-c212-11e6-936d-44f574d68f86.png)

Where normal behaviour is
![seleccion_005](https://cloud.githubusercontent.com/assets/3016656/21195477/b348d8a0-c212-11e6-800a-d2ee61d383a7.png)

