### PR TITLE
[12.0][FIX] mass_mailing_custom_unsubscribe: mailing contact contains `opt_out`

### DIFF
--- a/mass_mailing_custom_unsubscribe/controllers/main.py
+++ b/mass_mailing_custom_unsubscribe/controllers/main.py
@@ -58,7 +58,8 @@ class CustomUnsubscribe(MassMailController):
             mailing_obj = request.env['mail.mass_mailing']
             mass_mailing = mailing_obj.sudo().browse(mailing_id)
             model = mass_mailing.mailing_model_real
-            if "opt_out" in request.env[model]._fields:
+            if ("opt_out" in request.env[model]._fields and
+                    model != "mail.mass_mailing.contact"):
                 mass_mailing.update_opt_out_other(email, [res_id], True)
                 result = request.render("mass_mailing.page_unsubscribed", {
                     "email": email,


### PR DESCRIPTION
So we need to explicitly opt-out (:rofl:) that model from the new alternative mechanism for unsubscribing records.

@Tecnativa TT24523