### PR TITLE
[FIX] mass_mailing_list_dynamic: Reversible dynamic list

### DIFF
--- a/mass_mailing_list_dynamic/README.rst
+++ b/mass_mailing_list_dynamic/README.rst
@@ -21,6 +21,7 @@ To create a dynamic mailing list, you need to:
 #. Go to *Mass Mailing > Mailings > Mailing Lists* and create one.
 #. Check the *Dynamic* box.
 #. Choose a *Sync method*:
+
    - Leave empty to use as a manual mailing list, the normal behavior.
    - *Only add new records* to make sure no records disappear from the list
      when partners stop matching the *Synchronization critera*.
@@ -46,9 +47,6 @@ Usage
    checked.
 #. Before sending the mass mailing, the list will be synced for having latest
    changes.
-
-Usage
-=====
 
 When you hit the *Sync now* button or send a mass mailing to this list, its
 contacts will be automatically updated.
@@ -90,6 +88,7 @@ Contributors
 * `Tecnativa <https://www.tecnativa.com>`_:
   * Jairo Llopis <jairo.llopis@tecnativa.com>
   * Pedro M. Baeza <pedro.baeza@tecnativa.com>
+  * David Vidal <david.vidal@tecnativa.com>
 
 Do not contact contributors directly about support or help with technical issues.
 

--- a/mass_mailing_list_dynamic/__manifest__.py
+++ b/mass_mailing_list_dynamic/__manifest__.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017 Tecnativa - Jairo Llopis
+# Copyright 2018 Tecnativa - David Vidal
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Dynamic Mass Mailing Lists",
     "summary": "Mass mailing lists that get autopopulated",
-    "version": "10.0.1.1.0",
+    "version": "10.0.1.1.1",
     "category": "Marketing",
     "website": "https://github.com/OCA/social",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/mass_mailing_list_dynamic/models/mail_mass_mailing_contact.py
+++ b/mass_mailing_list_dynamic/models/mail_mass_mailing_contact.py
@@ -13,7 +13,8 @@ class MassMailingContact(models.Model):
     def _check_no_manual_edits_on_fully_synced_lists(self):
         if self.env.context.get("syncing"):
             return
-        if any(one.list_id.sync_method == "full" for one in self):
+        if any((one.list_id.dynamic and
+                one.list_id.sync_method == "full") for one in self):
             raise ValidationError(
                 _("Cannot edit manually contacts in a fully "
                     "synchronized list. Change its sync method or execute "

--- a/mass_mailing_list_dynamic/tests/test_dynamic_lists.py
+++ b/mass_mailing_list_dynamic/tests/test_dynamic_lists.py
@@ -78,6 +78,15 @@ class DynamicListCase(common.SavepointCase):
             contact1.email = "other@example.com"
         with self.assertRaises(ValidationError):
             contact1.partner_id = self.partners[0]
+        # Unset dynamic list
+        self.list.dynamic = False
+        # Now the contact is created without exception
+        Contact.create({
+            "list_id": self.list.id,
+            "email": "test@example.com",
+        })
+        # Contacts can now be changed
+        contact1.name = "other"
 
     def test_sync_when_sending_mail(self):
         """Check that list in synced when sending a mass mailing."""


### PR DESCRIPTION
If you make a dynamic list and want to revert it to normal later, a exception is going to raise if full sync was set. This patch prevents it.

cc @Tecnativa