### PR TITLE
[FIX] mail_tracking_mailgun: permissions

### DIFF
--- a/mail_tracking_mailgun/__manifest__.py
+++ b/mail_tracking_mailgun/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Mail tracking for Mailgun",
     "summary": "Mail tracking and Mailgun webhooks integration",
-    "version": "11.0.1.1.1",
+    "version": "11.0.1.1.2",
     "category": "Social Network",
     "website": "https://github.com/OCA/social",
     "author": "Tecnativa, "

--- a/mail_tracking_mailgun/models/mail_tracking_email.py
+++ b/mail_tracking_mailgun/models/mail_tracking_email.py
@@ -64,7 +64,7 @@ class MailTrackingEmail(models.Model):
             digestmod=hashlib.sha256).hexdigest()
 
     def _mailgun_values(self):
-        icp = self.env['ir.config_parameter']
+        icp = self.env['ir.config_parameter'].sudo()
         api_key = icp.get_param('mailgun.apikey')
         if not api_key:
             raise ValidationError(_('There is no Mailgun API key!'))
@@ -79,7 +79,8 @@ class MailTrackingEmail(models.Model):
 
     def _mailgun_signature_verify(self, event):
         event = event or {}
-        api_key = self.env['ir.config_parameter'].get_param('mailgun.apikey')
+        icp = self.env['ir.config_parameter'].sudo()
+        api_key = icp.get_param('mailgun.apikey')
         if not api_key:
             _logger.warning("No Mailgun api key configured. "
                             "Please add 'mailgun.apikey' to System parameters "


### PR DESCRIPTION
- In v11 only admins can read from ir.config_parameter so a sudo() must
be made to be able to get a parameter.

cc @Tecnativa