### PR TITLE
[10.0][FIX] mail_sendgrid*. Use info loglevel for import error.

### DIFF
--- a/mail_sendgrid/models/mail_mail.py
+++ b/mail_sendgrid/models/mail_mail.py
@@ -19,7 +19,7 @@ try:
     from sendgrid.helpers.mail import Email, Attachment, CustomArg, Content, \
         Personalization, Substitution, Mail, Header
 except ImportError:
-    _logger.warning("ImportError raised while loading module.")
+    _logger.info("ImportError raised while loading module.")
     _logger.debug("ImportError details:", exc_info=True)
 
 

--- a/mail_sendgrid/models/sendgrid_template.py
+++ b/mail_sendgrid/models/sendgrid_template.py
@@ -15,7 +15,7 @@ _logger = logging.getLogger(__name__)
 try:
     import sendgrid
 except ImportError:
-    _logger.warning("ImportError raised while loading module.")
+    _logger.info("ImportError raised while loading module.")
     _logger.debug("ImportError details:", exc_info=True)
 
 

--- a/mail_sendgrid_mass_mailing/models/mail_mail.py
+++ b/mail_sendgrid_mass_mailing/models/mail_mail.py
@@ -9,7 +9,7 @@ _logger = logging.getLogger(__name__)
 try:
     from sendgrid.helpers.mail import TrackingSettings, SubscriptionTracking
 except ImportError:
-    _logger.warning("ImportError raised while loading module.")
+    _logger.info("ImportError raised while loading module.")
     _logger.debug("ImportError details:", exc_info=True)
 
 


### PR DESCRIPTION
Using _logger.warning for ImportError exception results in runbot/travis failures.

It is also more in line with how this is handled in other modules.

See also:
https://github.com/OCA/maintainer-tools/blob/master/CONTRIBUTING.md#importerror