### PR TITLE
[IMP] mail_optional_autofollow : add feature on send invoice wizard

### DIFF
--- a/mail_optional_autofollow/__init__.py
+++ b/mail_optional_autofollow/__init__.py
@@ -1,1 +1,2 @@
+from . import models
 from . import wizard

--- a/mail_optional_autofollow/__manifest__.py
+++ b/mail_optional_autofollow/__manifest__.py
@@ -12,9 +12,11 @@
     'version': '12.0.1.0.0',
     'license': 'AGPL-3',
     'depends': [
+        'account',
         'mail',
     ],
     'data': [
+        'wizard/account_invoice_send.xml',
         'wizard/mail_compose_message_view.xml',
     ],
     'installable': True,

--- a/mail_optional_autofollow/models/__init__.py
+++ b/mail_optional_autofollow/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_invoice
+from . import mail_thread

--- a/mail_optional_autofollow/models/account_invoice.py
+++ b/mail_optional_autofollow/models/account_invoice.py
@@ -1,0 +1,15 @@
+# Copyright 2020 ABF OSIELL <http://osiell.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    @api.multi
+    @api.returns('mail.message', lambda value: value.id)
+    def message_post(self, **kwargs):
+        return super(AccountInvoice, self.with_context(
+            mail_post_autofollow_override=self.env.context.get(
+                'mail_post_autofollow', True))).message_post(**kwargs)

--- a/mail_optional_autofollow/models/mail_thread.py
+++ b/mail_optional_autofollow/models/mail_thread.py
@@ -1,0 +1,25 @@
+# Copyright 2020 ABF OSIELL <http://osiell.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class MailThread(models.AbstractModel):
+    _inherit = 'mail.thread'
+
+    @api.multi
+    @api.returns('mail.message', lambda value: value.id)
+    def message_post(
+            self, body='', subject=None, message_type='notification',
+            subtype=None, parent_id=False, attachments=None,
+            notif_layout=False, add_sign=True, model_description=False,
+            mail_auto_delete=True, **kwargs):
+        return super(MailThread, self.with_context(
+            mail_post_autofollow=self.env.context.get(
+                'mail_post_autofollow_override', self.env.context.get(
+                    'mail_post_autofollow', True)))).message_post(
+                        body=body, subject=subject, message_type=message_type,
+                        subtype=subtype, parent_id=parent_id,
+                        attachments=attachments, notif_layout=notif_layout,
+                        add_sign=add_sign, model_description=model_description,
+                        mail_auto_delete=mail_auto_delete, **kwargs)

--- a/mail_optional_autofollow/tests/test_mail_optional_autofollow.py
+++ b/mail_optional_autofollow/tests/test_mail_optional_autofollow.py
@@ -8,37 +8,50 @@ class TestAttachExistingAttachment(common.TransactionCase):
 
     def setUp(self):
         super().setUp()
-        self.partner_obj = self.env['res.partner']
-        self.partner_01 = self.env.ref('base.res_partner_10')
         self.partner_02 = self.env.ref('base.res_partner_address_17')
+        self.default_model = 'res.partner'
+        self.default_res_id = self.env.ref('base.res_partner_10').id
 
     def test_send_email_attachment(self):
         ctx = self.env.context.copy()
         ctx.update({
-            'default_model': 'res.partner',
-            'default_res_id': self.partner_01.id,
+            'default_model': self.default_model,
+            'default_res_id': self.default_res_id,
             'default_composition_mode': 'comment',
         })
         mail_compose = self.env['mail.compose.message']
         values = mail_compose.with_context(ctx)\
-            .onchange_template_id(False, 'comment', 'res.partner',
-                                  self.partner_01.id)['value']
+            .onchange_template_id(False, 'comment', self.default_model,
+                                  self.default_res_id)['value']
         values['partner_ids'] = [(4, self.partner_02.id)]
         compose_id = mail_compose.with_context(ctx).create(values)
         compose_id.autofollow_recipients = False
         compose_id.with_context(ctx).send_mail()
         res = self.env["mail.followers"].search(
-            [('res_model', '=', 'res.partner'),
-             ('res_id', '=', self.partner_01.id),
+            [('res_model', '=', self.default_model),
+             ('res_id', '=', self.default_res_id),
              ('partner_id', '=', self.partner_02.id)])
         # I check if the recipient isn't a follower
         self.assertEqual(len(res.ids), 0)
+        res = self.env["mail.followers"].search(
+            [('res_model', '=', self.default_model),
+             ('res_id', '=', self.default_res_id),
+             ('partner_id', '=', self.env.user.partner_id.id)])
+        # I check if the current user is a follower
+        # (by default with 'mail_create_nosubscribe')
+        self.assertEqual(len(res.ids), 1)
         compose_id = mail_compose.with_context(ctx).create(values)
         compose_id.autofollow_recipients = True
         compose_id.with_context(ctx).send_mail()
         res = self.env["mail.followers"].search(
-            [('res_model', '=', 'res.partner'),
-             ('res_id', '=', self.partner_01.id),
+            [('res_model', '=', self.default_model),
+             ('res_id', '=', self.default_res_id),
              ('partner_id', '=', self.partner_02.id)])
         # I check if the recipient is a follower
         self.assertEqual(len(res.ids), 1)
+
+    def test_send_invoice(self):
+        self.default_model = 'account.invoice'
+        self.default_res_id = self.env.ref(
+            'l10n_generic_coa.demo_invoice_3').id
+        self.test_send_email_attachment()

--- a/mail_optional_autofollow/wizard/account_invoice_send.xml
+++ b/mail_optional_autofollow/wizard/account_invoice_send.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <record model="ir.ui.view" id="email_compose_message_wizard_inherit_form">
-        <field name="name">mail.compose.message.form (mail_optional_autofollow)</field>
-        <field name="model">mail.compose.message</field>
-        <field name="inherit_id" ref="mail.email_compose_message_wizard_form"/>
+
+    <record id="account_invoice_send_wizard_form" model="ir.ui.view">
+        <field name="name">account.invoice.send.form</field>
+        <field name="model">account.invoice.send</field>
+        <field name="inherit_id" ref="account.account_invoice_send_wizard_form"/>
         <field name="arch" type="xml">
             <xpath expr="//div[field[@name='partner_ids']]" position="after">
                 <field name="autofollow_recipients" attrs="{'invisible': [('composition_mode', '=', 'mass_mail')]}"/>
             </xpath>
         </field>
     </record>
+
 </odoo>


### PR DESCRIPTION
Add module feature on the wizard for sending invoices.

Similar to #493 for the improvement part

Bypass this : [https://github.com/OCA/OCB/blob/12.0/addons/account/models/account_invoice.py#L704](https://github.com/OCA/OCB/blob/12.0/addons/account/models/account_invoice.py#L704) !