### PR TITLE
[FIX] Bug {TypeError: dict.message.hasEmailCc is not a function} 

### DIFF
--- a/mail_tracking/static/src/js/mail_tracking.js
+++ b/mail_tracking/static/src/js/mail_tracking.js
@@ -22,6 +22,15 @@ odoo.define('mail_tracking.partner_tracking', function(require){
         hasPartnerTrackings: function () {
             return false;
         },
+
+        /**
+         * Messages do not have any email Cc values.
+         *
+         * @return {boolean}
+         */
+        hasEmailCc: function () {
+            return false;
+        },
     });
 
     Message.include({


### PR DESCRIPTION
[FIX] Bug {TypeError: dict.message.hasEmailCc is not a function} during the creation of a new document.

We use addon mail_tracking of version odoo 12.0.
When we have model inherited from mail.thread and create new document we have error: TypeError: dict.message.hasEmailCc is not a function.
Addon mail_tracking extends template mail.widget.Thread.Message and uses t-if statement message.hasEmailCc().
When new document is creating, then mail addon create standard message "Creating a new record...", which is created from AbstractMessage class constructor, which do not has method hasEmailCc.
Added this default method to AbstractMessage class, which return false.