### PR TITLE
[FIX] mail_debrand: name of overridden method

### DIFF
--- a/mail_debrand/__openerp__.py
+++ b/mail_debrand/__openerp__.py
@@ -4,7 +4,7 @@
 {
     "name": "Mail Debrand",
     "summary": "Remove Odoo branding from email footers",
-    "version": "8.0.1.0.0",
+    "version": "8.0.1.0.1",
     "category": "Social Network",
     "website": "http://www.antiun.com",
     "author": "Antiun Ingeniería S.L., Odoo Community Association (OCA)",

--- a/mail_debrand/models/mail.py
+++ b/mail_debrand/models/mail.py
@@ -9,8 +9,8 @@ class MailNotification(models.Model):
     _inherit = "mail.notification"
 
     @api.model
-    def _get_signature_footer(self, user_id, res_model=None, res_id=None,
-                              user_signature=True):
+    def get_signature_footer(self, user_id, res_model=None, res_id=None,
+                             user_signature=True):
         """Generate signature footer only with the chosen parts.
 
         Now, you can set ``skip_signature_user=True`` in the context to remove

--- a/mail_debrand/tests/test_mail.py
+++ b/mail_debrand/tests/test_mail.py
@@ -15,7 +15,7 @@ class SignatureCase(TransactionCase):
     def signature(self, **context):
         """Get user's signature."""
         return (self.mail_notification.with_context(**context)
-                ._get_signature_footer(self.user.id))
+                .get_signature_footer(self.user.id))
 
     def test_signature_user_custom(self):
         """User name does not appear in signature when it is custom."""


### PR DESCRIPTION
As per https://github.com/odoo/odoo/blob/8.0/addons/mail/mail_followers.py#L138.

@Yajo, this one is a bit of a mystery. I could not find any trace of this method name with the preceding underscore.