### PR TITLE
[13.0][FIX] mail_inline_css: deafult value for lang

### DIFF
--- a/mail_inline_css/__manifest__.py
+++ b/mail_inline_css/__manifest__.py
@@ -13,5 +13,6 @@
     "installable": True,
     "external_dependencies": {"python": ["premailer"]},
     "depends": ["email_template_qweb"],
+    "data": ["views/email_preview.xml"],
     "demo": ["demo/demo_template.xml", "demo/demo_mail_template.xml"],
 }

--- a/mail_inline_css/views/email_preview.xml
+++ b/mail_inline_css/views/email_preview.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <record model="ir.ui.view" id="email_template_preview_form">
+    <field name="model">mail.template</field>
+    <field name="inherit_id" ref="mail.email_template_form" />
+    <field name="arch" type="xml">
+        <!-- inject default value for lang to prevent call to generate_email method in
+        default_get of the wizard-->
+        <xpath expr="//button[@name='%(mail.wizard_email_template_preview)d']" position="attributes">
+            <attribute name="context">{'template_id':active_id, 'default_preview_lang': context['lang']}</attribute>
+        </xpath>
+
+    </field>
+  </record>
+</odoo>


### PR DESCRIPTION
email.preview.wizard raises an error when [initializing values](https://github.com/odoo/odoo/blob/aba0b299243c3d9b4615e1066d641aa8360aabac/addons/mail/wizard/email_template_preview.py#L38) for lang, replacing of "body_html" field is failing as it not there yet, it will appear when [onchange](https://github.com/odoo/odoo/blob/aba0b299243c3d9b4615e1066d641aa8360aabac/addons/mail/wizard/email_template_preview.py#L47) method for 'lang' will be called 