### PR TITLE
[9.0] [FIX] Mail Optional Follower Notification: fix needaction

### DIFF
--- a/mail_optional_follower_notification/README.rst
+++ b/mail_optional_follower_notification/README.rst
@@ -27,8 +27,6 @@ This field it's initialized to true to keep the standard behavior.
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/205/9.0
 
- * https://www.odoo.com/forum/help-1
-
 
 Bug Tracker
 ===========

--- a/mail_optional_follower_notification/models/mail_message.py
+++ b/mail_optional_follower_notification/models/mail_message.py
@@ -17,3 +17,13 @@ class MailMessage(models.Model):
             force_partners_to_notify = [d['id'] for d in partner_list]
             ctx['force_partners_to_notify'] = force_partners_to_notify
         return super(MailMessage, self.with_context(ctx)).create(values)
+
+    @api.multi
+    def _notify(self, force_send=False, user_signature=True):
+        res = super(MailMessage, self)._notify(
+            force_send=force_send, user_signature=user_signature)
+        if self.env.context.get('force_partners_to_notify'):
+            # Needaction only for recipients
+            self.needaction_partner_ids = [
+                (6, 0, self.env.context.get('force_partners_to_notify'))]
+        return res


### PR DESCRIPTION
When unchecking followers, they were notified anyway because added to needaction partners. This bug was fixed in 10.0.

------------------------------------

From 1665bc95ec47a3cf1caa0171e1daf8da18151112 and b67bf4eaa3be0f8d041ddd8d8f8ca43718731f6e