### PR TITLE
[FIX][mass_mailing_custom_unsubscribe] Reasons noupdate

### DIFF
--- a/mass_mailing_custom_unsubscribe/__openerp__.py
+++ b/mass_mailing_custom_unsubscribe/__openerp__.py
@@ -23,7 +23,7 @@
 {
     'name': "Customizable unsubscription process on mass mailing emails",
     'category': 'Marketing',
-    'version': '8.0.2.0.0',
+    'version': '8.0.2.1.0',
     'depends': [
         'mass_mailing',
         'website_crm',
@@ -31,7 +31,7 @@
     'data': [
         'security/ir.model.access.csv',
         'data/install_salt.xml',
-        'data/mail.unsubscription.reason.csv',
+        'data/mail_unsubscription_reason.xml',
         'views/assets.xml',
         'views/mail_unsubscription_reason_view.xml',
         'views/mail_mass_mailing_list_view.xml',

--- a/mass_mailing_custom_unsubscribe/data/mail.unsubscription.reason.csv
+++ b/mass_mailing_custom_unsubscribe/data/mail.unsubscription.reason.csv
@@ -1,5 +1,0 @@
-"id","name","sequence","details_required"
-"reason_not_interested","I'm not interested",10,"False"
-"reason_not_requested","I did not request this",20,"False"
-"reason_too_many","I get too many emails",30,"False"
-"reason_other","Other reason",100,"True"

--- a/mass_mailing_custom_unsubscribe/data/mail_unsubscription_reason.xml
+++ b/mass_mailing_custom_unsubscribe/data/mail_unsubscription_reason.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- © 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<openerp>
+<data noupdate="1">
+
+    <record id="reason_not_interested"
+            model="mail.unsubscription.reason"
+            forcecreate="False">
+        <field name="name">I'm not interested</field>
+        <field name="sequence">10</field>
+        <field name="details_required" eval="False"/>
+    </record>
+
+    <record id="reason_not_requested"
+            model="mail.unsubscription.reason"
+            forcecreate="False">
+        <field name="name">I did not request this</field>
+        <field name="sequence">20</field>
+        <field name="details_required" eval="False"/>
+    </record>
+
+    <record id="reason_too_many"
+            model="mail.unsubscription.reason"
+            forcecreate="False">
+        <field name="name">I get too many emails</field>
+        <field name="sequence">30</field>
+        <field name="details_required" eval="False"/>
+    </record>
+
+    <record id="reason_other"
+            model="mail.unsubscription.reason"
+            forcecreate="False">
+        <field name="name">Other reason</field>
+        <field name="sequence">100</field>
+        <field name="details_required" eval="True"/>
+    </record>
+
+</data>
+</openerp>


### PR DESCRIPTION
After this fix, when you update the addon, you will not lose your customized reasons.

Had to move from csv to XML because there's no noupdate=1 in csv.

@Tecnativa