### PR TITLE
[12.0][FIX] mass_mailing_list_dynamic: list sync on send

### DIFF
--- a/mass_mailing_list_dynamic/models/mail_mass_mailing.py
+++ b/mass_mailing_list_dynamic/models/mail_mass_mailing.py
@@ -7,7 +7,9 @@ from odoo import models
 class MassMailing(models.Model):
     _inherit = "mail.mass_mailing"
 
-    def send_mail(self):
-        """Sync dynamic lists before sending mailings to them."""
+    def get_remaining_recipients(self):
+        """When evaluating remaining recipients we must resync the list in
+           advance to avoid missing recipients due to domain change or new
+           partners fitting into the conditions"""
         self.contact_list_ids.action_sync()
-        return super().send_mail()
+        return super().get_remaining_recipients()


### PR DESCRIPTION
- We change the method to hook on (it wasn't correctly overriden anyway)
to ensure the list is resynced even if no recipients are left. For
example: we create a dynamic list with a domain expecting it to sync in
the first mass_mailing. It wouldn't sync as Odoo dismisses the mailing
considering no recipients are left thus it wouldn't get into the
`send_mail` method.

cc @Tecnativa TT24723