### PR TITLE
[FIX] mail_trackin_mailgun: partner form

### DIFF
--- a/mail_tracking_mailgun/__manifest__.py
+++ b/mail_tracking_mailgun/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Mail tracking for Mailgun",
     "summary": "Mail tracking and Mailgun webhooks integration",
-    "version": "11.0.1.0.1",
+    "version": "11.0.1.0.2",
     "category": "Social Network",
     "website": "https://github.com/OCA/social",
     "author": "Tecnativa, "

--- a/mail_tracking_mailgun/views/res_partner.xml
+++ b/mail_tracking_mailgun/views/res_partner.xml
@@ -13,14 +13,14 @@
             <field name="email_bounced" position="after">
                 <label for="check_email_bounced" string="Mailgun"
                        attrs="{'invisible': [('email', '=', False)]}"/>
-                <group col="3" name="mailgun_buttons" attrs="{'invisible': [('email', '=', False)]}">
+                <div name="mailgun_buttons" attrs="{'invisible': [('email', '=', False)]}">
                     <button name="check_email_bounced" type="object" string="Check Mailgun" class="oe_link"/>
                     <button name="check_email_validity" type="object" string="Check email validity" class="oe_link"/>
                     <button name="force_set_bounced" type="object" string="Set Bounced" class="oe_link"
                             attrs="{'invisible': [('email_bounced', '=', True)]}"/>
                     <button name="force_unset_bounced" type="object" string="Unset Bounced" class="oe_link"
                             attrs="{'invisible': [('email_bounced', '=', False)]}"/>
-                </group>
+                </div>
             </field>
         </field>
     </record>


### PR DESCRIPTION
- Some res.partner form fields were not properly render due to this
module inherited view.