### PR TITLE
[13.0][FIX] mass_mailing_partner: Unsubscribe should not unlink the subscription.

### DIFF
--- a/mass_mailing_partner/README.rst
+++ b/mass_mailing_partner/README.rst
@@ -23,7 +23,7 @@ Link partners with mass-mailing
     :target: https://runbot.odoo-community.org/runbot/205/13.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| |badge5| 
+|badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module links mass-mailing contacts with partners.
 

--- a/mass_mailing_partner/models/mailing_contact.py
+++ b/mass_mailing_partner/models/mailing_contact.py
@@ -3,6 +3,7 @@
 # Copyright 2015 Javier Iniesta <javieria@antiun.com>
 # Copyright 2017 David Vidal <david.vidal@tecnativa.com>
 # Copyright 2020 Tecnativa - Manuel Calero
+# Copyright 2020 Hibou Corp.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import _, api, fields, models
@@ -51,8 +52,8 @@ class MailingContact(models.Model):
         record._onchange_partner_mass_mailing_partner()
         new_vals = record._convert_to_write(record._cache)
         new_vals.update(
-            subscription_list_ids=vals.get("subscription_list_ids", False),
-            list_ids=vals.get("list_ids", False),
+            subscription_list_ids=vals.get("subscription_list_ids", []),
+            list_ids=vals.get("list_ids", []),
         )
         return super(MailingContact, self).create(new_vals)
 
@@ -65,8 +66,8 @@ class MailingContact(models.Model):
             record._onchange_partner_mass_mailing_partner()
             new_vals = record._convert_to_write(record._cache)
             new_vals.update(
-                subscription_list_ids=vals.get("subscription_list_ids", False),
-                list_ids=vals.get("list_ids", False),
+                subscription_list_ids=vals.get("subscription_list_ids", []),
+                list_ids=vals.get("list_ids", []),
             )
             super(MailingContact, contact).write(new_vals)
         return True

--- a/mass_mailing_partner/readme/CONTRIBUTORS.rst
+++ b/mass_mailing_partner/readme/CONTRIBUTORS.rst
@@ -9,3 +9,5 @@
     * Ernesto Tejeda
     * Victor M.M. Torres
     * Manuel Calero
+
+* `Hibou Corp. <https://hibou.io>`_


### PR DESCRIPTION
Unsubscribe should not unlink the subscription.

Before, on the backend if you check the `opt_out` checkbox and saving on a `mailing.contact`, the entire row (`mailing.contact.subscription`) would be unlinked.  Combined with `mass_mailing_list_dynamic` this means the contact would just be re-subscribed over and over.

After, check `opt_out` will fill `unsubscription_date` and the row will stay.  Tests in `mass_mailing_list_dynamic` pass. 

Needed for https://github.com/OCA/social/pull/518