### PR TITLE
[11.0][FIX] mail_tracking_mailgun: Read config parameters with sudo

### DIFF
--- a/mail_tracking_mailgun/__manifest__.py
+++ b/mail_tracking_mailgun/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Mail tracking for Mailgun",
     "summary": "Mail tracking and Mailgun webhooks integration",
-    "version": "11.0.1.0.2",
+    "version": "11.0.1.0.3",
     "category": "Social Network",
     "website": "https://github.com/OCA/social",
     "author": "Tecnativa, "

--- a/mail_tracking_mailgun/models/res_partner.py
+++ b/mail_tracking_mailgun/models/res_partner.py
@@ -147,13 +147,15 @@ class ResPartner(models.Model):
 
     @api.model
     def create(self, vals):
-        if 'email' in vals and self.env['ir.config_parameter'].get_param(
-                'mailgun.auto_check_partner_email'):
+        if ('email' in vals and
+                self.env['ir.config_parameter'].sudo().get_param(
+                    'mailgun.auto_check_partner_email')):
             self._autocheck_partner_email()
         return super(ResPartner, self).create(vals)
 
     def write(self, vals):
-        if 'email' in vals and self.env['ir.config_parameter'].get_param(
-                'mailgun.auto_check_partner_email'):
+        if ('email' in vals and
+                self.env['ir.config_parameter'].sudo().get_param(
+                    'mailgun.auto_check_partner_email')):
             self._autocheck_partner_email()
         return super(ResPartner, self).write(vals)


### PR DESCRIPTION
With this module a user without Administration/Settings group can not create or write a partner.
After merge cherrypick to v10.0