### PR TITLE
[IMP] mass_mailing_list_dynamic: make user aware of list change

### DIFF
--- a/mass_mailing_list_dynamic/__manifest__.py
+++ b/mass_mailing_list_dynamic/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Dynamic Mass Mailing Lists",
     "summary": "Mass mailing lists that get autopopulated",
-    "version": "10.0.1.1.1",
+    "version": "10.0.1.2.0",
     "category": "Marketing",
     "website": "https://github.com/OCA/social",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/mass_mailing_list_dynamic/models/mail_mass_mailing_list.py
+++ b/mass_mailing_list_dynamic/models/mail_mass_mailing_list.py
@@ -2,7 +2,7 @@
 # Copyright 2017 Tecnativa - Jairo Llopis
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 from odoo.tools import safe_eval
 
 
@@ -28,6 +28,10 @@ class MassMailingList(models.Model):
         default="[('opt_out', '=', False), ('email', '!=', False)]",
         required=True,
         help="Filter partners to sync in this list",
+    )
+    is_synced = fields.Boolean(
+        help="Helper field to make the user aware of unsynced changes",
+        default=True,
     )
 
     def action_sync(self):
@@ -55,5 +59,11 @@ class MassMailingList(models.Model):
                     "list_id": one.id,
                     "partner_id": partner.id,
                 })
+            one.is_synced = True
         # Invalidate cached contact count
         self.invalidate_cache(["contact_nbr"], dynamic.ids)
+
+    @api.onchange("dynamic", "sync_method", "sync_domain")
+    def _onchange_dynamic(self):
+        if self.dynamic:
+            self.is_synced = False

--- a/mass_mailing_list_dynamic/tests/test_dynamic_lists.py
+++ b/mass_mailing_list_dynamic/tests/test_dynamic_lists.py
@@ -126,3 +126,14 @@ class DynamicListCase(common.SavepointCase):
         self.partners[:1].write({
             'email': 'test_mass_mailing_list_dynamic@example.org',
         })
+
+    def test_is_synced(self):
+        self.list.dynamic = False
+        self.list._onchange_dynamic()
+        # It shouldn't change when list is reversed to normal
+        self.assertTrue(self.list.is_synced)
+        self.list.dynamic = True
+        self.list._onchange_dynamic()
+        self.assertFalse(self.list.is_synced)
+        self.list.action_sync()
+        self.assertTrue(self.list.is_synced)

--- a/mass_mailing_list_dynamic/views/mail_mass_mailing_list_view.xml
+++ b/mass_mailing_list_dynamic/views/mail_mass_mailing_list_view.xml
@@ -15,6 +15,7 @@
                         <field
                             name="dynamic"
                         />
+                        <field name="is_synced" invisible="1"/>
                     </group>
                     <group attrs="{'invisible': [('dynamic', '=', False)]}">
                         <label for="sync_method"/>
@@ -26,7 +27,16 @@
                                 name="action_sync"
                                 type="object"
                                 string="Sync now"
+                                icon="fa-exclamation-triangle"
+                                class="btn-danger"
+                                attrs="{'invisible': [('is_synced', '=', True)]}"
+                            />
+                            <button
+                                name="action_sync"
+                                type="object"
+                                string="Sync now"
                                 icon="fa-refresh"
+                                attrs="{'invisible': [('is_synced', '=', False)]}"
                             />
                         </div>
                     </group>
@@ -61,6 +71,16 @@
                     />
                 </group>
             </xpath>
+            <field name="contact_nbr" position="attributes">
+                <attribute name="attrs">
+                    {'invisible': [('is_synced', '=', False)]}
+                </attribute>
+            </field>
+            <field name="contact_nbr" position="after">
+                <span attrs="{'invisible': [('is_synced', '=', True)]}">
+                    <strong>???</strong>
+                </span>
+            </field>
         </field>
     </record>
 

--- a/mass_mailing_list_dynamic/wizards/mail_mass_mailing_load_filter.py
+++ b/mass_mailing_list_dynamic/wizards/mail_mass_mailing_load_filter.py
@@ -12,7 +12,9 @@ class MassMailingLoadFilter(models.TransientModel):
         comodel_name='ir.filters',
         string="Filter to load",
         required=True,
-        domain=[('model_id', '=', 'res.partner')],
+        domain="[('model_id', '=', 'res.partner'), '|', "
+               "('user_id', '=', uid), ('user_id','=',False)]",
+        ondelete='cascade',
     )
 
     def load_filter(self):


### PR DESCRIPTION
- Adds is_synced field to track whether a dynamic list has unsynced
changes or not so the user is aware that the definitive number of
contacts is yet to be determined.
- It fixes an issue that made impossible deleting a res.partner filter
when a list had use it to filter contacts.
- It also shows only the filters available for the user (shared and
belonging to self).

cc @Tecnativa