### PR TITLE
[9.0][FIX] Mail tracking bugfixes

### DIFF
--- a/mail_tracking/__openerp__.py
+++ b/mail_tracking/__openerp__.py
@@ -5,7 +5,7 @@
 {
     "name": "Email tracking",
     "summary": "Email tracking system for all mails sent",
-    "version": "9.0.3.0.1",
+    "version": "9.0.3.0.2",
     "category": "Social Network",
     "website": "http://www.tecnativa.com",
     "author": "Tecnativa, "

--- a/mail_tracking/models/ir_mail_server.py
+++ b/mail_tracking/models/ir_mail_server.py
@@ -23,7 +23,7 @@ class IrMailServer(models.Model):
         tracking_email_id = False
         # https://regex101.com/r/lW4cB1/2
         match = re.search(
-            r'<img [^>]* data-odoo-tracking-email=["\']([0-9]*)["\']', body)
+            r'<img[^>]*data-odoo-tracking-email=["\']([0-9]*)["\']', body)
         if match:
             try:
                 tracking_email_id = int(match.group(1))

--- a/mail_tracking/models/mail_message.py
+++ b/mail_tracking/models/mail_message.py
@@ -38,7 +38,7 @@ class MailMessage(models.Model):
             partner_trackings = []
             partners_already = self.env['res.partner']
             partners = self.env['res.partner']
-            trackings = self.env['mail.tracking.email'].search([
+            trackings = self.env['mail.tracking.email'].sudo().search([
                 ('mail_message_id', '=', message.id),
             ])
             # Search all trackings for this message

--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -222,8 +222,12 @@ class MailTrackingEmail(models.Model):
         self.ensure_one()
         tracking_url = self._get_mail_tracking_img()
         if tracking_url:
+            content = email.get('body', '')
+            content = re.sub(
+                r'<img[^>]*data-odoo-tracking-email=["\'][0-9]*["\'][^>]*>',
+                '', content)
             body = tools.append_content_to_html(
-                email.get('body', ''), tracking_url, plaintext=False,
+                content, tracking_url, plaintext=False,
                 container_tag='div')
             email['body'] = body
         return email


### PR DESCRIPTION
This PR fix two bugs found in mail_tracking:
* When an email notification is an answer of another email notification (for example, in a invoice mail thread), then mail_tracking addon add several tracking email IDs in body. This fix assure that there is only one ID (and the last one).
* Support for multi-company. Mail tracking status of partners from other companies raise an access error exception. This fix get status as sudo.