### PR TITLE
[IMP] mail_activity_team: include meetings

### DIFF
--- a/mail_activity_team/__manifest__.py
+++ b/mail_activity_team/__manifest__.py
@@ -14,6 +14,7 @@
         'mail_activity_board',
     ],
     'data': [
+        'views/calendar_event.xml',
         'views/assets_backend.xml',
         'security/ir.model.access.csv',
         'security/mail_activity_team_security.xml',

--- a/mail_activity_team/migrations/11.0.2.2.0/post-migration.py
+++ b/mail_activity_team/migrations/11.0.2.2.0/post-migration.py
@@ -1,0 +1,17 @@
+#  Copyright 2019 Tecnativa - Sergio Teruel
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    rule = env.ref('calendar.calendar_event_rule_private')
+    rule.write({
+        'name': 'Private or group events',
+        'domain_force': "['|', '|', "
+                        "('privacy', 'not in', ['private', 'team']),"
+                        "'&', ('privacy', '=', 'private'),"
+                        "('partner_ids', 'in', user.partner_id.id),"
+                        "'&', ('privacy', '=', 'team'),"
+                        "('team_id', 'in', user.activity_team_ids.ids)]"
+    })

--- a/mail_activity_team/models/__init__.py
+++ b/mail_activity_team/models/__init__.py
@@ -2,3 +2,4 @@ from . import mail_activity_team
 from . import mail_activity
 from . import res_users
 from . import mail_activity_mixin
+from . import calendar_event

--- a/mail_activity_team/models/calendar_event.py
+++ b/mail_activity_team/models/calendar_event.py
@@ -1,0 +1,68 @@
+# Copyright 2019 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models, _
+
+
+class CalendarEvent(models.Model):
+    _inherit = 'calendar.event'
+
+    def _get_default_team_id(self, user_id=None):
+        if not user_id:
+            user_id = self.env.uid
+        res_model = self.env.context.get('default_res_model')
+        model = self.env['ir.model'].search(
+            [('model', '=', res_model)], limit=1)
+        domain = [('member_ids', 'in', [user_id])]
+        if res_model:
+            domain.extend(['|', ('res_model_ids', '=', False),
+                           ('res_model_ids', 'in', model.ids)])
+        return self.env['mail.activity.team'].search(domain, limit=1)
+
+    privacy = fields.Selection(selection_add=[
+        ('team', 'Only team'),
+    ])
+    team_id = fields.Many2one(
+        comodel_name='mail.activity.team',
+        default=lambda s: s._get_default_team_id(),
+    )
+
+    @api.multi
+    def read(self, fields=None, load='_classic_read'):
+        expected_fields = ['privacy', 'team_id']
+        extra_fields = []
+        fixed_fields = [
+            'id', 'allday', 'start', 'stop', 'display_start', 'display_stop',
+            'duration', 'user_id', 'state', 'interval', 'count',
+            'recurrent_id_date', 'rrule'
+        ]
+        if not fields:
+            fields = list(self._fields)
+        for field in expected_fields:
+            if field not in fields:
+                fields.append(field)
+                extra_fields.append(field)
+        result = super().read(fields, load)
+        for r in result:
+            if r['team_id'] and r['privacy'] == 'team':
+                team_id = r['team_id']
+                if isinstance(team_id, tuple):
+                    team_id = team_id[0]
+                team = self.env['mail.activity.team'].browse(team_id)
+                users = team.member_ids
+                if self.env.user not in users:
+                    for f in r:
+                        recurrent_fields = self._get_recurrent_fields()
+                        public_fields = list(set(
+                            recurrent_fields + fixed_fields))
+                        if f not in public_fields:
+                            if isinstance(r[f], list):
+                                r[f] = []
+                            else:
+                                r[f] = False
+                        if f == 'name':
+                            r[f] = _('Busy')
+            for f in extra_fields:
+                if f in r:
+                    del r[f]
+        return result

--- a/mail_activity_team/models/mail_activity.py
+++ b/mail_activity_team/models/mail_activity.py
@@ -65,3 +65,9 @@ class MailActivity(models.Model):
                     activity.user_id not in self.team_id.member_ids:
                 raise ValidationError(
                     _('The assigned user is not member of the team.'))
+
+    @api.multi
+    def action_create_calendar_event(self):
+        res = super().action_create_calendar_event()
+        res['context']['default_team_id'] = self.team_id.id or False
+        return res

--- a/mail_activity_team/readme/CONTRIBUTORS.rst
+++ b/mail_activity_team/readme/CONTRIBUTORS.rst
@@ -1,3 +1,5 @@
 * `Eficent <https://www.eficent.com>`_:
 
   * Jordi Ballester Alomar (jordi.ballester@eficent.com)
+
+* Enric Tobella <etobella@creublanca.es>

--- a/mail_activity_team/security/mail_activity_team_security.xml
+++ b/mail_activity_team/security/mail_activity_team_security.xml
@@ -12,4 +12,9 @@
         <field name="perm_unlink" eval="True"/>
     </record>
 
+    <record id="calendar.calendar_event_rule_private" model="ir.rule">
+        <field name="name">Private or group events</field>
+        <field name="domain_force">['|', '|', ('privacy', 'not in', ['private', 'team']), '&amp;', ('privacy', '=', 'private'), ('partner_ids', 'in', user.partner_id.id), '&amp;', ('privacy', '=', 'team'), ('team_id', 'in', user.activity_team_ids.ids)]</field>
+    </record>
+
 </odoo>

--- a/mail_activity_team/views/calendar_event.xml
+++ b/mail_activity_team/views/calendar_event.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 Creu Blanca
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record model="ir.ui.view" id="view_calendar_event_form">
+        <field name="name">calendar.event.form (in mail_activity_team)</field>
+        <field name="model">calendar.event</field>
+        <field name="inherit_id" ref="calendar.view_calendar_event_form"/>
+        <field name="arch" type="xml">
+            <field name="privacy" position="after">
+                <field name="team_id"/>
+            </field>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_calendar_event_search">
+        <field name="name">calendar.event.search</field>
+        <field name="model">calendar.event</field>
+        <field name="inherit_id" ref="calendar.view_calendar_event_search"/>
+        <field name="arch" type="xml">
+            <field name="user_id" position="after">
+                <field name="team_id"/>
+            </field>
+            <filter name="mymeetings" position="after">
+                <filter string="My Team Meetings" help="My Team Meetings"
+                        name="team_meetings"
+                        domain="[('team_id.member_ids', '=', uid)]"/>
+            </filter>
+        </field>
+    </record>
+
+
+</odoo>


### PR DESCRIPTION
This PR allows to use teams on meetings (inherited from mail_activity_board). Now, a new privacy option is added to calendar.events, as you are able to read all the meetings of your team