### PR TITLE
email_template_qweb: ease override of values, include defaults

### DIFF
--- a/email_template_qweb/README.rst
+++ b/email_template_qweb/README.rst
@@ -9,7 +9,7 @@ QWeb for email templates
 This module was written to allow you to write email templates in QWeb instead
 of jinja2. The advantage here is that with QWeb, you can make use of
 inheritance and the ``call`` statement, which allows you to reuse designs and
-snippets in multiple templates, making your development process simpler. 
+snippets in multiple templates, making your development process simpler.
 Furthermore, QWeb views are easier to edit with the integrated ACE editor.
 
 Usage
@@ -19,7 +19,24 @@ To use this module, you need to:
 
 #. Select `QWeb` in the field `Body templating engine`
 #. Select a QWeb view to be used to render the body field
-#. Apart from QWeb's standard variables, you also have access to ``object`` and ``email_template``, which are browse records of the current object and the email template in use, respectively.
+
+
+**Variables**
+
+Apart from QWeb's standard variables, you also have access to:
+
+* ``object`` browse record of the current object
+* ``email_template`` browse record of email template in use
+* ``record`` depending on where the message is sent,
+  ``object`` can be either the real record or the mail message used to send the email.
+  In standard J2 templates this variable is available only for messages and only in the ctx.
+  This variable tries to solve this issue and provides always the same variable.
+* ``record_name`` always provide the display name of current record
+* In addition to these, you'll find all the variables available for J2 templates:
+  ``format_date``, ``format_tz``, ``format_amount``, ``user``, ``ctx``.
+  These will make easier to port existing J2 templates to Qweb.
+
+
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
@@ -46,6 +63,7 @@ Contributors
 * Holger Brunn <hbrunn@therp.nl>
 * Dave Lasley <dave@laslabs.com>
 * Carlos Lopez Mite <celm1990@gmail.com>
+* Simone Orsi <simone.orsi@camptocamp.com>
 
 Do not contact contributors directly about support or help with technical issues.
 

--- a/email_template_qweb/models/mail_template.py
+++ b/email_template_qweb/models/mail_template.py
@@ -1,6 +1,9 @@
 # Copyright 2016 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import api, fields, tools, models
+from odoo.addons.mail.models.mail_template import (
+    format_amount, format_date, format_tz
+)
 
 
 class MailTemplate(models.Model):
@@ -26,10 +29,9 @@ class MailTemplate(models.Model):
             if template.body_type == 'qweb' and\
                     (not fields or 'body_html' in fields):
                 for record in self.env[template.model].browse(res_id):
-                    body_html = template.body_view_id.render({
-                        'object': record,
-                        'email_template': template,
-                    })
+                    body_html = template.body_view_id.render(
+                        template._qweb_render_context(record)
+                    )
                     # Some wizards, like when sending a sales order, need this
                     # fix to display accents correctly
                     body_html = tools.ustr(body_html)
@@ -40,3 +42,62 @@ class MailTemplate(models.Model):
                         result[res_id]['body_html']
                     )
         return multi_mode and result or result[res_ids[0]]
+
+    def _qweb_render_context(self, record):
+        """Compute variables to render Qweb templates.
+
+        Some vars are added to ease porting of Jinja templates.
+        """
+        res = {
+            'object': record,
+            'email_template': self,
+        }
+        ctx = dict(self.env.context)
+        if record._name == 'mail.message':
+            partner_model = self.env['res.partner']  # pragma: no cover
+            # These variables are usually loaded when the notification is sent.
+            # It normally happens on `partner._notify` call,
+            # hence - due to the call here - is going to happen twice.
+            # Nevertheless there are some important values
+            # that can be mandatory for your templates
+            # especially if you load them
+            # from the mail composer. In this case
+            # the template will be rendered but it will miss many params.
+            # NOTE: some keys related to partner-specific permissions
+            # such as `actions` or `button_follow` won't be available
+            # until the final rendering happens.
+            # Check the variable `recipient_template_values`
+            # that comes from `_message_notification_recipients`
+            # in `partner._notify`.
+            ctx.update(
+                partner_model._notify_prepare_template_context(
+                    record
+                )
+            )  # pragma: no cover
+        res.update({
+            # Same as for Jinja rendering,
+            # taken from `mail_template.render_template`.
+            # These ease porting of old Jinja templates to qweb ones.
+            'format_date':
+                lambda date, format=False,
+                context=self._context: format_date(self.env, date, format),
+            'format_tz':
+                lambda dt, tz=False, format=False,
+                context=self._context: format_tz(self.env, dt, tz, format),
+            'format_amount':
+                lambda amount, currency,
+                context=self._context: format_amount(
+                    self.env, amount, currency),
+            'user': self.env.user,
+            # keep it for Jinja template compatibility
+            'ctx': ctx,
+        })
+        # Alias `record` to be always the main record needed by the template.
+        # Imagine a template for sale.order: when you load it in the composer
+        # the current `object` is the SO you are looking at,
+        # BUT when you send the message, the `object` is the message
+        # and not the SO anymore.
+        # Hence, stick the main record to `record` to make templates robust.
+        res['record'] = ctx.get('record', record)
+        res['record_name'] = ctx.get('record_name', record.display_name)
+        return res


### PR DESCRIPTION
Improvements:

1. provide hook to override rendering values
2. provide default rendering values as per Jinja templates