### PR TITLE
[WIP][mail_tracking] Fix broken images on README file

### DIFF
--- a/mail_tracking/README.rst
+++ b/mail_tracking/README.rst
@@ -30,22 +30,22 @@ status icon will appear just right to name of notified partner.
 
 These are all available status icons:
 
-.. |sent| image:: mail_tracking/static/src/img/sent.png
+.. |sent| image:: static/src/img/sent.png
    :width: 10px
 
-.. |delivered| image:: mail_tracking/static/src/img/delivered.png
+.. |delivered| image:: static/src/img/delivered.png
    :width: 15px
 
-.. |opened| image:: mail_tracking/static/src/img/opened.png
+.. |opened| image:: static/src/img/opened.png
    :width: 15px
 
-.. |error| image:: mail_tracking/static/src/img/error.png
+.. |error| image:: static/src/img/error.png
    :width: 10px
 
-.. |waiting| image:: mail_tracking/static/src/img/waiting.png
+.. |waiting| image:: static/src/img/waiting.png
    :width: 10px
 
-.. |unknown| image:: mail_tracking/static/src/img/unknown.png
+.. |unknown| image:: static/src/img/unknown.png
    :width: 10px
 
 |unknown|  **Unknown**: No email tracking info available. Maybe this notified partner has 'Receive Inbox Notifications by Email' == 'Never'


### PR DESCRIPTION
Images in mail_tracking README file are broken.
At the moment they look like as follows:

![1](https://cloud.githubusercontent.com/assets/3512779/21554813/135d7438-ce13-11e6-80f4-6d3b312ad2dc.png)

Using `figure` (as spotted [here](https://github.com/OCA/maintainer-tools/issues/112#issuecomment-230536053)) they look as follows :

![2](https://cloud.githubusercontent.com/assets/3512779/21554842/3afd7d1c-ce13-11e6-92d7-67140c8adc0a.png)

I should align image with its description but I'm not able, the best result I made is the following:

![3](https://cloud.githubusercontent.com/assets/3512779/21554875/872a7014-ce13-11e6-88f4-6944065f411b.png)

@antespi, @pedrobaeza, any hint would be very appreciated.