### PR TITLE
[11.0][FIX][IMP] mail_activity_team 

### DIFF
--- a/mail_activity_team/__manifest__.py
+++ b/mail_activity_team/__manifest__.py
@@ -25,5 +25,6 @@
 
     'qweb': [
         'static/src/xml/systray.xml',
+        'static/src/xml/activity.xml',
     ],
 }

--- a/mail_activity_team/models/__init__.py
+++ b/mail_activity_team/models/__init__.py
@@ -3,3 +3,4 @@ from . import mail_activity
 from . import res_users
 from . import mail_activity_mixin
 from . import calendar_event
+from . import mail_thread

--- a/mail_activity_team/models/mail_activity_mixin.py
+++ b/mail_activity_team/models/mail_activity_mixin.py
@@ -7,7 +7,7 @@ class MailActivityMixin(models.AbstractModel):
     _inherit = 'mail.activity.mixin'
 
     activity_team_user_ids = fields.Many2many(
-        comodel_name='res.users', string='test field',
+        comodel_name='res.users', string='Responsible Members',
         compute="_compute_activity_team_user_ids",
         search="_search_activity_team_user_ids",
     )

--- a/mail_activity_team/models/mail_thread.py
+++ b/mail_activity_team/models/mail_thread.py
@@ -1,0 +1,20 @@
+# Copyright 2020 sewisoft, guenter.selbert
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+
+
+class MailThread(models.AbstractModel):
+    _inherit = 'mail.thread'
+
+    @api.multi
+    def message_subscribe(self, partner_ids=None, channel_ids=None, subtype_ids=None,
+                          force=True):
+        """ filter none """
+        if partner_ids:
+            partner_ids = [pid for pid in partner_ids if pid]
+        return super().message_subscribe(
+            partner_ids=partner_ids,
+            channel_ids=channel_ids,
+            subtype_ids=subtype_ids,
+            force=force
+        )

--- a/mail_activity_team/static/src/xml/activity.xml
+++ b/mail_activity_team/static/src/xml/activity.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-extend="mail.activity_items">
+         <t t-jquery="t[t-esc='activity.user_id[1]']" t-operation="after">
+                    <t t-if="activity.team_id and activity.user_id"> / </t>
+             <t t-if="activity.team_id" t-esc="activity.team_id[1]"/>
+         </t>
+    </t>
+
+</templates>


### PR DESCRIPTION
NOTE: To apply additional PR for social repo I had to close #504 and apply the changes by this PR.

**FIX:**
When installing mail_activity_team without non depending module mail_restrict_follower_selection, an error (A follower must be either a partner or a channel (but not both)) will be shown when creating an activity without a user.
![image](https://user-images.githubusercontent.com/24382867/75960016-9d5b6b00-5ebf-11ea-9abf-c87fd2426e96.png)

**Improvements:**

Show team name on activties in chatter
Update team members activity tray on activity creation or modification
