### PR TITLE
[IMP][12.0] mail_attach_existing_attachment

### DIFF
--- a/mail_attach_existing_attachment/__manifest__.py
+++ b/mail_attach_existing_attachment/__manifest__.py
@@ -32,10 +32,12 @@
     'version': '12.0.1.0.0',
     'license': 'AGPL-3',
     'depends': [
+        'account',
         'mail',
         'document',
     ],
     'data': [
+        'wizard/account_invoice_send_view.xml',
         'wizard/mail_compose_message_view.xml',
     ],
     'installable': True,

--- a/mail_attach_existing_attachment/wizard/account_invoice_send_view.xml
+++ b/mail_attach_existing_attachment/wizard/account_invoice_send_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="account_invoice_send_wizard_form" model="ir.ui.view">
+        <field name="name">Send Invoice</field>
+        <field name="model">account.invoice.send</field>
+        <field name="inherit_id" ref="account.account_invoice_send_wizard_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='attachment_ids']" position="after">
+                <field name="model" invisible="1"/>
+                <field name="res_id" invisible="1"/>
+                <field name="can_attach_attachment" invisible="1"/>
+                <div attrs="{'invisible': [('can_attach_attachment', '=', False)]}">
+                    <br />
+                    <field name="object_attachment_ids" widget="many2many_checkboxes" domain="[('res_model', '=', model), ('res_id', '=', res_id)]" />
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
since 12.0 account invoice has it's own wizard and own model.
account.invoice.send inherits mail.compose.message so no changes needed here.
the view account.account_invoice_send_wizard_form just needs the same customization as email_compose_message_wizard_inherit_form

issue https://github.com/OCA/social/issues/375