### PR TITLE
[FIX] mail_tracking_mailgun: manual sync gets events from other recipients

### DIFF
--- a/mail_tracking_mailgun/__openerp__.py
+++ b/mail_tracking_mailgun/__openerp__.py
@@ -7,7 +7,7 @@
 {
     "name": "Mail tracking for Mailgun",
     "summary": "Mail tracking and Mailgun webhooks integration",
-    "version": "9.0.1.1.0",
+    "version": "9.0.1.2.0",
     "category": "Social Network",
     "website": "https://odoo-community.org/",
     "author": "Tecnativa, "

--- a/mail_tracking_mailgun/tests/test_mailgun.py
+++ b/mail_tracking_mailgun/tests/test_mailgun.py
@@ -78,7 +78,8 @@ class TestMailgun(TransactionCase):
                         "subject": "This is a test"
                     },
                 },
-                "event": "delivered"
+                "event": "delivered",
+                "recipient": "to@example.com",
             }]
         }
 


### PR DESCRIPTION
- The manual check can return events belonging to several recipients so they could be syncronized to a tracking not belonging to them.

cc @Tecnativa