### PR TITLE
[FIX] mail_activity_team

### DIFF
--- a/mail_activity_team/models/mail_activity.py
+++ b/mail_activity_team/models/mail_activity.py
@@ -46,14 +46,13 @@ class MailActivity(models.Model):
         if not self.team_id:
             return res
         res['domain']['user_id'] = [('id', 'in', self.team_id.member_ids.ids)]
-        if self.team_id.user_id:
-            self.user_id = self.team_id.user_id
-        elif len(self.team_id.member_ids.ids) == 1:
-            self.user_id = self.team_id.member_ids
-        elif self.env.user.id in self.team_id.member_ids.ids:
-            self.user_id = self.env.user
-        else:
-            self.user_id = self.env['res.users']
+        if self.user_id not in self.team_id.member_ids:
+            if self.team_id.user_id:
+                self.user_id = self.team_id.user_id
+            elif len(self.team_id.member_ids) == 1:
+                self.user_id = self.team_id.member_ids
+            else:
+                self.user_id = self.env['res.users']
         return res
 
     @api.multi


### PR DESCRIPTION
This PR fixes the fact that user_id in an activity was set by default to the activity team leader (if present) assigned to the activity. The user_id field in an activity (which is set by default to the user currently logged in) should remain the same if he/she is a member of the activity team selected.
**cc-**@jbeficent 