### PR TITLE
[FIX] mail_tracking: Set as reviewed notification

### DIFF
--- a/mail_tracking/models/mail_message.py
+++ b/mail_tracking/models/mail_message.py
@@ -203,18 +203,17 @@ class MailMessage(models.Model):
                 for msg in self.sorted('date', reverse=True)]
 
     @api.multi
-    def toggle_tracking_status(self):
-        """Toggle message tracking action.
+    def set_need_action_done(self):
+        """Set message tracking action as done
 
-        This will mark them to be (or not) ignored in the tracking issues
-        filter.
+        This will mark them to be ignored in the tracking issues filter.
         """
         self.check_access_rule('read')
-        self.mail_tracking_needs_action = not self.mail_tracking_needs_action
+        self.write({'mail_tracking_needs_action': False})
         notification = {
             'type': 'toggle_tracking_status',
-            'message_ids': [self.id],
-            'needs_actions': self.mail_tracking_needs_action
+            'message_ids': self.ids,
+            'needs_actions': False
         }
         self.env['bus.bus'].sendone(
             (self._cr.dbname, 'res.partner', self.env.user.partner_id.id),

--- a/mail_tracking/models/mail_resend_message.py
+++ b/mail_tracking/models/mail_resend_message.py
@@ -42,23 +42,13 @@ class MailResendMessage(models.TransientModel):
                 tracking_ids.write({'state': False})
                 # Send bus notifications to update Discuss and
                 # mail_failed_messages widget
-                notifications = [
-                    [
-                        (self._cr.dbname, 'res.partner',
-                         self.env.user.partner_id.id),
-                        {
-                            'type': 'update_failed_messages',
-                        }
-                    ],
-                    [
-                        (self._cr.dbname, 'res.partner',
-                         self.env.user.partner_id.id),
-                        {
-                            'type': 'toggle_tracking_status',
-                            'message_ids': [self.mail_message_id.id],
-                            'needs_actions': False,
-                        }
-                    ]
-                ]
-                self.env['bus.bus'].sendmany(notifications)
+                notification = {
+                    'type': 'toggle_tracking_status',
+                    'message_ids': [self.mail_message_id.id],
+                    'needs_actions': False
+                }
+                self.env['bus.bus'].sendone(
+                    (self._cr.dbname, 'res.partner',
+                     self.env.user.partner_id.id),
+                    notification)
         super().resend_mail_action()

--- a/mail_tracking/static/src/js/failed_message/discuss.js
+++ b/mail_tracking/static/src/js/failed_message/discuss.js
@@ -95,7 +95,7 @@ odoo.define('mail_tracking.FailedMessageDiscuss', function (require) {
          */
         _handlePartnerNotification: function (data) {
             if (data.type === 'toggle_tracking_status') {
-                this._handlePartnerToggleFailedNotification(data);
+                this._handleChangeTrackingNeedsActionNotification(data);
             } else {
                 // Workaround to avoid call '_handlePartnerChannelNotification'
                 // because this is related with the failed mailbox, not a
@@ -106,13 +106,14 @@ odoo.define('mail_tracking.FailedMessageDiscuss', function (require) {
 
         /**
          * This method updates messages in the failed mailbox when the flag
-         * 'mail_tracking_needs_action' is toggled. This can remove/add
-         * the message from/to failed mailbox and update mailbox counter.
+         * 'mail_tracking_needs_action' was changed to False. This can
+         * remove/add the message from/to failed mailbox and update mailbox
+         * counter.
          *
          * @private
          * @param {Object} data
          */
-        _handlePartnerToggleFailedNotification: function (data) {
+        _handleChangeTrackingNeedsActionNotification: function (data) {
             var self = this;
             var failed = this.getMailbox('failed');
             _.each(data.message_ids, function (messageID) {
@@ -320,7 +321,7 @@ odoo.define('mail_tracking.FailedMessageDiscuss', function (require) {
             var messageID = $(event.currentTarget).data('message-id');
             return this._rpc({
                 model: 'mail.message',
-                method: 'toggle_tracking_status',
+                method: 'set_need_action_done',
                 args: [[messageID]],
                 context: this.getSession().user_context,
             });

--- a/mail_tracking/static/src/js/failed_message/thread.js
+++ b/mail_tracking/static/src/js/failed_message/thread.js
@@ -26,7 +26,7 @@ odoo.define('mail_tracking.FailedMessageThread', function (require) {
      */
     function _readMessages (widget, ids) {
         if (!ids.length) {
-            return $.when();
+            return $.when([]);
         }
         var context = widget.record && widget.record.getContext();
         return widget._rpc({
@@ -150,7 +150,7 @@ odoo.define('mail_tracking.FailedMessageThread', function (require) {
         _markFailedMessageReviewed: function (id) {
             return this._rpc({
                 model: 'mail.message',
-                method: 'toggle_tracking_status',
+                method: 'set_need_action_done',
                 args: [[id]],
                 context: this.record.getContext(),
             });
@@ -171,7 +171,7 @@ odoo.define('mail_tracking.FailedMessageThread', function (require) {
                 var model = notif[0][1];
                 if (model === 'res.partner') {
                     var data = notif[1];
-                    if (data.type === 'update_failed_messages') {
+                    if (data.type === 'toggle_tracking_status') {
                         // Reload 'mail_failed_message' widget
                         self._reload({failed_message: true});
                     }

--- a/mail_tracking/tests/test_mail_tracking.py
+++ b/mail_tracking/tests/test_mail_tracking.py
@@ -215,7 +215,7 @@ class TestMailTracking(TransactionCase):
         self.assertTrue(messages)
         self.assertTrue(messages_failed)
         self.assertTrue(len(messages) > len(messages_failed))
-        tracking.mail_message_id.toggle_tracking_status()
+        tracking.mail_message_id.set_need_action_done()
         self.assertFalse(tracking.mail_message_id.mail_tracking_needs_action)
         self.assertTrue(
             MailMessageObj.get_failed_count() < failed_count)


### PR DESCRIPTION
Previous this commit, failed messages widget data wasn't updated properly when you set as reviewed/retry the last message displayed.

This commit resolve the problem and improves the "set as reviewed" action to avoid multi-user inconsistencies (don't toggle the value).

Cc @tecnativa