### PR TITLE
Fix issue on empty template with premailer

### DIFF
--- a/mail_inline_css/models/mail_template.py
+++ b/mail_inline_css/models/mail_template.py
@@ -28,6 +28,8 @@ class MailTemplate(models.Model):
         return result
 
     def _premailer_apply_transform(self, data_html):
+        if not data_html:
+            return data_html
         premailer = Premailer(html=data_html, **self._get_premailer_options())
         return premailer.transform()
 


### PR DESCRIPTION
If premailer receives an empty value, such as an empty string,
on parsing, it returns None and fails when trying to call
'etree.fromstring()' on this None result.

We should avoid to call premailer on an empty string, as the result
will anyway not change.

We may have an empty template for instance when a template could not
compile due to a mistake.