### PR TITLE
FIX mail_footer_notified_partner

### DIFF
--- a/mail_footer_notified_partner/__manifest__.py
+++ b/mail_footer_notified_partner/__manifest__.py
@@ -11,7 +11,7 @@
     "installable": True,
     "website": "http://acsone.eu",
     "category": "Mail",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "license": "AGPL-3",
     "depends": [
         "mail",


### PR DESCRIPTION
 we need to save the complete list of partners because
 _message_notification_recipients builds recipients
 grouped by users groups. Thus get_additional_footer would get a
 partial list of recipients