### PR TITLE
[ADD] mail_tracking_mailgun: manage failed state from mailgun

### DIFF
--- a/mail_tracking_mailgun/models/mail_tracking_email.py
+++ b/mail_tracking_mailgun/models/mail_tracking_email.py
@@ -45,6 +45,8 @@ class MailTrackingEmail(models.Model):
             'bounced': 'hard_bounce',
             'dropped': 'reject',
             'accepted': 'sent',
+            'failed': 'error',
+            'rejected': 'error',
         }
 
     def _mailgun_event_type_verify(self, event):


### PR DESCRIPTION
This change let Odoo process a state sent from Mailgun legacy Webhooks that seems to apply when the message is not sent because the related email has been mark as spam or have bounced before. 

For solve this we only add  two new state mapping to _mailgun_event_type_mapping_mailgun_event_type_mapping method:

* failed: Mailgun could not deliver the email to the recipient email server
* rejected: Mailgun rejected the request to send/forward the email

source in https://documentation.mailgun.com/en/latest/quickstart-events.html#events