### PR TITLE
[FIX] mail_tracking_mailgun: Validation API url

### DIFF
--- a/mail_tracking_mailgun/__openerp__.py
+++ b/mail_tracking_mailgun/__openerp__.py
@@ -7,7 +7,7 @@
 {
     "name": "Mail tracking for Mailgun",
     "summary": "Mail tracking and Mailgun webhooks integration",
-    "version": "9.0.1.3.0",
+    "version": "9.0.1.3.1",
     "category": "Social Network",
     "website": "https://odoo-community.org/",
     "author": "Tecnativa, "

--- a/mail_tracking_mailgun/models/res_partner.py
+++ b/mail_tracking_mailgun/models/res_partner.py
@@ -47,7 +47,8 @@ class ResPartner(models.Model):
                               ' in order to be able to check mails validity'))
         for partner in self:
             res = requests.get(
-                "%s/address/validate" % api_url,
+                # Validation API url is allways the same
+                'https://api.mailgun.net/v3/address/validate',
                 auth=("api", validation_key), params={
                     "address": partner.email,
                     "mailbox_verification": True,


### PR DESCRIPTION
- Besides Mailgun API url changes if the domain zone is in UE, it
remains the same for Validation API.

cc @Tecnativa