### PR TITLE
[12.0][IMP] mail_tracking: ignore catchall

### DIFF
--- a/mail_restrict_follower_selection/models/mail_thread.py
+++ b/mail_restrict_follower_selection/models/mail_thread.py
@@ -1,4 +1,5 @@
 from odoo import api, models
+from odoo.tools import config
 from odoo.tools.safe_eval import safe_eval
 
 
@@ -10,6 +11,11 @@ class MailThread(models.AbstractModel):
             self, result, partner=None, email=None, reason=''):
         result = super(MailThread, self)._message_add_suggested_recipient(
             result, partner=partner, email=email, reason=reason)
+        test_condition = config["test_enable"] and not self.env.context.get(
+            "test_restrict_follower"
+        )
+        if test_condition or self.env.context.get("no_restrict_follower"):
+            return result
         domain = self.env[
             'mail.wizard.invite'
         ]._mail_restrict_follower_selection_get_domain()

--- a/mail_tracking/models/__init__.py
+++ b/mail_tracking/models/__init__.py
@@ -10,3 +10,4 @@ from . import res_partner
 from . import mail_thread
 from . import mail_resend_message
 from . import mail_alias
+from . import ir_config_parameter

--- a/mail_tracking/models/ir_config_parameter.py
+++ b/mail_tracking/models/ir_config_parameter.py
@@ -1,0 +1,26 @@
+# Copyright 2020 Tecnativa - Alexandre Díaz
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, api
+
+
+class IrConfigParameter(models.Model):
+    _inherit = 'ir.config_parameter'
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        self.env['mail.alias'].clear_caches()
+        return res
+
+    @api.multi
+    def write(self, vals):
+        res = super().write(vals)
+        self.env['mail.alias'].clear_caches()
+        return res
+
+    @api.multi
+    def unlink(self):
+        res = super().unlink()
+        self.env['mail.alias'].clear_caches()
+        return res

--- a/mail_tracking/models/mail_alias.py
+++ b/mail_tracking/models/mail_alias.py
@@ -10,9 +10,15 @@ class MailAlias(models.Model):
     @api.model
     @tools.ormcache()
     def get_aliases(self):
-        return set(x['display_name'] for x in self.search_read([
+        aliases = set(x['display_name'] for x in self.search_read([
             ('alias_name', '!=', False),
         ], ['display_name']))
+        IrConfigParamObj = self.env["ir.config_parameter"].sudo()
+        catchall = "%s@%s" % (
+            IrConfigParamObj.get_param("mail.catchall.alias"),
+            IrConfigParamObj.get_param("mail.catchall.domain"))
+        aliases.add(catchall)
+        return aliases
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/mail_tracking/tests/test_mail_tracking.py
+++ b/mail_tracking/tests/test_mail_tracking.py
@@ -179,7 +179,7 @@ class TestMailTracking(TransactionCase):
             email[1] for email in recipients[self.recipient.id]
         }
         self.assertIn('unnamed@test.com', suggested_mails)
-        self.assertEqual(len(recipients[self.recipient.id][0]), 3)
+        self.assertEqual(len(recipients[self.recipient.id]), 3)
         # Repeated Cc recipients
         message = self.env['mail.message'].create({
             'subject': 'Message test',
@@ -195,12 +195,12 @@ class TestMailTracking(TransactionCase):
         })
         message._notify(message, {}, force_send=True)
         recipients = self.recipient.message_get_suggested_recipients()
-        self.assertEqual(len(recipients[self.recipient.id][0]), 3)
+        self.assertEqual(len(recipients[self.recipient.id]), 3)
         self._check_partner_trackings_cc(message)
 
     def _check_partner_trackings_to(self, message):
         message_dict = message.message_format()[0]
-        self.assertEqual(len(message_dict['partner_trackings']), 3)
+        self.assertEqual(len(message_dict['partner_trackings']), 4)
         # mail cc
         foundPartner = False
         foundNoPartner = False
@@ -241,16 +241,18 @@ class TestMailTracking(TransactionCase):
             'res_id': self.recipient.id,
             'partner_ids': [(4, self.recipient.id)],
             'email_to': 'Dominique Pinon <support+unnamed@test.com>'
-                        ', sender@example.com, recipient@example.com',
+                        ', sender@example.com, recipient@example.com'
+                        ', TheCatchall@test.com',
             'body': '<p>This is another test message</p>',
         })
         message._notify(message, {}, force_send=True)
         recipients = self.recipient.message_get_suggested_recipients()
-        self.assertEqual(len(recipients[self.recipient.id][0]), 3)
+        self.assertEqual(len(recipients[self.recipient.id]), 4)
         self._check_partner_trackings_to(message)
         # Catchall + Alias
-        self.env['ir.config_parameter'].set_param(
-            'mail.catchall.domain', 'test.com')
+        IrConfigParamObj = self.env["ir.config_parameter"].sudo()
+        IrConfigParamObj.set_param("mail.catchall.alias", "TheCatchall")
+        IrConfigParamObj.set_param('mail.catchall.domain', 'test.com')
         self.env['mail.alias'].create({
             'alias_model_id': self.env['ir.model']._get('res.partner').id,
             'alias_name': 'support+unnamed',


### PR DESCRIPTION
- Improve tests
- Ignore catchall from suggested recipients

cc @tecnativa @rafaelbn
**Needs to be ported to 13.0**