### PR TITLE
[FIX] mass_mailing_partner: permissions

### DIFF
--- a/mass_mailing_partner/__manifest__.py
+++ b/mass_mailing_partner/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Link partners with mass-mailing",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "author": "Tecnativa, "
               "Odoo Community Association (OCA)",
     "website": "https://www.tecnativa.com",

--- a/mass_mailing_partner/models/res_partner.py
+++ b/mass_mailing_partner/models/res_partner.py
@@ -19,7 +19,8 @@ class ResPartner(models.Model):
         comodel_name='mail.mass_mailing.contact', inverse_name='partner_id')
     mass_mailing_contacts_count = fields.Integer(
         string='Mailing list number',
-        compute='_compute_mass_mailing_contacts_count', store=True)
+        compute='_compute_mass_mailing_contacts_count', store=True,
+        compute_sudo=True)
     mass_mailing_stats = fields.One2many(
         string="Mass mailing stats",
         comodel_name='mail.mail.statistics', inverse_name='partner_id')
@@ -30,7 +31,7 @@ class ResPartner(models.Model):
     @api.constrains('email')
     def _check_email_mass_mailing_contacts(self):
         for partner in self:
-            if partner.mass_mailing_contact_ids and not partner.email:
+            if partner.sudo().mass_mailing_contact_ids and not partner.email:
                 raise ValidationError(
                     _("This partner '%s' is subscribed to one or more "
                       "mailing lists. Email must be assigned.") % partner.name)

--- a/mass_mailing_partner/views/res_partner_view.xml
+++ b/mass_mailing_partner/views/res_partner_view.xml
@@ -10,6 +10,7 @@
     <field name="name">Partner Form with mailing contacts</field>
     <field name="model">res.partner</field>
     <field name="inherit_id" ref="base.view_partner_form"/>
+    <field name="groups_id" eval="[(4, ref('mass_mailing.group_mass_mailing_user'))]"/>
     <field name="arch" type="xml">
         <div name="button_box" position="inside">
             <button name="%(mass_mailing.action_view_mass_mailing_contacts)d"
@@ -40,6 +41,7 @@
     <field name="name">Partner Search with mailing contacts</field>
     <field name="model">res.partner</field>
     <field name="inherit_id" ref="base.view_res_partner_filter"/>
+    <field name="groups_id" eval="[(4, ref('mass_mailing.group_mass_mailing_user'))]"/>
     <field name="priority">20</field>
     <field name="arch" type="xml">
         <field name="category_id" position="after">


### PR DESCRIPTION
- Oddo changed `mass_mailing_contact`permissions from Employee to Mass Mailing User.
- That raises exceptions for users not in that group in partner view whenever accessing views or methods in wich such field is implied.

cc @Tecnativa