### PR TITLE
[FIX] mail_tracking_mass_mailing: Integration tests

### DIFF
--- a/mail_tracking_mass_mailing/__manifest__.py
+++ b/mail_tracking_mass_mailing/__manifest__.py
@@ -7,9 +7,9 @@
 {
     "name": "Mail tracking for mass mailing",
     "summary": "Improve mass mailing email tracking",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "Social Network",
-    "website": "http://www.tecnativa.com",
+    "website": "https://github.com/OCA/social",
     "author": "Tecnativa, "
               "Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/mail_tracking_mass_mailing/tests/test_mass_mailing.py
+++ b/mail_tracking_mass_mailing/tests/test_mass_mailing.py
@@ -6,12 +6,14 @@
 
 import mock
 from odoo.tools import mute_logger
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import at_install, post_install, TransactionCase
 
 mock_send_email = ('odoo.addons.base.ir.ir_mail_server.'
                    'IrMailServer.send_email')
 
 
+@at_install(False)
+@post_install(True)
 class TestMassMailing(TransactionCase):
     def setUp(self, *args, **kwargs):
         super(TestMassMailing, self).setUp(*args, **kwargs)


### PR DESCRIPTION
Testing this addon failed if i.e. `mass_mailing_list_dynamic` was installed before.

Moving tests to post-install mode fixes integration tests.

@Tecnativa