### PR TITLE
[10.0][FIX] travis: set premailer version fixe to last compatible with python2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-premailer
+premailer==3.6.2
 sendgrid<v6.0.0


### PR DESCRIPTION
Original #567 error is probably related to this