### PR TITLE
Add indexes to speed up performance

### DIFF
--- a/mail_sendgrid/models/substitution.py
+++ b/mail_sendgrid/models/substitution.py
@@ -15,7 +15,7 @@ class Substitution(models.Model):
     key = fields.Char()
     lang = fields.Char()
     email_template_id = fields.Many2one(
-        'mail.template', ondelete='cascade')
+        'mail.template', ondelete='cascade', index=True)
     email_id = fields.Many2one(
-        'mail.mail', ondelete='cascade')
+        'mail.mail', ondelete='cascade', index=True)
     value = fields.Char()

--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -42,7 +42,7 @@ class MailTrackingEmail(models.Model):
         string="Message", comodel_name='mail.message', readonly=True,
         index=True)
     mail_id = fields.Many2one(
-        string="Email", comodel_name='mail.mail', readonly=True)
+        string="Email", comodel_name='mail.mail', readonly=True, index=True)
     partner_id = fields.Many2one(
         string="Partner", comodel_name='res.partner', readonly=True)
     recipient = fields.Char(string='Recipient email', readonly=True)


### PR DESCRIPTION
We had some performance issues in our database when dealing with mail_message objects. By analyzing the queries we noticed some were coming from mail_tracking modules missing some indexes on foreign keys. This change helps to boost the performance.