### PR TITLE
[FIX] mass_mailing_event: Avoid double test

### DIFF
--- a/mass_mailing_event/tests/test_mass_mailing_event.py
+++ b/mass_mailing_event/tests/test_mass_mailing_event.py
@@ -6,7 +6,7 @@
 from odoo.tests.common import at_install, post_install, SavepointCase
 
 
-@at_install(True)
+@at_install(False)
 @post_install(True)
 class TestMassMailingEvent(SavepointCase):
 


### PR DESCRIPTION
Fix a typo introduced in #259 that didn't disable tests at install

@Tecnativa