### PR TITLE
[11.0][FIX] mail_tracking: Repeated suggested cc emails

### DIFF
--- a/mail_tracking/models/mail_thread.py
+++ b/mail_tracking/models/mail_thread.py
@@ -24,19 +24,21 @@ class MailThread(models.AbstractModel):
     def message_get_suggested_recipients(self):
         res = super().message_get_suggested_recipients()
         ResPartnerObj = self.env['res.partner']
+        email_cc_formated_list = []
         for record in self:
-            messages = record.message_ids.filtered('email_cc')
-            for msg in messages:
-                email_cc_list = email_split_and_format(msg.email_cc)
-                for cc in email_cc_list:
-                    email_parts = getaddresses([cc])[0]
-                    partner_id = record.message_partner_info_from_emails(
-                        [email_parts[1]])[0].get('partner_id')
-                    if not partner_id:
-                        res[record.id].append((False, cc, _('Cc')))
-                    else:
-                        partner = ResPartnerObj.browse(partner_id,
-                                                       self._prefetch)
-                        record._message_add_suggested_recipient(
-                            res, partner=partner, reason=_('Cc'))
+            emails_cc = record.message_ids.mapped('email_cc')
+            for email in emails_cc:
+                email_cc_formated_list.extend(email_split_and_format(email))
+        email_cc_formated_list = set(email_cc_formated_list)
+        for cc in email_cc_formated_list:
+            email_parts = getaddresses([cc])[0]
+            partner_id = record.message_partner_info_from_emails(
+                [email_parts[1]])[0].get('partner_id')
+            if not partner_id:
+                record._message_add_suggested_recipient(
+                    res, email=cc, reason=_('Cc'))
+            else:
+                partner = ResPartnerObj.browse(partner_id, self._prefetch)
+                record._message_add_suggested_recipient(
+                    res, partner=partner, reason=_('Cc'))
         return res

--- a/mail_tracking/tests/test_mail_tracking.py
+++ b/mail_tracking/tests/test_mail_tracking.py
@@ -139,6 +139,21 @@ class TestMailTracking(TransactionCase):
         recipients = self.recipient.message_get_suggested_recipients()
         self.assertEqual(recipients[self.recipient.id][0][1],
                          'unnamed@test.com')
+        self.assertEqual(len(recipients[self.recipient.id][0]), 3)
+        # Repeated Cc recipients
+        message = self.env['mail.message'].create({
+            'subject': 'Message test',
+            'author_id': self.sender.id,
+            'email_from': self.sender.email,
+            'message_type': 'comment',
+            'model': 'res.partner',
+            'res_id': self.recipient.id,
+            'partner_ids': [(4, self.recipient.id)],
+            'email_cc': 'unnamed@test.com, sender@example.com',
+            'body': '<p>This is another test message</p>',
+        })
+        recipients = self.recipient.message_get_suggested_recipients()
+        self.assertEqual(len(recipients[self.recipient.id][0]), 3)
 
     def mail_send(self, recipient):
         mail = self.env['mail.mail'].create({


### PR DESCRIPTION
This PR fixes repeated suggested cc emails introduced in https://github.com/OCA/social/pull/407