### PR TITLE
[FIX] mail_optional_follower_notification: Check force_partners_to_notify instead of notify_followers.

### DIFF
--- a/mail_optional_follower_notification/__manifest__.py
+++ b/mail_optional_follower_notification/__manifest__.py
@@ -11,7 +11,7 @@
               'Odoo Community Association (OCA)',
     'website': "http://acsone.eu",
     'category': 'Social Network',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'license': 'AGPL-3',
     'depends': [
         'mail',

--- a/mail_optional_follower_notification/models/mail_message.py
+++ b/mail_optional_follower_notification/models/mail_message.py
@@ -24,7 +24,8 @@ class MailMessage(models.Model):
         res = super(MailMessage, self)._notify(
             force_send=force_send, send_after_commit=send_after_commit,
             user_signature=user_signature)
-        if not self.env.context.get('notify_followers'):
+        if self.env.context.get('force_partners_to_notify'):
             # Needaction only for recipients
-            self.needaction_partner_ids = [(6, 0, self.partner_ids.ids)]
+            self.needaction_partner_ids = [
+                (6, 0, self.env.context.get('force_partners_to_notify'))]
         return res


### PR DESCRIPTION
Without this commit, followers are NEVER notified when a message is directly posted on the tracker (without click to open the mail compose message form).

My bad ... 