### PR TITLE
[IMP] Improve xpath selector and formatting for new mail templates

### DIFF
--- a/mail_debrand/views/mail_notification_view.xml
+++ b/mail_debrand/views/mail_notification_view.xml
@@ -15,15 +15,21 @@
 
     <!-- Replaces Powered By on these notifications -->
     <template id="mail_notification_borders" inherit_id="mail.mail_notification_borders" priority="99">
-        <xpath expr="//tr[last()]" position="replace" />
+        <xpath expr="//td[text()[contains(., 'Powered by')]]" position="replace" >
+            <td align="center" style="padding: 8px; font-size:11px;" />
+        </xpath>
     </template>
 
     <template id="mail_notification_light" inherit_id="mail.mail_notification_light" priority="99">
-        <xpath expr="//tr[last()]" position="replace" />
+        <xpath expr="//td[text()[contains(., 'Powered by')]]" position="replace" >
+            <td align="center" style="min-width: 590px;" />
+        </xpath>
     </template>
 
     <template id="mail_notification_paynow" inherit_id="mail.mail_notification_paynow" priority="99">
-        <xpath expr="//tr[last()]" position="replace" />
+        <xpath expr="//td[text()[contains(., 'Powered by')]]" position="replace" >
+            <td align="center" style="min-width: 590px; padding: 8px; font-size:11px;"/>
+        </xpath>
     </template>
 
 </odoo>


### PR DESCRIPTION
@rvalyi @pedrobaeza This is the simplest lightest fix which will resolve the xpath selector combined with priority issue on the newer templates. I probably could have done it with bracketing the last(), but I saw that when deleting the tr element, it actually removes a little bit of border, so it looked nicer to replace the td with another empty one of same formatting.

This brings it into scope of the v10 module, but does not remove all Powered by in all modules, just mail. #344 will do for all modules but I need to do tests for that and isn't so urgent.