### PR TITLE
[FIX] mass_mailing_partner: Allow unprivileged users to edit partners

### DIFF
--- a/mass_mailing_partner/__manifest__.py
+++ b/mass_mailing_partner/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Link partners with mass-mailing",
-    "version": "10.0.1.0.1",
+    "version": "10.0.1.0.2",
     "author": "Tecnativa, "
               "Odoo Community Association (OCA)",
     "website": "https://www.tecnativa.com",

--- a/mass_mailing_partner/models/res_partner.py
+++ b/mass_mailing_partner/models/res_partner.py
@@ -56,7 +56,8 @@ class ResPartner(models.Model):
                 mm_vals['name'] = vals['name']
             if vals.get('email'):
                 mm_vals['name'] = vals['email']
-            self.env["mail.mass_mailing.contact"].search([
+            # Using sudo because ACLs shouldn't produce data inconsistency
+            self.env["mail.mass_mailing.contact"].sudo().search([
                 ("partner_id", "in", self.ids),
             ]).write(mm_vals)
         return res

--- a/mass_mailing_partner/tests/test_res_partner.py
+++ b/mass_mailing_partner/tests/test_res_partner.py
@@ -18,9 +18,21 @@ class ResPartnerCase(base.BaseCase):
         self.assertEqual(self.partner.mass_mailing_contacts_count, 2)
 
     def test_write_res_partner(self):
+        user = self.env['res.users'].create({
+            'login': 'test',
+            'name': 'test',
+            'email': 'test@example.org',
+            'groups_id': [
+                (4, self.env.ref('base.group_user').id),
+                (4, self.env.ref('base.group_partner_manager').id),
+            ]
+        })
         contact = self.create_mailing_contact(
             {'email': 'partner@test.com', 'list_id': self.mailing_list.id})
-        self.partner.write({'name': 'Changed', 'email': 'partner@changed.com'})
+        self.partner.sudo(user).write({
+            'name': 'Changed',
+            'email': 'partner@changed.com',
+        })
         self.assertEqual(contact.name, self.partner.name)
         self.assertEqual(contact.email, self.partner.email)
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
Without this patch, users without access to reading and editing mass mailing contact records are now unable to change a partner's name or email. They'd recieve an exception such as:

    AccessError: Sorry, you are not allowed to access this document. Only users with the following access level are currently allowed to do that:
    - Mass Mailing/User

    (Document model: mail.mass_mailing.contact)

Restrictive ACLs shouldn't restrict normal user operation nor DB consistency, so using sudo mode now and testing behavior.

@Tecnativa