### PR TITLE
Fix mail_inline_css transform hook

### DIFF
--- a/mail_inline_css/models/mail_template.py
+++ b/mail_inline_css/models/mail_template.py
@@ -21,19 +21,20 @@ class MailTemplate(models.Model):
         """Use `premailer` to convert styles to inline styles."""
         result = super().generate_email(res_ids, fields=fields)
         if isinstance(res_ids, int):
-            premailer = Premailer(
-                html=result['body_html'],
-                **self._get_premailer_options(),
-            )
-            result['body_html'] = premailer.transform()
+            result['body_html'] = \
+                self._premailer_apply_transform(result["body_html"])
         else:
             for __, data in result.items():
-                premailer = Premailer(
-                    html=data['body_html'],
-                    **self._get_premailer_options(),
-                )
-                data['body_html'] = premailer.transform()
+                data['body_html'] = \
+                    self._premailer_apply_transform(data["body_html"])
         return result
+
+    def _premailer_apply_transform(self, data_html):
+        premailer = Premailer(
+            html=data_html,
+            **self._get_premailer_options(),
+        )
+        return premailer.transform()
 
     def _get_premailer_options(self):
         return {}

--- a/mail_inline_css/models/mail_template.py
+++ b/mail_inline_css/models/mail_template.py
@@ -3,7 +3,7 @@
 
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, models
+from odoo import models
 
 try:
     from premailer import Premailer
@@ -16,22 +16,15 @@ except (ImportError, IOError) as err:  # pragma: no cover
 class MailTemplate(models.Model):
     _inherit = 'mail.template'
 
-    @api.multi
-    def generate_email(self, res_ids, fields=None):
-        """Use `premailer` to convert styles to inline styles."""
-        result = super().generate_email(res_ids, fields=fields)
-        if isinstance(res_ids, int):
-            result['body_html'] = \
-                self._premailer_apply_transform(result["body_html"])
-        else:
-            for __, data in result.items():
-                data['body_html'] = \
-                    self._premailer_apply_transform(data["body_html"])
-        return result
+    def render_post_process(self, html):
+        html = super().render_post_process(html)
+        return self._premailer_apply_transform(html)
 
-    def _premailer_apply_transform(self, data_html):
+    def _premailer_apply_transform(self, html):
+        if not html.strip():
+            return html
         premailer = Premailer(
-            html=data_html,
+            html=html,
             **self._get_premailer_options(),
         )
         return premailer.transform()


### PR DESCRIPTION
The mail module offers a better hook to manipulate html: `render_post_process`.
By using this, we make sure the transform is applied properly
before html tags sanitizing happens,
which can alter - if not screw - the final result.

Finally, it simplifies code :)

Previous commit is a backport from v12 https://github.com/OCA/social/commit/0d68d9dee422befd2e3c1f48d038e1476a3c56ea