### PR TITLE
[11.0][FIX] mail_drop_target: Add sudo on config_param

### DIFF
--- a/mail_drop_target/models/mail_thread.py
+++ b/mail_drop_target/models/mail_thread.py
@@ -16,7 +16,7 @@ class MailThread(models.AbstractModel):
                      save_original=False, strip_attachments=False,
                      thread_id=None):
         disable_notify_mail_drop_target = \
-            self.env["ir.config_parameter"].get_param(
+            self.env["ir.config_parameter"].sudo().get_param(
                 "mail_drop_target.disable_notify", default=False)
         self_message_process = self
         if disable_notify_mail_drop_target:


### PR DESCRIPTION
Missing sudo on getting the parameter

@JordiBForgeFlow @JoanSForgeFlow @LoisRForgeFlow @hbrunn @jarroyomorales 