### PR TITLE
[11.0][FIX] mail_restrict_follower_selection: res_model not in context

### DIFF
--- a/mail_restrict_follower_selection/models/mail_followers.py
+++ b/mail_restrict_follower_selection/models/mail_followers.py
@@ -13,7 +13,7 @@ class MailFollowers(models.Model):
                               channel_data, force=True):
         domain = self.env[
             'mail.wizard.invite'
-        ]._mail_restrict_follower_selection_get_domain()
+        ]._mail_restrict_follower_selection_get_domain(res_model=res_model)
         partners = self.env['res.partner'].search(
             [('id', 'in', list(partner_data))] +
             safe_eval(domain)

--- a/mail_restrict_follower_selection/models/mail_wizard_invite.py
+++ b/mail_restrict_follower_selection/models/mail_wizard_invite.py
@@ -10,11 +10,13 @@ class MailWizardInvite(models.TransientModel):
     _inherit = 'mail.wizard.invite'
 
     @api.model
-    def _mail_restrict_follower_selection_get_domain(self):
+    def _mail_restrict_follower_selection_get_domain(self, res_model=None):
+        if not res_model:
+            res_model = self.env.context.get('default_res_model')
         parameter_name = 'mail_restrict_follower_selection.domain'
         return self.env['ir.config_parameter'].sudo().get_param(
             "{0}.{1}".format(parameter_name,
-                             self.env.context.get('default_res_model')),
+                             res_model),
             self.env['ir.config_parameter'].sudo().get_param(
                 parameter_name, default='[]')
         )


### PR DESCRIPTION
When creating a record from a record from another model, the model is not in the context (`default_res_model` key). For example: creating an invoice from a sale order.