### PR TITLE
[FIX] mail_tracking_mailgun: manual sync gets events from other recipients

### DIFF
--- a/mail_tracking_mailgun/README.rst
+++ b/mail_tracking_mailgun/README.rst
@@ -40,6 +40,10 @@ parameters:
   validity you must config this parameter with your account Public Validation
   Key.
 
+You can also config partner email autocheck with this system parameter:
+
+- `mailgun.auto_check_partner_email`: Set it to True.
+
 Usage
 =====
 

--- a/mail_tracking_mailgun/__manifest__.py
+++ b/mail_tracking_mailgun/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Mail tracking for Mailgun",
     "summary": "Mail tracking and Mailgun webhooks integration",
-    "version": "10.0.1.1.2",
+    "version": "10.0.1.1.3",
     "category": "Social Network",
     "website": "https://odoo-community.org/",
     "author": "Tecnativa, "

--- a/mail_tracking_mailgun/models/mail_tracking_email.py
+++ b/mail_tracking_mailgun/models/mail_tracking_email.py
@@ -10,6 +10,7 @@ import requests
 from datetime import datetime
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools import email_split
 
 import logging
 _logger = logging.getLogger(__name__)
@@ -242,9 +243,70 @@ class MailTrackingEmail(models.Model):
                 raise ValidationError(_("Event information not longer stored"))
             for item in content["items"]:
                 if not self.env['mail.tracking.event'].search(
-                        [('mailgun_id', '=', item["id"])]):
+                # mailgun event hasn't been synced and recipient is the same as
+                # in the evaluated tracking. We use email_split since tracking
+                # recipient could come in format: "example" <to@dest.com>
+                        [('mailgun_id', '=', item["id"])]) and (
+                            item.get("recipient", "") ==
+                            email_split(tracking.recipient)[0]):
                     mapped_event_type = self._mailgun_event_type_mapping.get(
                         item["event"], item["event"])
                     metadata = self._mailgun_metadata(
                         mapped_event_type, item, {})
                     tracking.event_create(mapped_event_type, metadata)
+
+    @api.multi
+    def check_email_list_validity(self, email_list):
+        """
+        Checks email list validity with Mailgun's API
+        API documentation:
+        https://documentation.mailgun.com/en/latest/api-email-validation.html
+        """
+        api_key, api_url, domain, validation_key = self.env[
+            'mail.tracking.email']._mailgun_values()
+        if not validation_key:
+            raise UserError(_('You need to configure mailgun.validation_key'
+                              ' in order to be able to check mails validity'))
+        result = {}
+        for email in email_list:
+            res = requests.get(
+                "%s/address/validate" % api_url,
+                auth=("api", validation_key), params={
+                    "address": email,
+                    "mailbox_verification": True,
+                })
+            if not res or res.status_code != 200:
+                result[email] = {'result': (_(
+                    'Error %s trying to '
+                    'check mail' % res.status_code or 'of connection'))}
+                continue
+            content = json.loads(res.content, res.apparent_encoding)
+            if 'mailbox_verification' not in content:
+                result[email] = {'result': (
+                    _("Mailgun Error. Mailbox verification value wasn't"
+                      " returned"))}
+                continue
+            # Not a valid address: API sets 'is_valid' as False
+            # and 'mailbox_verification' as None
+            if not content['is_valid']:
+                result[email] = {'result': (
+                    _('%s is not a valid email address. Please check it '
+                      'in order to avoid sending issues') % (email))}
+                continue
+            # If the mailbox is not valid API returns 'mailbox_verification'
+            # as a string with value 'false'
+            if content['mailbox_verification'] == 'false':
+                result[email] = {'result': (
+                    _('%s failed the mailbox verification. Please check it '
+                      'in order to avoid sending issues') % (email))}
+                continue
+            # If Mailgun can't complete the validation request the API returns
+            # 'mailbox_verification' as a string set to 'unknown'
+            if content['mailbox_verification'] == 'unknown':
+                result[email] = {'result': (
+                    _("%s couldn't be verified. Either the request couln't be "
+                      "completed or the mailbox provider doesn't support "
+                      "email verification") % (email))}
+                continue
+            result[email] = {'result': _("The mailbox is correct")}
+        return result

--- a/mail_tracking_mailgun/models/mail_tracking_event.py
+++ b/mail_tracking_mailgun/models/mail_tracking_event.py
@@ -2,7 +2,7 @@
 # Copyright 2017 Tecnativa - David Vidal
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp import models, fields
+from odoo import models, fields
 
 
 class MailTrackingEvent(models.Model):

--- a/mail_tracking_mailgun/tests/test_mailgun.py
+++ b/mail_tracking_mailgun/tests/test_mailgun.py
@@ -43,6 +43,8 @@ class TestMailgun(TransactionCase):
             'mail.catchall.domain', self.domain)
         self.env['ir.config_parameter'].set_param(
             'mailgun.validation_key', self.api_key)
+        self.env['ir.config_parameter'].set_param(
+            'mailgun.auto_check_partner_email', '')
         self.event = {
             'Message-Id': u'<xxx.xxx.xxx-openerp-xxx-res.partner@test_db>',
             'X-Mailgun-Sid': u'WyIwNjgxZSIsICJ0b0BleGFtcGxlLmNvbSIsICI3MG'
@@ -332,14 +334,16 @@ class TestMailgun(TransactionCase):
     @mock.patch(_packagepath + '.models.res_partner.requests')
     def test_email_validity(self, mock_request):
         self.partner.email_bounced = False
-        self.partner.email = 'info@tecnativa.com'
         mock_request.get.return_value.apparent_encoding = 'ascii'
         mock_request.get.return_value.status_code = 200
         mock_request.get.return_value.content = json.dumps({
             'is_valid': True,
             'mailbox_verification': 'true',
         }, ensure_ascii=True)
-        self.partner.check_email_validity()
+        # Trigger email auto validation in partner
+        self.env['ir.config_parameter'].set_param(
+            'mailgun.auto_check_partner_email', 'True')
+        self.partner.email = 'info@tecnativa.com'
         self.assertFalse(self.partner.email_bounced)
         self.partner.email = 'xoxoxoxo@tecnativa.com'
         # Not a valid mailbox

--- a/mail_tracking_mailgun/tests/test_mailgun.py
+++ b/mail_tracking_mailgun/tests/test_mailgun.py
@@ -79,7 +79,8 @@ class TestMailgun(TransactionCase):
                         "subject": "This is a test"
                     },
                 },
-                "event": "delivered"
+                "event": "delivered",
+                "recipient": "to@example.com",
             }]
         }
 


### PR DESCRIPTION
- The manual check can return events belonging to several recipients so they could be syncronized to a tracking not belonging to them.

cc @Tecnativa