### PR TITLE
[13.0][IMP] mail_activity_board: Direct access to related model instance

### DIFF
--- a/mail_activity_board/__manifest__.py
+++ b/mail_activity_board/__manifest__.py
@@ -7,7 +7,7 @@
     "development_status": "Beta",
     "category": "Social Network",
     "website": "https://github.com/OCA/social",
-    "author": "SDi, David Juaneda, Odoo Community Association (OCA)",
+    "author": "SDi, David Juaneda, ACSONE SA/NV, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "installable": True,
     "depends": ["calendar", "board"],

--- a/mail_activity_board/models/mail_activity.py
+++ b/mail_activity_board/models/mail_activity.py
@@ -17,6 +17,24 @@ class MailActivity(models.Model):
     calendar_event_id_partner_ids = fields.Many2many(
         related="calendar_event_id.partner_ids", readonly=True
     )
+    related_model_instance = fields.Reference(
+        selection="_selection_related_model_instance",
+        compute="_compute_related_model_instance",
+        string="Document",
+    )
+
+    @api.depends("res_id", "res_model")
+    def _compute_related_model_instance(self):
+        for record in self:
+            ref = False
+            if record.res_id:
+                ref = "{},{}".format(record.res_model, record.res_id)
+            record.related_model_instance = ref
+
+    @api.model
+    def _selection_related_model_instance(self):
+        models = self.env["ir.model"].search([("is_mail_activity", "=", True)])
+        return [(model.model, model.name) for model in models]
 
     def open_origin(self):
         self.ensure_one()

--- a/mail_activity_board/readme/CONTRIBUTORS.rst
+++ b/mail_activity_board/readme/CONTRIBUTORS.rst
@@ -9,3 +9,7 @@
 * `Pesol <https://www.pesol.es>`_:
 
   * Pedro Gonzalez (pedro.gonzalez@pesol.es)
+
+* `ACSONE SA/NV <https://www.acsone.eu>`_
+
+  * Laurent Mignon <laurent.mignon@acsone.eu>

--- a/mail_activity_board/tests/test_mail_activity_board.py
+++ b/mail_activity_board/tests/test_mail_activity_board.py
@@ -194,6 +194,14 @@ class TestMailActivityBoardMethods(TransactionCase):
         for act in acts:
             self.assertIn(act, self.partner_client.activity_ids.ids)
 
+    def test_related_model_instance(self):
+        """ This test case checks the direct access from the activity to the
+        linked model instance
+        """
+        self.assertEqual(self.act3.related_model_instance, self.partner_client)
+        self.act3.write({"res_id": False, "res_model": False})
+        self.assertFalse(self.act3.related_model_instance)
+
     def test_read_permissions(self):
         search1 = self.env["mail.activity"].with_user(self.employee).search([])
         self.assertEqual(len(search1), 3)

--- a/mail_activity_board/views/mail_activity_view.xml
+++ b/mail_activity_board/views/mail_activity_view.xml
@@ -4,6 +4,45 @@
     VIEWS
 -->
 
+    <!-- FORM POP
+
+        Add a link to the related model instance to ease navigation
+    -->
+    <record id="mail_activity_view_form_popup" model="ir.ui.view">
+        <field
+            name="name"
+        >mail.activity.view.form.popup (in mail_activity_board)</field>
+        <field name="model">mail.activity</field>
+        <field name="inherit_id" ref="mail.mail_activity_view_form_popup" />
+        <field name="arch" type="xml">
+            <field name="activity_type_id" position="before">
+                <field
+                    name="related_model_instance"
+                    attrs="{'invisible': [('related_model_instance','=', False)]}"
+                />
+            </field>
+        </field>
+    </record>
+
+    <!-- CALENDAR VIEW
+        Add a link to the related model instance to ease navigation
+    -->
+    <record id="mail_activity_view_calendar" model="ir.ui.view">
+        <field
+            name="name"
+        >mail.activity.view.form.calendar (in mail_activity_board)</field>
+        <field name="model">mail.activity</field>
+        <field name="inherit_id" ref="mail.mail_activity_view_calendar" />
+        <field name="arch" type="xml">
+            <field name="res_name" position="before">
+                <field name="related_model_instance" />
+            </field>
+            <field name="res_name" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+        </field>
+    </record>
+
     <!-- FORM VIEW -->
     <record id="mail_activity_view_form_board" model="ir.ui.view">
         <field name="name">mail.activity.boards.view.form</field>
@@ -88,7 +127,12 @@
                     name="decoration-success"
                 >(date_deadline &gt; current_date)</attribute>
             </xpath>
-
+            <field name="res_name" position="before">
+                <field name="related_model_instance" />
+            </field>
+            <field name="res_name" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
         </field>
     </record>
 


### PR DESCRIPTION
Add a direct access from activity calendar and form views to the linked model instance.

Bedore this change, it was not possible to access to the model instance linked to an activity from the calendar view nor from the view opened by clicling on the activity into the calendar.

* [x] requires https://github.com/odoo/odoo/pull/41262

![image](https://user-images.githubusercontent.com/544090/70055306-92035580-15d9-11ea-9283-d29f7c2d43d7.png)

![image](https://user-images.githubusercontent.com/544090/70055337-9f204480-15d9-11ea-954b-430fa2185321.png)
