### PR TITLE
[FIX] avoid bounce on 'error' event

### DIFF
--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -105,8 +105,7 @@ class MailTrackingEmail(models.Model):
         if not email:
             return False
         res = self._email_last_tracking_state(email)
-        return res and res[0].get('state', '') in {'rejected', 'error',
-                                                   'spam', 'bounced'}
+        return res and res[0].get('state') in {'rejected', 'spam', 'bounced'}
 
     @api.model
     def _email_last_tracking_state(self, email):
@@ -222,7 +221,6 @@ class MailTrackingEmail(models.Model):
             'error_description': tools.ustr(exception),
             'state': 'error',
         })
-        self.sudo()._partners_email_bounced_set('error')
         return True
 
     @api.multi

--- a/mail_tracking/tests/test_mail_tracking.py
+++ b/mail_tracking/tests/test_mail_tracking.py
@@ -303,7 +303,7 @@ class TestMailTracking(TransactionCase):
             self.assertEqual('error', tracking.state)
             self.assertEqual('Warning', tracking.error_type)
             self.assertEqual('Test error', tracking.error_description)
-            self.assertTrue(self.recipient.email_bounced)
+            self.assertFalse(self.recipient.email_bounced)
 
     def test_partner_email_change(self):
         mail, tracking = self.mail_send(self.recipient.email)

--- a/mail_tracking_mass_mailing/models/mail_tracking_email.py
+++ b/mail_tracking_mass_mailing/models/mail_tracking_email.py
@@ -47,7 +47,6 @@ class MailTrackingEmail(models.Model):
     def smtp_error(self, mail_server, smtp_server, exception):
         res = super(MailTrackingEmail, self).smtp_error(
             mail_server, smtp_server, exception)
-        self._contacts_email_bounced_set('error')
         return res
 
     @api.multi

--- a/mail_tracking_mass_mailing/tests/test_mass_mailing.py
+++ b/mail_tracking_mass_mailing/tests/test_mass_mailing.py
@@ -55,7 +55,7 @@ class TestMassMailing(TransactionCase):
                     self.assertEqual('Warning', track.error_type)
                     self.assertEqual('Mock test error',
                                      track.error_description)
-            self.assertTrue(self.contact_a.email_bounced)
+            self.assertFalse(self.contact_a.email_bounced)
 
     def test_tracking_email_link(self):
         self.mailing.send_mail()


### PR DESCRIPTION
Catching this event as a bounce leads quite often to false bounces, like
in the cases the error is due to our own instance SMTP errors. Errors
like a too large message should no bounce a thread's recipients as the
problem isn't in the recipients side but ours.

We leave anyway some true positives aside (like in the case of malformed
email addresses). We should be able to detect and fix those anyway.

cc @Tecnativa TT20293