### PR TITLE
[11.0][FWD] mail_digest: fix behavior w/ `force_send` enabled

### DIFF
--- a/mail_digest/README.rst
+++ b/mail_digest/README.rst
@@ -64,6 +64,15 @@ a message with subtype assigned **will NOT be sent** via digest if:
 NOTE: under the hood the digest notification logic excludes followers to be notified,
 since you really want to notify only mail.digest's partner.
 
+NOTE 2: Odoo's mail machinery has an option `force_send`
+to send the email immediately without waiting for the mail queue to be processed.
+When this option is used the email is sent right away
+and the message record is deleted right after.
+
+A typical use case is the reset password mail.
+We assume that if you use that option you really want the email to go out "now"
+so when `force_send` is used, digest machinery is completely bypassed.
+
 
 Digest rendering preview
 ------------------------

--- a/mail_digest/__manifest__.py
+++ b/mail_digest/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Mail digest',
     'summary': """Basic digest mail handling.""",
-    'version': '11.0.1.1.0',
+    'version': '11.0.1.1.2',
     'license': 'AGPL-3',
     'author': 'Camptocamp, Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/social',

--- a/mail_digest/tests/test_partner_domains.py
+++ b/mail_digest/tests/test_partner_domains.py
@@ -110,6 +110,20 @@ class PartnerDomainCase(SavepointCase):
         domain = partner._get_notify_by_email_domain(message, digest=True)
         self._assert_found(partner, domain)
 
+    def test_notify_domains_digest_force_send(self):
+        # when `force_send` is true, digest machinery is bypassed
+        message = self.message_model.create({'body': 'My Body', })
+        partner = self.partner1
+        partner.notify_email = 'digest'
+        # even if we have digest mode on, we find the guy
+        domain = partner._get_notify_by_email_domain(message, force_send=True)
+        self._assert_found(partner, domain)
+        # when asking for digest domain we don't get digest-related leaves
+        # as digest domain part is bypassed
+        domain = partner._get_notify_by_email_domain(
+            message, force_send=True, digest=True)
+        self.assertNotIn('notify_email', [x[0] for x in domain])
+
     def test_notify_domains_none(self):
         message = self.message_model.create({'body': 'My Body', })
         partner = self.partner1


### PR DESCRIPTION
FWD port of https://github.com/OCA/social/commit/004e0edee3c06ccc4cb77d7020c6af54d81edf0f from v10

`force_send` is an option in `mail` core module
that allows to send an email immediately.

Handling the message w/ digest is wrong and in any case
we gonna have a digest w/out the message inside it
since is going to be deleted right after send.

A typical use case is the notification sent to new followers.