### PR TITLE
[12.0][FIX] mail_tracking: performance fix

### DIFF
--- a/mail_tracking/models/mail_message.py
+++ b/mail_tracking/models/mail_message.py
@@ -18,6 +18,7 @@ class MailMessage(models.Model):
         comodel_name='mail.tracking.email',
         inverse_name='mail_message_id',
         string="Mail Trackings",
+        auto_join=True,
     )
     mail_tracking_needs_action = fields.Boolean(
         help="The message tracking will be considered"


### PR DESCRIPTION
When searching for failed messages, [this line][1] made Odoo search messages in 2 steps:

1. Find which `mail.tracking.email` records are in those states.
2. Find which of them belong to the present `mail.message` records.

Step 2 could take a long time if there were a lot of failures in a DB. In our proven case, this made loading the `res.partner` form view take about ~6s per partner. It was also slowing down other views.

With this simple fix, [that nasty line linked above][1] is solved with just one query like this:

```SQL
SELECT "mail_message".id FROM "mail_tracking_email" as "mail_message__mail_tracking_ids","mail_message"
WHERE ("mail_message"."id"="mail_message__mail_tracking_ids"."maiL_message_id") AND (((("mail_message"."model" = 'res.partner')  AND ("mail_message"."mail_tracking_needs_action" = true))  AND  ("mail_message__mail_tracking_ids"."state" in ('rejected','error','bounced','soft-bounced','spam')))  AND  ("mail_message"."res_id" in (1000)))
ORDER BY "mail_message"."id" DESC
```

Thus this makes the forms load at normal speed again.

[1]: https://github.com/OCA/social/blob/8bd98212b8d04aa3de82e9f51063b9d185ac0f1c/mail_tracking/models/mail_thread.py#L25

TT24805