### PR TITLE
[IMP] Apply follower domain on automatically added followers

### DIFF
--- a/mail_restrict_follower_selection/README.rst
+++ b/mail_restrict_follower_selection/README.rst
@@ -7,6 +7,8 @@ Restrict follower selection
 
 This module was written to allow you to restrict the selection of possible followers. For example, if you use the social ERP functions only internally, it makes sense to filter possible followers for being employees. Otherwise, you'll get a quite crowded list of partners to choose from.
 
+Moreover, the module disables the option to automatically add followers that do not meet the domain.
+
 Configuration
 =============
 
@@ -21,7 +23,7 @@ Usage
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/205/10.0
+   :target: https://runbot.odoo-community.org/runbot/205/11.0
 
 For further information, please visit:
 
@@ -43,6 +45,7 @@ Contributors
 
 * Holger Brunn <hbrunn@therp.nl>
 * Nguyen Tan Phuc <phuc.nt@komit-consulting.com>
+* Enric Tobella <etobella@creublanca.es>
 
 Maintainer
 ----------

--- a/mail_restrict_follower_selection/__manifest__.py
+++ b/mail_restrict_follower_selection/__manifest__.py
@@ -4,8 +4,8 @@
 
 {
     "name": "Restrict follower selection",
-    "version": "11.0.1.0.0",
-    "author": "Therp BV,Odoo Community Association (OCA)",
+    "version": "11.0.2.0.0",
+    "author": "Therp BV,Creu Blanca,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Social Network",
     "summary": "Define a domain from which followers can be selected",

--- a/mail_restrict_follower_selection/models/__init__.py
+++ b/mail_restrict_follower_selection/models/__init__.py
@@ -2,4 +2,5 @@
 # Copyright (C) 2017 Komit <http://www.komit-consulting.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from . import mail_followers
 from . import mail_wizard_invite

--- a/mail_restrict_follower_selection/models/mail_followers.py
+++ b/mail_restrict_follower_selection/models/mail_followers.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2018 Creu Blanca
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+from odoo.tools.safe_eval import safe_eval
+
+
+class MailFollowers(models.Model):
+    _inherit = 'mail.followers'
+
+    @api.model
+    def _add_follower_command(self, res_model, res_ids, partner_data,
+                              channel_data, force=True):
+        domain = self.env[
+            'mail.wizard.invite'
+        ]._mail_restrict_follower_selection_get_domain()
+        partners = self.env['res.partner'].search(
+            [('id', 'in', list(partner_data))] +
+            safe_eval(domain)
+        )
+        return super()._add_follower_command(
+            res_model, res_ids,
+            {p.id: partner_data[p.id] for p in partners},
+            channel_data, force=force)

--- a/mail_restrict_follower_selection/models/mail_wizard_invite.py
+++ b/mail_restrict_follower_selection/models/mail_wizard_invite.py
@@ -12,10 +12,10 @@ class MailWizardInvite(models.TransientModel):
     @api.model
     def _mail_restrict_follower_selection_get_domain(self):
         parameter_name = 'mail_restrict_follower_selection.domain'
-        return self.env['ir.config_parameter'].get_param(
+        return self.env['ir.config_parameter'].sudo().get_param(
             "{0}.{1}".format(parameter_name,
                              self.env.context.get('default_res_model')),
-            self.env['ir.config_parameter'].get_param(
+            self.env['ir.config_parameter'].sudo().get_param(
                 parameter_name, default='[]')
         )
 

--- a/mail_restrict_follower_selection/tests/test_mail_restrict_follower_selection.py
+++ b/mail_restrict_follower_selection/tests/test_mail_restrict_follower_selection.py
@@ -3,10 +3,18 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from lxml import etree
-from openerp.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase
 
 
 class TestMailRestrictFollowerSelection(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.partner = self.env['res.partner'].create({
+            'name': 'Partner',
+            'customer': True,
+            'email': 'test@test.com',
+        })
 
     def test_fields_view_get(self):
         result = self.env['mail.wizard.invite'].fields_view_get(
@@ -14,3 +22,36 @@ class TestMailRestrictFollowerSelection(TransactionCase):
         for field in etree.fromstring(result['arch']).xpath(
                 '//field[@name="partner_ids"]'):
             self.assertTrue(field.get('domain'))
+
+    def send_action(self):
+        compose = self.env['mail.compose.message'].with_context({
+            'mail_post_autofollow': True,
+            'default_composition_mode': 'comment',
+            'default_model': 'res.partner',
+            'default_use_active_domain': True,
+        }).create({
+            'subject': 'From Composer Test',
+            'body': '${object.description}',
+            'res_id': self.partner.id,
+            'partner_ids': [(4, id) for id in self.partner.ids],
+        })
+        self.assertEqual(compose.partner_ids, self.partner)
+        compose.send_mail_action()
+
+    def test_followers_meet(self):
+        self.partner.write({'customer': True})
+        self.assertTrue(self.partner.customer)
+        self.send_action()
+        self.assertIn(
+            self.partner,
+            self.partner.message_follower_ids.mapped('partner_id')
+        )
+
+    def test_followers_not_meet(self):
+        self.partner.write({'customer': False})
+        self.assertFalse(self.partner.customer)
+        self.send_action()
+        self.assertNotIn(
+            self.partner,
+            self.partner.message_follower_ids.mapped('partner_id')
+        )


### PR DESCRIPTION
Sometimes, followers are added automatically, but the domain is not applied.

For example, if your domain is [('customer', '=', True)], and you take a partner with customer == False and send a message including the partner email, this partner will be added as follower, but it shouldn't.

This PR solves this issue.