### PR TITLE
[11.0][mail_drop_target] disable the notification to existing followers on a new email dropped to a record.

### DIFF
--- a/mail_drop_target/__manifest__.py
+++ b/mail_drop_target/__manifest__.py
@@ -18,5 +18,6 @@
     },
     "data": [
         'views/templates.xml',
+        'views/res_config_settings_views.xml',
     ],
 }

--- a/mail_drop_target/models/__init__.py
+++ b/mail_drop_target/models/__init__.py
@@ -1,3 +1,4 @@
 # Copyright 2018 Therp BV <https://therp.nl>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from . import mail_thread
+from . import res_config_settings

--- a/mail_drop_target/models/mail_thread.py
+++ b/mail_drop_target/models/mail_thread.py
@@ -15,7 +15,14 @@ class MailThread(models.AbstractModel):
     def message_drop(self, model, message, custom_values=None,
                      save_original=False, strip_attachments=False,
                      thread_id=None):
-        result = self.message_process(
+        disable_notify_mail_drop_target = \
+            self.env["ir.config_parameter"].get_param(
+                "mail_drop_target.disable_notify", default=False)
+        self_message_process = self
+        if disable_notify_mail_drop_target:
+            self_message_process = self_message_process.with_context(
+                message_create_from_mail_mail=True)
+        result = self_message_process.message_process(
             model, message, custom_values=custom_values,
             save_original=save_original, strip_attachments=strip_attachments,
             thread_id=thread_id

--- a/mail_drop_target/models/res_config_settings.py
+++ b/mail_drop_target/models/res_config_settings.py
@@ -1,0 +1,33 @@
+# Copyright 2019 Eficent Business and IT Consulting Services, S.L.
+#                <https//www.eficent.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import api, fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    disable_notify_mail_drop_target = fields.Boolean(
+        'Disable Notification followers on mail dropped to a Thread',
+        help="When this setting is set, when a user drops an "
+             "email into an existing thread the followers of the thread will "
+             "not be notified. This sets an ir.config.parameter "
+             "mail_drop_target.disable_notify")
+
+    @api.model
+    def get_values(self):
+        res = super(ResConfigSettings, self).get_values()
+
+        disable_notify_mail_drop_target = \
+            self.env["ir.config_parameter"].get_param(
+                "mail_drop_target.disable_notify", default=False)
+        res.update(
+            disable_notify_mail_drop_target=disable_notify_mail_drop_target,
+        )
+        return res
+
+    def set_values(self):
+        super(ResConfigSettings, self).set_values()
+        self.env['ir.config_parameter'].set_param(
+            "mail_drop_target.disable_notify",
+            self.disable_notify_mail_drop_target or '')

--- a/mail_drop_target/readme/CONFIGURATION.rst
+++ b/mail_drop_target/readme/CONFIGURATION.rst
@@ -1,0 +1,3 @@
+To disable the automatic notification to existing followers when you drop an
+email to a record, go to *Settings*, activate the developer mode, and then go to
+*Settings / General Settings* and set the flag 'Disable Mail Drag&Drop Notification'.

--- a/mail_drop_target/readme/DESCRIPTION.rst
+++ b/mail_drop_target/readme/DESCRIPTION.rst
@@ -1,3 +1,7 @@
 This module was written to allow users to drag&drop emails from their desktop to Odoo.
 
 It supports as well RFC822 .eml files as Outlook .msg (those only if `an extra library <https://github.com/mattgwwalker/msg-extractor>`_ is installed) files.
+
+When the mail is dropped to an odoo record, it will automatically send a notification
+of that new message that has been added to all the existing followers. It is possible
+to disable this notification.

--- a/mail_drop_target/views/res_config_settings_views.xml
+++ b/mail_drop_target/views/res_config_settings_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="res_config_settings_view_form" model="ir.ui.view">
+            <field name="name">res.config.settings.view.form.inherit.mail</field>
+            <field name="model">res.config.settings</field>
+            <field name="inherit_id" ref="mail.res_config_settings_view_form"/>
+            <field name="arch" type="xml">
+                <div id="emails" position="inside">
+                    <div class="col-xs-12 col-md-6 o_setting_box">
+                        <div class="o_setting_left_pane">
+                            <field name="disable_notify_mail_drop_target"/>
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label string="Disable Mail Drag&amp;Drop Notification" for="disable_notify_mail_drop_target"/>
+                            <div class="text-muted">
+                                When a user drops an email into an existing thread
+                                the followers of the thread will not be notified.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
When the mail is dropped to an odoo record, it will automatically send a notification
of that new message that has been added to all the existing followers. It is possible
to disable this notification.

To disable the automatic notification to existing followers when you drop an
email to a record, go to *Settings*, activate the developer mode, and then go to
*Settings / General Settings* and set the flag 'Disable Mail Drag&Drop Notification'.

![image](https://user-images.githubusercontent.com/7683926/69422443-fbef4580-0d23-11ea-9590-7f8fe0f8cad6.png)

