### PR TITLE
ADD module mail_inline_css

### DIFF
--- a/mail_inline_css/README.rst
+++ b/mail_inline_css/README.rst
@@ -55,6 +55,14 @@ Just use any mail template as Odoo standard feature
    :target: https://runbot.odoo-community.org/runbot/205/10
 
 
+Note:
+
+  Odoo with module web_editor already implements this feature on the client side (js).
+  This module brings this server side feature for cases without js part. It could the more stable way over the Odoo versions with a stable api in a dedicated library 
+  with adhoc python unit tests.
+
+
+
 Bug Tracker
 ===========
 

--- a/mail_inline_css/README.rst
+++ b/mail_inline_css/README.rst
@@ -1,0 +1,101 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+===============
+Mail Inline CSS
+===============
+
+When you send HTML emails you can't use style tags but instead you have
+to put inline ``style`` attributes on every element. So from this:
+
+.. code:: html
+
+    <html>
+    <style type="text/css">
+    h1 { border:1px solid black }
+    p { color:red;}
+    </style>
+    <h1 style="font-weight:bolder">Peter</h1>
+    <p>Hej</p>
+    </html>
+
+You want this:
+
+.. code:: html
+
+    <html>
+    <h1 style="font-weight:bolder; border:1px solid black">Peter</h1>
+    <p style="color:red">Hej</p>
+    </html>
+
+This module use premailer library to do this. 
+
+It parses an HTML page, looks up ``style`` blocks
+and parses the CSS. It then uses the ``lxml.html`` parser to modify the
+DOM tree of the page accordingly.
+
+Installation
+============
+
+To install this module, you need first to install `premailer` python library with:
+
+.. code:: bash
+
+    pip install premailer
+
+
+Usage
+=====
+
+Just use any mail template as Odoo standard feature
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/205/10
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/social/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* David BEAL <david.beal@akretion.com>
+
+Do not contact contributors directly about support or help with technical issues.
+
+Funders
+-------
+
+The development of this module has been financially supported by:
+
+* Akretion
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/mail_inline_css/__init__.py
+++ b/mail_inline_css/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/mail_inline_css/__manifest__.py
+++ b/mail_inline_css/__manifest__.py
@@ -1,0 +1,18 @@
+# coding: utf-8
+# © 2017 David BEAL @ Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Mail Inline CSS',
+    "summary": "Convert style tags in inline style in your mails",
+    'version': '10.0.1.0.0',
+    'author': 'Akretion, Odoo Community Association (OCA)',
+    'website': 'https://github.com/OCA/social',
+    'license': 'AGPL-3',
+    'category': 'Tools',
+    'depends': ['mail'],
+    'installable': True,
+    "external_dependencies": {
+        "python": ['premailer'],
+    },
+}

--- a/mail_inline_css/models/__init__.py
+++ b/mail_inline_css/models/__init__.py
@@ -1,0 +1,1 @@
+from . import mail

--- a/mail_inline_css/models/mail.py
+++ b/mail_inline_css/models/mail.py
@@ -1,0 +1,24 @@
+# coding: utf-8
+# © 2017 David BEAL @ Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+from odoo import models
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from premailer import transform
+except (ImportError, IOError) as err:
+    _logger.debug(err)
+
+
+class MailTemplate(models.Model):
+    _inherit = 'mail.template'
+
+    def generate_email(self, res_ids, fields=None):
+        res = super(MailTemplate, self).generate_email(res_ids, fields=fields)
+        for id in res:
+            if res[id].get('body_html'):
+                res[id]['body_html'] = transform(res[id]['body_html'])
+        return res

--- a/mail_inline_css/models/mail.py
+++ b/mail_inline_css/models/mail.py
@@ -18,7 +18,6 @@ class MailTemplate(models.Model):
 
     def generate_email(self, res_ids, fields=None):
         res = super(MailTemplate, self).generate_email(res_ids, fields=fields)
-        for id in res:
-            if res[id].get('body_html'):
-                res[id]['body_html'] = transform(res[id]['body_html'])
+        if 'body_html' in res:
+            res['body_html'] = transform(res['body_html'])
         return res

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+premailer


### PR DESCRIPTION
When you send HTML emails you can't use style tags but instead you have
to put inline ``style`` attributes on every element.

This module use premailer library to do this