### PR TITLE
[FIX] mail_tracking_mailgun: json.load() won't swallow bytes

### DIFF
--- a/mail_tracking_mailgun/__manifest__.py
+++ b/mail_tracking_mailgun/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Mail tracking for Mailgun",
     "summary": "Mail tracking and Mailgun webhooks integration",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "category": "Social Network",
     "website": "https://github.com/OCA/social",
     "author": "Tecnativa, "

--- a/mail_tracking_mailgun/models/mail_tracking_email.py
+++ b/mail_tracking_mailgun/models/mail_tracking_email.py
@@ -5,7 +5,6 @@
 
 import hashlib
 import hmac
-import json
 import requests
 from datetime import datetime
 from odoo import _, api, fields, models
@@ -115,7 +114,7 @@ class MailTrackingEmail(models.Model):
         ts = event.get('timestamp', False)
         try:
             ts = float(ts)
-        except:
+        except Exception:
             ts = False
         if ts:
             dt = datetime.utcfromtimestamp(ts)
@@ -238,7 +237,8 @@ class MailTrackingEmail(models.Model):
             if not res or res.status_code != 200:
                 raise ValidationError(_(
                     "Couldn't retrieve Mailgun information"))
-            content = json.loads(res.content)
+            # content = json.loads(res.content)
+            content = res.json()
             if "items" not in content:
                 raise ValidationError(_("Event information not longer stored"))
             for item in content["items"]:

--- a/mail_tracking_mailgun/models/mail_tracking_email.py
+++ b/mail_tracking_mailgun/models/mail_tracking_email.py
@@ -237,7 +237,6 @@ class MailTrackingEmail(models.Model):
             if not res or res.status_code != 200:
                 raise ValidationError(_(
                     "Couldn't retrieve Mailgun information"))
-            # content = json.loads(res.content)
             content = res.json()
             if "items" not in content:
                 raise ValidationError(_("Event information not longer stored"))

--- a/mail_tracking_mailgun/models/res_partner.py
+++ b/mail_tracking_mailgun/models/res_partner.py
@@ -6,7 +6,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import requests
-import json
 
 from odoo import _, api, models
 from odoo.exceptions import UserError
@@ -57,7 +56,7 @@ class ResPartner(models.Model):
                 raise UserError(_(
                     'Error %s trying to '
                     'check mail' % res.status_code or 'of connection'))
-            content = json.loads(res.content)
+            content = res.json()
             if 'mailbox_verification' not in content:
                 if not self.env.context.get('mailgun_auto_check'):
                     raise UserError(


### PR DESCRIPTION
- json.load() in python under 3.6 doesn't support binary input.
- https://docs.python.org/3/whatsnew/3.6.html#json
- This way, we let requests to decode the response itself.

cc @Tecnativa