### PR TITLE
FIX multiple body fields that were conflicting in mass mailing when using Sendgrid

### DIFF
--- a/mail_sendgrid/wizards/email_template_preview.py
+++ b/mail_sendgrid/wizards/email_template_preview.py
@@ -17,7 +17,7 @@ class EmailTemplatePreview(models.TransientModel):
         template_id = self.env.context.get('template_id')
         template = self.env['mail.template'].browse(template_id)
         sendgrid_template = template.sendgrid_localized_template
-        if sendgrid_template:
+        if sendgrid_template and body_html:
             self.body_html = sendgrid_template.html_content.replace(
                 '<%body%>', body_html)
         return result

--- a/mail_sendgrid_mass_mailing/tests/test_mass_mailing.py
+++ b/mail_sendgrid_mass_mailing/tests/test_mass_mailing.py
@@ -81,7 +81,6 @@ class TestMailSendgrid(SavepointCase):
         """
         Test the preview field is getting the Sendgrid template
         """
-        self.mass_mailing.html_copy = self.mass_mailing.body_html
         preview = self.mass_mailing.body_sendgrid
         self.assertIn(u'<h1>Test Sendgrid</h1>', preview)
         self.assertIn('hello!', preview)

--- a/mail_sendgrid_mass_mailing/views/mass_mailing_view.xml
+++ b/mail_sendgrid_mass_mailing/views/mass_mailing_view.xml
@@ -6,19 +6,15 @@
         <field name="model">mail.mass_mailing</field>
         <field name="inherit_id" ref="mass_mailing.view_mail_mass_mailing_form"/>
         <field name="arch" type="xml">
-            <field name="body_html" position="attributes">
+            <xpath expr="//notebook/page[1]" position="attributes">
                 <attribute name="attrs">{'invisible': [('email_template_id', '!=', False)]}</attribute>
-            </field>
-            <field name="body_html" position="after">
-                <field name="html_unframe" widget="html" attrs="{'invisible': [('email_template_id', '=', False)]}"/>
-            </field>
+            </xpath>
             <xpath expr="//field[@name='mailing_model']/.." position="after">
                 <field name="email_template_id" domain="[('model', '=', mailing_model), ('sendgrid_template_ids', '!=', False)]"/>
                 <field name="lang" attrs="{'invisible': [('email_template_id', '=', False)]}"/>
             </xpath>
             <xpath expr="//notebook/page[1]" position="after">
                 <page string="Sendgrid Preview" attrs="{'invisible': [('email_template_id', '=', False)]}">
-                    <field name="html_copy" invisible="1"/>
                     <field name="body_sendgrid" widget="html"/>
                 </page>
             </xpath>

--- a/mail_sendgrid_mass_mailing/wizards/test_mailing.py
+++ b/mail_sendgrid_mass_mailing/wizards/test_mailing.py
@@ -21,7 +21,7 @@ class TestMassMailing(models.TransientModel):
             sendgrid_template = template.sendgrid_localized_template
             res_id = self.env.user.partner_id.id
             body = template.render_template(
-                mailing.body_html, template.model, [res_id],
+                template.body_html, template.model, [res_id],
                 post_process=True)[res_id]
             test_emails = tools.email_split(self.email_to)
             emails = self.env['mail.mail']


### PR DESCRIPTION
- Instead of copying body of template to mass mailing, directly use
  the template text for mass mailings when using Sendgrid.
- If needed, the template must be edited instead of the mass mailing.
- This simplifies the code complexity