### PR TITLE
[FIX] mail_tracking_mailgun: alternative domain

### DIFF
--- a/mail_tracking_mailgun/README.rst
+++ b/mail_tracking_mailgun/README.rst
@@ -36,6 +36,8 @@ parameters:
   domain.
 - `mailgun.api_url`: It should be fine as it is, but it could change in the
   future.
+- `mailgun.domain`: In case your sending domain is different from the one
+  configured in `mail.catchall.domain`.
 - `mailgun.validation_key`: If you want to be able to check mail address
   validity you must config this parameter with your account Public Validation
   Key.

--- a/mail_tracking_mailgun/__openerp__.py
+++ b/mail_tracking_mailgun/__openerp__.py
@@ -7,7 +7,7 @@
 {
     "name": "Mail tracking for Mailgun",
     "summary": "Mail tracking and Mailgun webhooks integration",
-    "version": "9.0.1.2.1",
+    "version": "9.0.1.3.0",
     "category": "Social Network",
     "website": "https://odoo-community.org/",
     "author": "Tecnativa, "

--- a/mail_tracking_mailgun/models/mail_tracking_email.py
+++ b/mail_tracking_mailgun/models/mail_tracking_email.py
@@ -71,7 +71,8 @@ class MailTrackingEmail(models.Model):
             raise ValidationError(_('There is no Mailgun API key!'))
         api_url = icp.get_param(
             'mailgun.api_url', 'https://api.mailgun.net/v3')
-        domain = icp.get_param('mail.catchall.domain')
+        catchall_domain = icp.get_param('mail.catchall.domain')
+        domain = icp.get_param('mailgun.domain', catchall_domain)
         if not domain:
             raise ValidationError(_('A Mailgun domain value is needed!'))
         validation_key = icp.get_param('mailgun.validation_key')

--- a/mail_tracking_mailgun/tests/test_mailgun.py
+++ b/mail_tracking_mailgun/tests/test_mailgun.py
@@ -102,6 +102,11 @@ class TestMailgun(TransactionCase):
         self.test_event_delivered()
         with self.assertRaises(ValidationError):
             self.env['mail.tracking.email']._mailgun_values()
+        # now we set an specific domain for Mailgun:
+        # i.e: we configure new EU zone without loosing old domain statistics
+        self.env['ir.config_parameter'].set_param(
+            'mailgun.domain', 'eu.example.com')
+        self.test_event_delivered()
 
     def test_bad_signature(self):
         self.event.update({
@@ -159,9 +164,10 @@ class TestMailgun(TransactionCase):
         response = self.env['mail.tracking.email'].event_process(
             None, self.event, self.metadata)
         self.assertEqual('OK', response)
-        event = self.event_search('delivered')
-        self.assertEqual(event.timestamp, float(self.timestamp))
-        self.assertEqual(event.recipient, self.recipient)
+        events = self.event_search('delivered')
+        for event in events:
+            self.assertEqual(event.timestamp, float(self.timestamp))
+            self.assertEqual(event.recipient, self.recipient)
 
     # https://documentation.mailgun.com/user_manual.html#tracking-opens
     def test_event_opened(self):


### PR DESCRIPTION
- In case the sending domain is different from the one configured in the
mail.domain.catchall setting.

cc @Tecnativa