### PR TITLE
FIX mail_notify_bounce: TypeError: decoding Unicode is not supported

### DIFF
--- a/mail_notify_bounce/__manifest__.py
+++ b/mail_notify_bounce/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Notify bounce emails",
     "summary": "Notify bounce emails to preconfigured addresses",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "Mail",
     "website": "https://github.com/OCA/social",
     "author": "Agile Business Group, Odoo Community Association (OCA)",

--- a/mail_notify_bounce/models/mail_thread.py
+++ b/mail_notify_bounce/models/mail_thread.py
@@ -59,7 +59,7 @@ class MailThread(models.AbstractModel):
                 'body_html': (
                     u"%s<br/><br/><br/>%s<br/><br/>%s"
                     % (
-                        unicode(message_dict['body'], errors='replace'),
+                        message_dict['body'],
                         _("Raw message:"),
                         unicode(message.__str__(), errors='replace').replace(
                             "\n", "<br/>")


### PR DESCRIPTION
as message_dict['body'] is unicode yet