### PR TITLE
[13.0][FIX] mail_tracking: do not warn not found if already opened

### DIFF
--- a/mail_tracking/controllers/main.py
+++ b/mail_tracking/controllers/main.py
@@ -81,18 +81,14 @@ class MailTrackingController(MailController):
         with db_env(db) as env:
             try:
                 tracking_email = env["mail.tracking.email"].search(
-                    [
-                        ("id", "=", tracking_email_id),
-                        ("state", "in", ["sent", "delivered"]),
-                        ("token", "=", token),
-                    ]
+                    [("id", "=", tracking_email_id), ("token", "=", token)]
                 )
-                if tracking_email:
-                    tracking_email.event_create("open", metadata)
-                else:
+                if not tracking_email:
                     _logger.warning(
                         "MailTracking email '%s' not found", tracking_email_id
                     )
+                elif tracking_email.state in ("sent", "delivered"):
+                    tracking_email.event_create("open", metadata)
             except Exception:
                 pass
 


### PR DESCRIPTION
The state will be 'opened' after first time email is opened. Each
successive open triggered warning, because state was already 'opened'
and thus did not match domain state in (sent, delivered).

Forward-ported from #d9ad3464

Original PR: #531 