### PR TITLE
[10.0] IMP mail_tracking performances

### DIFF
--- a/mail_tracking/__manifest__.py
+++ b/mail_tracking/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Email tracking",
     "summary": "Email tracking system for all mails sent",
-    "version": "10.0.1.0.1",
+    "version": "10.0.1.1.0",
     "category": "Social Network",
     "website": "http://www.tecnativa.com",
     "author": "Tecnativa, "

--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -39,7 +39,8 @@ class MailTrackingEmail(models.Model):
     date = fields.Date(
         string="Date", readonly=True, compute="_compute_date", store=True)
     mail_message_id = fields.Many2one(
-        string="Message", comodel_name='mail.message', readonly=True)
+        string="Message", comodel_name='mail.message', readonly=True,
+        index=True)
     mail_id = fields.Many2one(
         string="Email", comodel_name='mail.mail', readonly=True)
     partner_id = fields.Many2one(

--- a/mail_tracking/models/mail_tracking_event.py
+++ b/mail_tracking/models/mail_tracking_event.py
@@ -28,7 +28,7 @@ class MailTrackingEvent(models.Model):
         string="Date", readonly=True, compute="_compute_date", store=True)
     tracking_email_id = fields.Many2one(
         string='Message', readonly=True, required=True, ondelete='cascade',
-        comodel_name='mail.tracking.email')
+        comodel_name='mail.tracking.email', index=True)
     event_type = fields.Selection(string='Event type', selection=[
         ('sent', 'Sent'),
         ('delivered', 'Delivered'),


### PR DESCRIPTION
On our server,
queries based on "mail_tracking_event"."tracking_email_id" improved from ~500 ms to ~2 ms
queries based on "mail_tracking_email"."mail_message_id" improved from ~170 ms to ~3 ms

The last ones are run tens of times when a thread has many messages