### PR TITLE
[FIX] do not use section titles in readme fragments

### DIFF
--- a/mass_mailing_custom_unsubscribe/readme/CONFIGURE.rst
+++ b/mass_mailing_custom_unsubscribe/readme/CONFIGURE.rst
@@ -1,6 +1,3 @@
-Unsubscription Reasons
-----------------------
-
 You can customize what reasons will be displayed to your unsubscriptors when
 they are going to unsubscribe. To do it:
 


### PR DESCRIPTION
This creates inconsistency issues when assembling them in the README.

cc/ @chienandalu 