### PR TITLE
[11.0][IMP] make mail_activity_team and mail_activity_done work together

### DIFF
--- a/mail_activity_done/README.rst
+++ b/mail_activity_done/README.rst
@@ -23,7 +23,7 @@ Mail Activity Done
     :target: https://runbot.odoo-community.org/runbot/205/11.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| |badge5| 
+|badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module implements the capability to keep activities that have been
 completed, for future reporting, by setting them with the boolean 'Done'.
@@ -57,6 +57,7 @@ Contributors
 ~~~~~~~~~~~~
 
 * Jordi Ballester <jordi.ballester@eficent.com> (www.eficent.com)
+* Guenter Selbert <guenter.selbert@sewisoft.de> (sewisoft.de)
 
 Maintainers
 ~~~~~~~~~~~

--- a/mail_activity_done/__manifest__.py
+++ b/mail_activity_done/__manifest__.py
@@ -2,7 +2,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 {
     "name": "Mail Activity Done",
-    "version": "11.0.2.0.0",
+    "version": "11.0.3.0.0",
     "author": "Eficent,"
               "Odoo Community Association (OCA)",
     "license": "LGPL-3",

--- a/mail_activity_done/models/mail_activity.py
+++ b/mail_activity_done/models/mail_activity.py
@@ -23,7 +23,6 @@ class MailActivity(models.Model):
 
 
 class MailActivityMixin(models.AbstractModel):
-
     _inherit = 'mail.activity.mixin'
     activity_ids = fields.One2many(
         domain=lambda self: [('res_model', '=', self._name),

--- a/mail_activity_done/readme/CONTRIBUTORS.rst
+++ b/mail_activity_done/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Jordi Ballester <jordi.ballester@eficent.com> (www.eficent.com)
+* Guenter Selbert <guenter.selbert@sewisoft.de> (sewisoft.de)

--- a/mail_activity_done/static/description/index.html
+++ b/mail_activity_done/static/description/index.html
@@ -403,6 +403,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#id4">Contributors</a></h2>
 <ul class="simple">
 <li>Jordi Ballester &lt;<a class="reference external" href="mailto:jordi.ballester&#64;eficent.com">jordi.ballester&#64;eficent.com</a>&gt; (www.eficent.com)</li>
+<li>Guenter Selbert &lt;<a class="reference external" href="mailto:guenter.selbert&#64;sewisoft.de">guenter.selbert&#64;sewisoft.de</a>&gt; (sewisoft.de)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/mail_activity_team/README.rst
+++ b/mail_activity_team/README.rst
@@ -23,7 +23,7 @@ Mail Activity Team
     :target: https://runbot.odoo-community.org/runbot/205/11.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| |badge5| 
+|badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module adds the possibility to assign teams to activities.
 
@@ -81,6 +81,8 @@ Contributors
   * Jordi Ballester Alomar (jordi.ballester@eficent.com)
 
 * Enric Tobella <etobella@creublanca.es>
+
+* Guenter Selbert (guenter.selbert@sewisoft.de)
 
 Maintainers
 ~~~~~~~~~~~

--- a/mail_activity_team/models/res_users.py
+++ b/mail_activity_team/models/res_users.py
@@ -34,6 +34,10 @@ class ResUsers(models.Model):
                             )
                             GROUP BY m.id, states, act.res_model, act.user_id;
                             """
+        if 'active' in self.env['mail.activity']._fields:
+            query = query.replace("WHERE team_id in",
+                                  "WHERE act.active = true AND team_id in")
+
         user = user_id if user_id else self.env.uid
         self.env.cr.execute(query, {
             'today': fields.Date.context_today(self),

--- a/mail_activity_team/readme/CONTRIBUTORS.rst
+++ b/mail_activity_team/readme/CONTRIBUTORS.rst
@@ -3,3 +3,5 @@
   * Jordi Ballester Alomar (jordi.ballester@eficent.com)
 
 * Enric Tobella <etobella@creublanca.es>
+
+* Guenter Selbert <guenter.selbert@sewisoft.de>

--- a/mail_activity_team/static/description/index.html
+++ b/mail_activity_team/static/description/index.html
@@ -424,6 +424,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </li>
 <li>Enric Tobella &lt;<a class="reference external" href="mailto:etobella&#64;creublanca.es">etobella&#64;creublanca.es</a>&gt;</li>
+<li>Guenter Selbert <<a class="reference external" href="mailto:guenter.selbert&#64;sewisoft.de">guenter.selbert&#64;sewisoft.de</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
as the title says, both modules are not really good work together, because of the bad code of the odoo core. 

FIXES: 
- Hide done/archived team activities at the counter tray
- Updates the tray counter after changing an team activity to done 