### PR TITLE
[FIX] travis. set postgres version to 9.6 as 9.3 is not available in xenial.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ sudo: false
 cache: pip
 
 addons:
+  postgresql: "9.6"
   apt:
     packages:
       - expect-dev  # provides unbuffer utility


### PR DESCRIPTION
Same as in all repos.