### PR TITLE
[FIX] mail_tracking: wrong bounced partner

### DIFF
--- a/mail_tracking/README.rst
+++ b/mail_tracking/README.rst
@@ -96,6 +96,7 @@ Contributors
   * Pedro M. Baeza <pedro.baeza@tecnativa.com>
   * Antonio Espinosa <antonio.espinosa@tecnativa.com>
   * David Vidal <david.vidal@tecnativa.com>
+  * Rafael Blasco <rafael.blasco@tecnativa.com>
 
 Maintainer
 ----------

--- a/mail_tracking/__manifest__.py
+++ b/mail_tracking/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Email tracking",
     "summary": "Email tracking system for all mails sent",
-    "version": "11.0.1.1.0",
+    "version": "11.0.1.2.0",
     "category": "Social Network",
     "website": "http://github.com/OCA/social",
     "author": "Tecnativa, "

--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -94,12 +94,16 @@ class MailTrackingEmail(models.Model):
 
     @api.model
     def email_is_bounced(self, email):
-        if email:
-            return self.search_count([
-                ('recipient_address', '=', email.lower()),
-                ('state', 'in', ('error', 'rejected', 'spam', 'bounced')),
-            ]) > 0
-        return False
+        if not email:
+            return False
+        res = self._email_last_tracking_state(email)
+        return res and res[0].get('state', '') in ['rejected', 'error',
+                                                   'spam', 'bounced']
+
+    @api.model
+    def _email_last_tracking_state(self, email):
+        return self.search_read([('recipient_address', '=', email.lower())],
+                                ['state'], limit=1, order='time DESC')
 
     @api.model
     def email_score_from_email(self, email):

--- a/mail_tracking/tests/__init__.py
+++ b/mail_tracking/tests/__init__.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016 Antonio Espinosa - <antonio.espinosa@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-# flake8: noqa
 
 from . import test_mail_tracking

--- a/mail_tracking/tests/test_mail_tracking.py
+++ b/mail_tracking/tests/test_mail_tracking.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016 Antonio Espinosa - <antonio.espinosa@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
@@ -50,10 +49,6 @@ class TestMailTracking(TransactionCase):
         http.request = self.last_request
         return super(TestMailTracking, self).tearDown(*args, **kwargs)
 
-    def test_email_lower(self):
-        self.recipient.write({'email': 'UPPER@example.com'})
-        self.assertEqual('upper@example.com', self.recipient.email)
-
     def test_empty_email(self):
         self.recipient.write({'email_bounced': True})
         self.recipient.write({'email': False})
@@ -61,7 +56,6 @@ class TestMailTracking(TransactionCase):
         self.assertEqual(False, self.recipient.email_bounced)
         self.recipient.write({'email_bounced': True})
         self.recipient.write({'email': ''})
-        self.assertEqual(False, self.recipient.email)
         self.assertEqual(False, self.recipient.email_bounced)
         self.assertEqual(
             False,
@@ -302,6 +296,15 @@ class TestMailTracking(TransactionCase):
             tracking.event_create('hard_bounce', {})
             self.assertEqual('bounced', tracking.state)
         self.assertEqual(0.0, self.recipient.email_score)
+
+    def test_bounce_new_partner(self):
+        mail, tracking = self.mail_send(self.recipient.email)
+        tracking.event_create('hard_bounce', {})
+        new_partner = self.env['res.partner'].create({
+            'name': 'Test New Partner',
+        })
+        new_partner.email = self.recipient.email
+        self.assertTrue(new_partner.email_bounced)
 
     def test_recordset_email_score(self):
         """For backwords compatibility sake"""


### PR DESCRIPTION
- Partner get bounced when his associated email is in a hard bounced
tracking. It didn't matter if the hard bounce event was solved in that
recipient later and leaded to an increasing number of false positives.
- We also use the email_bounced_set() method to get the whole bounce
info in case positive.

cc @Tecnativa