### PR TITLE
[IMP] Shut mock exceptions up

### DIFF
--- a/mail_tracking/tests/test_mail_tracking.py
+++ b/mail_tracking/tests/test_mail_tracking.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import mock
+from odoo.tools import mute_logger
 import base64
 import time
 from odoo import http
@@ -222,6 +223,7 @@ class TestMailTracking(TransactionCase):
         )
         self.assertEqual(len(opens), 3)
 
+    @mute_logger('odoo.addons.mail.models.mail_mail')
     def test_smtp_error(self):
         with mock.patch(mock_send_email) as mock_func:
             mock_func.side_effect = Warning('Test error')

--- a/mail_tracking_mailgun/tests/test_mailgun.py
+++ b/mail_tracking_mailgun/tests/test_mailgun.py
@@ -2,6 +2,7 @@
 # Copyright 2016 Antonio Espinosa - <antonio.espinosa@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo.tools import mute_logger
 from odoo.tests.common import TransactionCase
 
 
@@ -63,6 +64,8 @@ class TestMailgun(TransactionCase):
         self.env['ir.config_parameter'].set_param('mailgun.apikey', '')
         self.test_event_delivered()
 
+    @mute_logger('odoo.addons.mail_tracking_mailgun.models'
+                 '.mail_tracking_email')
     def test_bad_signature(self):
         self.event.update({
             'event': u'delivered',
@@ -72,6 +75,8 @@ class TestMailgun(TransactionCase):
             None, self.event, self.metadata)
         self.assertEqual('ERROR: Signature', response)
 
+    @mute_logger('odoo.addons.mail_tracking_mailgun.models'
+                 '.mail_tracking_email')
     def test_bad_event_type(self):
         self.event.update({
             'event': u'bad_event',
@@ -80,6 +85,8 @@ class TestMailgun(TransactionCase):
             None, self.event, self.metadata)
         self.assertEqual('ERROR: Event type not supported', response)
 
+    @mute_logger('odoo.addons.mail_tracking_mailgun.models'
+                 '.mail_tracking_email')
     def test_bad_db(self):
         self.event.update({
             'event': u'delivered',
@@ -102,6 +109,8 @@ class TestMailgun(TransactionCase):
             None, self.event, self.metadata)
         self.assertEqual('OK', response)
 
+    @mute_logger('odoo.addons.mail_tracking_mailgun.models'
+                 '.mail_tracking_email')
     def test_tracking_not_found(self):
         self.event.update({
             'event': u'delivered',


### PR DESCRIPTION
Mock tests exceptions make Travis fail on every dependence hanged on this module. That makes impossible to fully complete tests on those PRs. This hopefully solves it.

@Tecnativa