### PR TITLE
[FIX] mass_mailing_partner: Fix and optimize batch writes

### DIFF
--- a/mass_mailing_partner/models/mail_mass_mailing_contact.py
+++ b/mass_mailing_partner/models/mail_mass_mailing_contact.py
@@ -64,7 +64,7 @@ class MailMassMailingContact(models.Model):
         m_mailing = self.env['mail.mass_mailing.list']
         m_partner = self.env['res.partner']
         list_id = vals.get('list_id', self.list_id.id)
-        mailing_list = m_mailing.browse(list_id, self._prefetch)
+        mailing_list = m_mailing.browse(list_id, prefetch=self._prefetch)
         # Look for a partner with that email
         email = email.strip()
         partner = m_partner.search([('email', '=ilike', email)], limit=1)

--- a/mass_mailing_partner/models/mail_mass_mailing_contact.py
+++ b/mass_mailing_partner/models/mail_mass_mailing_contact.py
@@ -34,12 +34,19 @@ class MailMassMailingContact(models.Model):
         return super(MailMassMailingContact, self).create(vals)
 
     def write(self, vals):
+        remaining = self
         for contact in self:
-            if vals.get('partner_id', None) is False:
-                # If removing partner, search again by email
-                vals = contact._set_partner(vals)
-            vals = contact._set_name_email(vals)
-        return super(MailMassMailingContact, self).write(vals)
+            _vals = vals.copy()
+            # If removing partner, search again by email
+            if _vals.get('partner_id') is False:
+                _vals = contact._set_partner(_vals)
+            _vals = contact._set_name_email(_vals)
+            # If changed, write it separately
+            if vals != _vals:
+                remaining -= contact
+                super(MailMassMailingContact, contact).write(_vals)
+        # Normal batch write for contacts that need no customization
+        return super(MailMassMailingContact, remaining).write(vals)
 
     def _prepare_partner(self, vals, mailing_list):
         vals = {
@@ -57,13 +64,13 @@ class MailMassMailingContact(models.Model):
         m_mailing = self.env['mail.mass_mailing.list']
         m_partner = self.env['res.partner']
         list_id = vals.get('list_id', self.list_id.id)
-        mailing_list = m_mailing.browse(list_id)
+        mailing_list = m_mailing.browse(list_id, self._prefetch)
         # Look for a partner with that email
         email = email.strip()
-        partners = m_partner.search([('email', '=ilike', email)], limit=1)
-        if partners:
-            # Partner found
-            vals['partner_id'] = partners[0].id
+        partner = m_partner.search([('email', '=ilike', email)], limit=1)
+        # Different partner found
+        if partner and partner != self.partner_id:
+            vals['partner_id'] = partner.id
         elif mailing_list.partner_mandatory:
             # Create partner
             partner = m_partner.sudo().create(
@@ -75,7 +82,9 @@ class MailMassMailingContact(models.Model):
         partner_id = vals.get('partner_id', self.partner_id.id)
         if not partner_id:
             return vals
-        partner = self.env['res.partner'].browse(partner_id)
-        vals['email'] = partner.email
-        vals['name'] = partner.name
+        partner = self.env['res.partner'].browse(partner_id, self._prefetch)
+        if vals.get("email", self.email) != partner.email:
+            vals['email'] = partner.email
+        if vals.get("name", self.name) != partner.name:
+            vals['name'] = partner.name
         return vals

--- a/mass_mailing_partner/models/mail_mass_mailing_contact.py
+++ b/mass_mailing_partner/models/mail_mass_mailing_contact.py
@@ -82,7 +82,8 @@ class MailMassMailingContact(models.Model):
         partner_id = vals.get('partner_id', self.partner_id.id)
         if not partner_id:
             return vals
-        partner = self.env['res.partner'].browse(partner_id, prefetch=self._prefetch)
+        partner = self.env['res.partner'].browse(
+            partner_id, prefetch=self._prefetch)
         if vals.get("email", self.email) != partner.email:
             vals['email'] = partner.email
         if vals.get("name", self.name) != partner.name:

--- a/mass_mailing_partner/models/mail_mass_mailing_contact.py
+++ b/mass_mailing_partner/models/mail_mass_mailing_contact.py
@@ -82,7 +82,7 @@ class MailMassMailingContact(models.Model):
         partner_id = vals.get('partner_id', self.partner_id.id)
         if not partner_id:
             return vals
-        partner = self.env['res.partner'].browse(partner_id, self._prefetch)
+        partner = self.env['res.partner'].browse(partner_id, prefetch=self._prefetch)
         if vals.get("email", self.email) != partner.email:
             vals['email'] = partner.email
         if vals.get("name", self.name) != partner.name:


### PR DESCRIPTION
Before this patch, all customizations done per contact in a batch write, except the last one, were ignored. It also was enforcing to write on some fields that were already fine, triggering their constraints unnecesarily, and causing unwanted side effects such as when combined with `mail_tracking_mass_mailing` and `mass_mailing_list_dynamic` in a fully synced list.

After this patch, customized writes are written one by one, and they only get the really needed customizations.

@Tecnativa