### PR TITLE
[12.0][FIX] mass_mailing_resend: Incorrect warning text

### DIFF
--- a/mass_mailing_resend/__manifest__.py
+++ b/mass_mailing_resend/__manifest__.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 Tecnativa - Pedro M. Baeza
+# Copyright 2017-2020 Tecnativa - Pedro M. Baeza
 # Copyright 2018 Tecnativa - Ernesto Tejeda
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/mass_mailing_resend/i18n/es.po
+++ b/mass_mailing_resend/i18n/es.po
@@ -21,13 +21,11 @@ msgstr ""
 msgid ""
 "<i class=\"fa fa-info-circle\"/> New sending will be done only to not sent/"
 "new recipients. If you want to resend again the mass mailing to already sent "
-"recipients, click on <b>Emails Sent</b> smart-button for removing the "
-"existing record(s)."
+"recipients, you have to duplicate this mailing."
 msgstr ""
 "<i class=\"fa fa-info-circle\"/> El nuevo envío se realizará solo a los "
 "destinatarios no enviados/nuevos. Si quiere reenviar otra vez el correo "
-"masivo a destinatarios ya enviados, pulse en el botón <b>Correos enviados</"
-"b> para eliminar el/los registro/s existentes."
+"masivo a destinatarios ya enviados, debe duplicar el envío."
 
 #. module: mass_mailing_resend
 #: model:ir.model,name:mass_mailing_resend.model_mail_mass_mailing

--- a/mass_mailing_resend/i18n/mass_mailing_resend.pot
+++ b/mass_mailing_resend/i18n/mass_mailing_resend.pot
@@ -15,7 +15,7 @@ msgstr ""
 
 #. module: mass_mailing_resend
 #: model_terms:ir.ui.view,arch_db:mass_mailing_resend.view_mail_mass_mailing_form
-msgid "<i class=\"fa fa-info-circle\"/> New sending will be done only to not sent/new recipients. If you want to resend again the mass mailing to already sent recipients, click on <b>Emails Sent</b> smart-button for removing the existing record(s)."
+msgid "<i class=\"fa fa-info-circle\"/> New sending will be done only to not sent/new recipients. If you want to resend again the mass mailing to already sent recipients, you have to duplicate this mailing."
 msgstr ""
 
 #. module: mass_mailing_resend
@@ -33,4 +33,3 @@ msgstr ""
 #, python-format
 msgid "You can't resend a mass mailing that is being sent or in draft state."
 msgstr ""
-

--- a/mass_mailing_resend/views/mass_mailing_views.xml
+++ b/mass_mailing_resend/views/mass_mailing_views.xml
@@ -15,7 +15,7 @@
             <header position="after">
                 <div class="oe_form_box_info bg-warning oe_text_center" attrs="{'invisible': ['|', ('state', '!=', 'draft'), ('sent', '=', 0)]}">
                     <p>
-                        <i class="fa fa-info-circle"/> New sending will be done only to not sent/new recipients. If you want to resend again the mass mailing to already sent recipients, click on <b>Emails Sent</b> smart-button for removing the existing record(s).
+                        <i class="fa fa-info-circle"/> New sending will be done only to not sent/new recipients. If you want to resend again the mass mailing to already sent recipients, you have to duplicate this mailing.
                     </p>
                 </div>
             </header>


### PR DESCRIPTION
It's not possible anymore to remove mass mailing stats for tricking the system to send the same mailing to the already sent recipients, which is, on the other hand, something not healthy for traceability purposes, so this limitation will continue.

We only change then the warning message for being correct in the statement.

@Tecnativa TT25325