### PR TITLE
[FIX] mass_mailing_partner: compute fields performance

### DIFF
--- a/mass_mailing_partner/__openerp__.py
+++ b/mass_mailing_partner/__openerp__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Link partners with mass-mailing",
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.0.1",
     "author": "Antiun Ingeniería S.L., "
               "Tecnativa, "
               "Odoo Community Association (OCA)",

--- a/mass_mailing_partner/models/res_partner.py
+++ b/mass_mailing_partner/models/res_partner.py
@@ -39,18 +39,25 @@ class ResPartner(models.Model):
     @api.depends('mass_mailing_contact_ids',
                  'mass_mailing_contact_ids.opt_out')
     def _compute_mass_mailing_contacts_count(self):
+        contact_data = self.env['mail.mass_mailing.contact'].read_group(
+            [('partner_id', 'in', self.ids)], ['partner_id'], ['partner_id'])
+        mapped_data = dict(
+            [(contact['partner_id'][0], contact['partner_id_count'])
+             for contact in contact_data])
         for partner in self:
-            partner.mass_mailing_contacts_count = len(
-                self.env['mail.mass_mailing.contact'].search_read(
-                    [('partner_id', '=', partner.id)], ['id']))
+            partner.mass_mailing_contacts_count = mapped_data.get(partner.id,
+                                                                  0)
 
     @api.multi
     @api.depends('mass_mailing_stats')
     def _compute_mass_mailing_stats_count(self):
+        contact_data = self.env['mail.mail.statistics'].read_group(
+            [('partner_id', 'in', self.ids)], ['partner_id'], ['partner_id'])
+        mapped_data = dict(
+            [(contact['partner_id'][0], contact['partner_id_count'])
+             for contact in contact_data])
         for partner in self:
-            partner.mass_mailing_stats_count = len(
-                self.env['mail.mail.statistics'].search_read(
-                    [('partner_id', '=', partner.id)], ['id']))
+            partner.mass_mailing_stats_count = mapped_data.get(partner.id, 0)
 
     @api.multi
     def write(self, vals):

--- a/mass_mailing_partner/models/res_partner.py
+++ b/mass_mailing_partner/models/res_partner.py
@@ -51,7 +51,6 @@ class ResPartner(models.Model):
             partner.mass_mailing_stats_count = len(
                 self.env['mail.mail.statistics'].search_read(
                     [('partner_id', '=', partner.id)], ['id']))
-        self.mass_mailing_stats_count = len(self.mass_mailing_stats)
 
     @api.multi
     def write(self, vals):

--- a/mass_mailing_partner/models/res_partner.py
+++ b/mass_mailing_partner/models/res_partner.py
@@ -35,15 +35,22 @@ class ResPartner(models.Model):
                 _("This partner '%s' is subscribed to one or more "
                   "mailing lists. Email must be assigned." % self.name))
 
-    @api.one
+    @api.multi
     @api.depends('mass_mailing_contact_ids',
                  'mass_mailing_contact_ids.opt_out')
     def _compute_mass_mailing_contacts_count(self):
-        self.mass_mailing_contacts_count = len(self.mass_mailing_contact_ids)
+        for partner in self:
+            partner.mass_mailing_contacts_count = len(
+                self.env['mail.mass_mailing.contact'].search_read(
+                    [('partner_id', '=', partner.id)], ['id']))
 
-    @api.one
+    @api.multi
     @api.depends('mass_mailing_stats')
     def _compute_mass_mailing_stats_count(self):
+        for partner in self:
+            partner.mass_mailing_stats_count = len(
+                self.env['mail.mail.statistics'].search_read(
+                    [('partner_id', '=', partner.id)], ['id']))
         self.mass_mailing_stats_count = len(self.mass_mailing_stats)
 
     @api.multi


### PR DESCRIPTION
- In DB which use large amounts of records and intesive use of
mass_mailings, not optimized compute records lead to a drastical
decrease of performance

cc @Tecnativa