### PR TITLE
[IMP] mail_tracking: Cc name & check if mail is Cc

### DIFF
--- a/mail_tracking/models/mail_message.py
+++ b/mail_tracking/models/mail_message.py
@@ -45,6 +45,11 @@ class MailMessage(models.Model):
             trackings = self.env['mail.tracking.email'].sudo().search([
                 ('mail_message_id', '=', message.id),
             ])
+            # Get Cc recipients
+            email_cc_list = email_split(message.email_cc)
+            if any(email_cc_list):
+                partners |= partners.search([('email', 'in', email_cc_list)])
+            email_cc_list = set(email_cc_list)
             # Search all trackings for this message
             for tracking in trackings:
                 status = self._partner_tracking_status_get(tracking)
@@ -52,8 +57,9 @@ class MailMessage(models.Model):
                     tracking.partner_id.name or tracking.recipient)
                 partner_trackings.append((
                     status, tracking.id, recipient, tracking.partner_id.id,
-                    tracking.partner_id.email))
+                    False))
                 if tracking.partner_id:
+                    email_cc_list.discard(tracking.partner_id.email)
                     partners_already |= tracking.partner_id
             # Search all recipients for this message
             if message.partner_ids:
@@ -64,36 +70,18 @@ class MailMessage(models.Model):
             partners -= partners_already
             for partner in partners:
                 # If there is partners not included, then status is 'unknown'
-                partner_trackings.append((
-                    'unknown', False, partner.name, partner.id, partner.email))
-            res[message.id] = partner_trackings
-        return res
-
-    @api.multi
-    def _get_email_cc(self):
-        """This method gets all Cc mails and the associated partner if exist.
-            The result is a dictionary by 'message id' with a list of tuples
-            (str:email_cc, list:[partner id, partner display_name] or False)
-        """
-        res = {}
-        ResPartnerObj = self.env['res.partner']
-        for message in self:
-            email_cc_list = email_split(message.email_cc)
-            email_cc_list_checked = []
-            if any(email_cc_list):
-                partners = ResPartnerObj.search([
-                    ('email', 'in', email_cc_list)
-                ])
-                email_cc_list = set(email_cc_list)
-                for partner in partners:
+                # Because can be an Cc recipinet
+                isCc = False
+                if partner.email in email_cc_list:
                     email_cc_list.discard(partner.email)
-                    email_cc_list_checked.append(
-                        (partner.email, [partner.id, partner.name]))
-                for email in email_cc_list:
-                    email_cc_list_checked.append((email, False))
-            res.update({
-                message.id: email_cc_list_checked
-            })
+                    isCc = True
+                partner_trackings.append((
+                    'unknown', False, partner.name, partner.id, isCc))
+            for email in email_cc_list:
+                # If there is Cc without partner
+                partner_trackings.append((
+                    'unknown', False, email, False, True))
+            res[message.id] = partner_trackings
         return res
 
     @api.model
@@ -103,11 +91,9 @@ class MailMessage(models.Model):
         mail_message_ids = {m.get('id') for m in messages if m.get('id')}
         mail_messages = self.browse(mail_message_ids)
         partner_trackings = mail_messages.tracking_status()
-        email_cc = mail_messages._get_email_cc()
         for message_dict in messages:
             mail_message_id = message_dict.get('id', False)
             if mail_message_id:
                 message_dict['partner_trackings'] = \
                     partner_trackings[mail_message_id]
-                message_dict['email_cc'] = email_cc[mail_message_id]
         return res

--- a/mail_tracking/models/mail_message.py
+++ b/mail_tracking/models/mail_message.py
@@ -51,7 +51,8 @@ class MailMessage(models.Model):
                 recipient = (
                     tracking.partner_id.name or tracking.recipient)
                 partner_trackings.append((
-                    status, tracking.id, recipient, tracking.partner_id.id))
+                    status, tracking.id, recipient, tracking.partner_id.id,
+                    tracking.partner_id.email))
                 if tracking.partner_id:
                     partners_already |= tracking.partner_id
             # Search all recipients for this message
@@ -87,7 +88,7 @@ class MailMessage(models.Model):
                 for partner in partners:
                     email_cc_list.discard(partner.email)
                     email_cc_list_checked.append(
-                        (partner.email, [partner.id, partner.display_name]))
+                        (partner.email, [partner.id, partner.name]))
                 for email in email_cc_list:
                     email_cc_list_checked.append((email, False))
             res.update({

--- a/mail_tracking/models/mail_message.py
+++ b/mail_tracking/models/mail_message.py
@@ -2,7 +2,7 @@
 # Copyright 2019 Alexandre Díaz
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, api, fields
+from odoo import _, models, api, fields
 from odoo.tools import email_split
 
 
@@ -36,6 +36,12 @@ class MailMessage(models.Model):
             status = tracking_status_map.get(tracking_email_status, 'unknown')
         return status
 
+    def _partner_tracking_status_human_get(self, status):
+        statuses = {'waiting': _('Waiting'), 'error': _('Error'),
+                    'sent': _('Sent'), 'delivered': _('Delivered'),
+                    'opened': _('Opened'), 'unknown': _('Unknown')}
+        return _("Status: %s") % statuses[status]
+
     def tracking_status(self):
         res = {}
         for message in self:
@@ -57,6 +63,8 @@ class MailMessage(models.Model):
                     tracking.partner_id.name or tracking.recipient)
                 partner_trackings.append({
                     'status': status,
+                    'status_human':
+                        self._partner_tracking_status_human_get(status),
                     'tracking_id': tracking.id,
                     'recipient': recipient,
                     'partner_id': tracking.partner_id.id,
@@ -81,6 +89,8 @@ class MailMessage(models.Model):
                     isCc = True
                 partner_trackings.append({
                     'status': 'unknown',
+                    'status_human':
+                        self._partner_tracking_status_human_get('unknown'),
                     'tracking_id': False,
                     'recipient': partner.name,
                     'partner_id': partner.id,
@@ -90,6 +100,8 @@ class MailMessage(models.Model):
                 # If there is Cc without partner
                 partner_trackings.append({
                     'status': 'unknown',
+                    'status_human':
+                        self._partner_tracking_status_human_get('unknown'),
                     'tracking_id': False,
                     'recipient': email,
                     'partner_id': False,

--- a/mail_tracking/models/mail_message.py
+++ b/mail_tracking/models/mail_message.py
@@ -55,9 +55,13 @@ class MailMessage(models.Model):
                 status = self._partner_tracking_status_get(tracking)
                 recipient = (
                     tracking.partner_id.name or tracking.recipient)
-                partner_trackings.append((
-                    status, tracking.id, recipient, tracking.partner_id.id,
-                    False))
+                partner_trackings.append({
+                    'status': status,
+                    'tracking_id': tracking.id,
+                    'recipient': recipient,
+                    'partner_id': tracking.partner_id.id,
+                    'isCc': False,
+                })
                 if tracking.partner_id:
                     email_cc_list.discard(tracking.partner_id.email)
                     partners_already |= tracking.partner_id
@@ -70,17 +74,27 @@ class MailMessage(models.Model):
             partners -= partners_already
             for partner in partners:
                 # If there is partners not included, then status is 'unknown'
-                # Because can be an Cc recipinet
+                # Because can be an Cc recipient
                 isCc = False
                 if partner.email in email_cc_list:
                     email_cc_list.discard(partner.email)
                     isCc = True
-                partner_trackings.append((
-                    'unknown', False, partner.name, partner.id, isCc))
+                partner_trackings.append({
+                    'status': 'unknown',
+                    'tracking_id': False,
+                    'recipient': partner.name,
+                    'partner_id': partner.id,
+                    'isCc': isCc,
+                })
             for email in email_cc_list:
                 # If there is Cc without partner
-                partner_trackings.append((
-                    'unknown', False, email, False, True))
+                partner_trackings.append({
+                    'status': 'unknown',
+                    'tracking_id': False,
+                    'recipient': email,
+                    'partner_id': False,
+                    'isCc': True,
+                })
             res[message.id] = partner_trackings
         return res
 

--- a/mail_tracking/static/src/js/mail_tracking.js
+++ b/mail_tracking/static/src/js/mail_tracking.js
@@ -17,7 +17,6 @@ odoo.define('mail_tracking.partner_tracking', function (require) {
     chat_manager.make_message = function (data) {
         var msg = this._make_message_super(data);
         msg.partner_trackings = data.partner_trackings || [];
-        msg.email_cc = data.email_cc || [];
         return msg;
     };
 
@@ -30,7 +29,6 @@ odoo.define('mail_tracking.partner_tracking', function (require) {
         _preprocess_message: function () {
             var msg = this._super.apply(this, arguments);
             msg.partner_trackings = msg.partner_trackings || [];
-            msg.email_cc = msg.email_cc || [];
             return msg;
         },
         on_tracking_partner_click: function (event) {

--- a/mail_tracking/static/src/xml/mail_tracking.xml
+++ b/mail_tracking/static/src/xml/mail_tracking.xml
@@ -5,39 +5,39 @@
 <template>
 
 <t t-name="mail.tracking.status">
-    <t t-if="tracking[4]">
+    <t t-if="tracking['isCc']">
         <span class="mail_tracking_cc">
             <i class="fa fa-cc"></i>
         </span>
     </t>
-    <t t-elif="tracking[0] === 'unknown'">
+    <t t-elif="tracking['status'] === 'unknown'">
         <span class="mail_tracking_unknown">
             <i class="fa fa-ban"></i>
         </span>
     </t>
-    <t t-elif="tracking[0] === 'waiting'">
+    <t t-elif="tracking['status'] === 'waiting'">
         <span class="mail_tracking_waiting mail_tracking_pointer">
             <i class="fa fa-clock-o"></i>
         </span>
     </t>
-    <t t-elif="tracking[0] === 'error'">
+    <t t-elif="tracking['status'] === 'error'">
         <span class="mail_tracking_error mail_tracking_pointer">
             <i class="fa fa-remove"></i>
         </span>
     </t>
-    <t t-elif="tracking[0] === 'sent'">
+    <t t-elif="tracking['status'] === 'sent'">
         <span class="mail_tracking_sent mail_tracking_pointer">
             <i class="fa fa-check"></i>
         </span>
     </t>
-    <t t-elif="tracking[0] === 'delivered'">
+    <t t-elif="tracking['status'] === 'delivered'">
         <span class="fa-stack mail_tracking_delivered mail_tracking_pointer">
             <i class="fa fa-check fa-stack-1x" style="margin-left:1px"></i>
             <i class="fa fa-check fa-inverse fa-stack-1x" style="margin-left:-2px;"></i>
             <i class="fa fa-check fa-stack-1x" style="margin-left:-3px"></i>
         </span>
     </t>
-    <t t-elif="tracking[0] === 'opened'">
+    <t t-elif="tracking['status'] === 'opened'">
         <span class="fa-stack mail_tracking_opened mail_tracking_pointer">
             <i class="fa fa-check fa-stack-1x" style="margin-left:1px"></i>
             <i class="fa fa-check fa-inverse fa-stack-1x" style="margin-left:-2px;"></i>
@@ -54,19 +54,19 @@
                 <t t-if="!tracking_first">
                       -
                 </t>
-                <t t-if="tracking[3]">
-                    <a t-attf-class="o_mail_action_tracking_partner #{tracking[4] ? 'o_mail_cc' : ''}"
-                       t-att-data-partner="tracking[3]"
-                       t-attf-href="#model=res.partner&amp;id=#{tracking[3]}">
-                        <t t-esc="tracking[2]"/>
+                <t t-if="tracking['partner_id']">
+                    <a t-attf-class="o_mail_action_tracking_partner #{tracking['isCc'] ? 'o_mail_cc' : ''}"
+                       t-att-data-partner="tracking['partner_id']"
+                       t-attf-href="#model=res.partner&amp;id=#{tracking['partner_id']}">
+                        <t t-esc="tracking['recipient']"/>
                     </a>
                 </t>
-                <t t-if="!tracking[3]">
-                    <span t-attf-class="#{tracking[4] ? 'o_mail_cc' : ''}"><t t-esc="tracking[2]"/></span>
+                <t t-else="">
+                    <span t-attf-class="#{tracking['isCc'] ? 'o_mail_cc' : ''}"><t t-esc="tracking['recipient']"/></span>
                 </t>
                 <span class="mail_tracking o_mail_action_tracking_status"
-                      t-att-data-tracking="tracking[1]"
-                      t-attf-title="Status: #{tracking[0]}">
+                      t-att-data-tracking="tracking['tracking_id']"
+                      t-attf-title="Status: #{tracking['status']}">
                     <t t-call="mail.tracking.status"/>
                 </span>
             </t>

--- a/mail_tracking/static/src/xml/mail_tracking.xml
+++ b/mail_tracking/static/src/xml/mail_tracking.xml
@@ -66,7 +66,7 @@
                 </t>
                 <span class="mail_tracking o_mail_action_tracking_status"
                       t-att-data-tracking="tracking['tracking_id']"
-                      t-attf-title="Status: #{tracking['status']}">
+                      t-att-title="tracking['status_human']">
                     <t t-call="mail.tracking.status"/>
                 </span>
             </t>

--- a/mail_tracking/static/src/xml/mail_tracking.xml
+++ b/mail_tracking/static/src/xml/mail_tracking.xml
@@ -10,34 +10,34 @@
             <i class="fa fa-cc"></i>
         </span>
     </t>
-    <t t-elif="tracking[0] == 'unknown'">
+    <t t-elif="tracking[0] === 'unknown'">
         <span class="mail_tracking_unknown">
             <i class="fa fa-ban"></i>
         </span>
     </t>
-    <t t-elif="tracking[0] == 'waiting'">
+    <t t-elif="tracking[0] === 'waiting'">
         <span class="mail_tracking_waiting mail_tracking_pointer">
             <i class="fa fa-clock-o"></i>
         </span>
     </t>
-    <t t-elif="tracking[0] == 'error'">
+    <t t-elif="tracking[0] === 'error'">
         <span class="mail_tracking_error mail_tracking_pointer">
             <i class="fa fa-remove"></i>
         </span>
     </t>
-    <t t-elif="tracking[0] == 'sent'">
+    <t t-elif="tracking[0] === 'sent'">
         <span class="mail_tracking_sent mail_tracking_pointer">
             <i class="fa fa-check"></i>
         </span>
     </t>
-    <t t-elif="tracking[0] == 'delivered'">
+    <t t-elif="tracking[0] === 'delivered'">
         <span class="fa-stack mail_tracking_delivered mail_tracking_pointer">
             <i class="fa fa-check fa-stack-1x" style="margin-left:1px"></i>
             <i class="fa fa-check fa-inverse fa-stack-1x" style="margin-left:-2px;"></i>
             <i class="fa fa-check fa-stack-1x" style="margin-left:-3px"></i>
         </span>
     </t>
-    <t t-elif="tracking[0] == 'opened'">
+    <t t-elif="tracking[0] === 'opened'">
         <span class="fa-stack mail_tracking_opened mail_tracking_pointer">
             <i class="fa fa-check fa-stack-1x" style="margin-left:1px"></i>
             <i class="fa fa-check fa-inverse fa-stack-1x" style="margin-left:-2px;"></i>
@@ -50,13 +50,12 @@
     <t t-jquery="p[class='o_mail_info']" t-operation="after">
         <p class="o_mail_tracking">
             <strong>To:</strong>
-            <t t-set="first_tracking" t-value="true"/>
             <t t-foreach="message.partner_trackings" t-as="tracking">
                 <t t-set="isCc" t-value="false" />
                 <t t-foreach="message.email_cc" t-as="cc">
-                    <t t-if="cc[0] == tracking[4]" t-set="isCc" t-value="true" />
+                    <t t-if="!tracking[1] and cc[0] === tracking[4]" t-set="isCc" t-value="true" />
                 </t>
-                <t t-if="!first_tracking">
+                <t t-if="!tracking_first">
                       -
                 </t>
                 <t t-if="tracking[3]">
@@ -74,15 +73,17 @@
                       t-attf-title="Status: #{tracking[0]}">
                     <t t-call="mail.tracking.status"/>
                 </span>
-                <t t-set="first_tracking" t-value="false"/>
             </t>
 
             <t t-foreach="message.email_cc" t-as="cc">
                 <t t-set="needPrint" t-value="true" />
                 <t t-foreach="message.partner_trackings" t-as="tracking">
-                    <t t-if="cc[0] == tracking[4]" t-set="needPrint" t-value="false" />
+                    <t t-if="cc[0] === tracking[4]" t-set="needPrint" t-value="false" />
                 </t>
                 <t t-if="needPrint">
+                    <t t-if="!cc_first">
+                          -
+                    </t>
                     <t t-set="isCc" t-value="true" />
                     <t t-if="cc[1]">
                         <a t-attf-class="o_mail_action_tracking_partner o_mail_cc"

--- a/mail_tracking/static/src/xml/mail_tracking.xml
+++ b/mail_tracking/static/src/xml/mail_tracking.xml
@@ -5,7 +5,7 @@
 <template>
 
 <t t-name="mail.tracking.status">
-    <t t-if="isCc">
+    <t t-if="tracking[4]">
         <span class="mail_tracking_cc">
             <i class="fa fa-cc"></i>
         </span>
@@ -51,55 +51,24 @@
         <p class="o_mail_tracking">
             <strong>To:</strong>
             <t t-foreach="message.partner_trackings" t-as="tracking">
-                <t t-set="isCc" t-value="false" />
-                <t t-foreach="message.email_cc" t-as="cc">
-                    <t t-if="!tracking[1] and cc[0] === tracking[4]" t-set="isCc" t-value="true" />
-                </t>
                 <t t-if="!tracking_first">
                       -
                 </t>
                 <t t-if="tracking[3]">
-                    <a t-attf-class="o_mail_action_tracking_partner #{isCc ? 'o_mail_cc' : ''}"
+                    <a t-attf-class="o_mail_action_tracking_partner #{tracking[4] ? 'o_mail_cc' : ''}"
                        t-att-data-partner="tracking[3]"
                        t-attf-href="#model=res.partner&amp;id=#{tracking[3]}">
                         <t t-esc="tracking[2]"/>
                     </a>
                 </t>
                 <t t-if="!tracking[3]">
-                    <span><t t-esc="tracking[2]"/></span>
+                    <span t-attf-class="#{tracking[4] ? 'o_mail_cc' : ''}"><t t-esc="tracking[2]"/></span>
                 </t>
                 <span class="mail_tracking o_mail_action_tracking_status"
                       t-att-data-tracking="tracking[1]"
                       t-attf-title="Status: #{tracking[0]}">
                     <t t-call="mail.tracking.status"/>
                 </span>
-            </t>
-
-            <t t-foreach="message.email_cc" t-as="cc">
-                <t t-set="needPrint" t-value="true" />
-                <t t-foreach="message.partner_trackings" t-as="tracking">
-                    <t t-if="cc[0] === tracking[4]" t-set="needPrint" t-value="false" />
-                </t>
-                <t t-if="needPrint">
-                    <t t-if="!cc_first">
-                          -
-                    </t>
-                    <t t-set="isCc" t-value="true" />
-                    <t t-if="cc[1]">
-                        <a t-attf-class="o_mail_action_tracking_partner o_mail_cc"
-                           t-att-data-partner="cc[1][0]"
-                           t-attf-href="#model=res.partner&amp;id=#{cc[1][0]}">
-                            <t t-esc="cc[1][1]"/>
-                        </a>
-                    </t>
-                    <t t-else="">
-                        <span class="o_mail_cc"><t t-esc="cc[0]" /></span>
-                    </t>
-                    <span class="mail_tracking"
-                          title="Status: unknown">
-                          <t t-call="mail.tracking.status"/>
-                    </span>
-                </t>
             </t>
         </p>
     </t>

--- a/mail_tracking/tests/test_mail_tracking.py
+++ b/mail_tracking/tests/test_mail_tracking.py
@@ -112,6 +112,25 @@ class TestMailTracking(TransactionCase):
         tracking_email.event_create('open', metadata)
         self.assertEqual(tracking_email.state, 'opened')
 
+    def _check_partner_trackings(self, message):
+        message_dict = message.message_format()[0]
+        self.assertEqual(len(message_dict['partner_trackings']), 3)
+        # mail cc
+        foundPartner = False
+        foundNoPartner = False
+        for tracking in message_dict['partner_trackings']:
+            if tracking[3] == self.sender.id:
+                foundPartner = True
+                self.assertTrue(tracking[4])
+            elif tracking[2] == 'unnamed@test.com':
+                foundNoPartner = True
+                self.assertFalse(tracking[3])
+                self.assertTrue(tracking[4])
+            elif tracking[3] == self.recipient.id:
+                self.assertFalse(tracking[4])
+        self.assertTrue(foundPartner)
+        self.assertTrue(foundNoPartner)
+
     def test_email_cc(self):
         message = self.env['mail.message'].create({
             'subject': 'Message test',
@@ -124,17 +143,7 @@ class TestMailTracking(TransactionCase):
             'email_cc': 'unnamed@test.com, sender@example.com',
             'body': '<p>This is a test message</p>',
         })
-
-        message_dict = message.message_format()[0]
-        self.assertEqual(len(message_dict['email_cc']), 2)
-        # mail cc
-        # 'mail.message' First check Cc with res.partner
-        email_cc = message_dict['email_cc'][0]
-        self.assertEqual(email_cc[0], 'sender@example.com')
-        self.assertTrue(email_cc[1])
-        email_cc = message_dict['email_cc'][1]
-        self.assertEqual(email_cc[0], 'unnamed@test.com')
-        self.assertFalse(email_cc[1])
+        self._check_partner_trackings(message)
         # suggested recipients
         recipients = self.recipient.message_get_suggested_recipients()
         suggested_mails = {
@@ -151,11 +160,13 @@ class TestMailTracking(TransactionCase):
             'model': 'res.partner',
             'res_id': self.recipient.id,
             'partner_ids': [(4, self.recipient.id)],
-            'email_cc': 'unnamed@test.com, sender@example.com',
+            'email_cc': 'unnamed@test.com, sender@example.com'
+                        ', recipient@example.com',
             'body': '<p>This is another test message</p>',
         })
         recipients = self.recipient.message_get_suggested_recipients()
         self.assertEqual(len(recipients[self.recipient.id][0]), 3)
+        self._check_partner_trackings(message)
 
     def mail_send(self, recipient):
         mail = self.env['mail.mail'].create({

--- a/mail_tracking/tests/test_mail_tracking.py
+++ b/mail_tracking/tests/test_mail_tracking.py
@@ -98,10 +98,11 @@ class TestMailTracking(TransactionCase):
         status = message_dict['partner_trackings'][0]
         # Tracking status must be sent and
         # mail tracking must be the one search before
-        self.assertEqual(status[0], 'sent')
-        self.assertEqual(status[1], tracking_email.id)
-        self.assertEqual(status[2], self.recipient.display_name)
-        self.assertEqual(status[3], self.recipient.id)
+        self.assertEqual(status['status'], 'sent')
+        self.assertEqual(status['tracking_id'], tracking_email.id)
+        self.assertEqual(status['recipient'], self.recipient.display_name)
+        self.assertEqual(status['partner_id'], self.recipient.id)
+        self.assertEqual(status['isCc'], False)
         # And now open the email
         metadata = {
             'ip': '127.0.0.1',
@@ -119,15 +120,15 @@ class TestMailTracking(TransactionCase):
         foundPartner = False
         foundNoPartner = False
         for tracking in message_dict['partner_trackings']:
-            if tracking[3] == self.sender.id:
+            if tracking['partner_id'] == self.sender.id:
                 foundPartner = True
-                self.assertTrue(tracking[4])
-            elif tracking[2] == 'unnamed@test.com':
+                self.assertTrue(tracking['isCc'])
+            elif tracking['recipient'] == 'unnamed@test.com':
                 foundNoPartner = True
-                self.assertFalse(tracking[3])
-                self.assertTrue(tracking[4])
-            elif tracking[3] == self.recipient.id:
-                self.assertFalse(tracking[4])
+                self.assertFalse(tracking['partner_id'])
+                self.assertTrue(tracking['isCc'])
+            elif tracking['partner_id'] == self.recipient.id:
+                self.assertFalse(tracking['isCc'])
         self.assertTrue(foundPartner)
         self.assertTrue(foundNoPartner)
 


### PR DESCRIPTION
This PR improve how the Cc is showed, now only display the basic name.
Now, if a recipient (that is Cc too) have a tracking record it will display checks instead of "Cc" mark.

Cc @Tecnativa