### PR TITLE
[FIX] body_html is not added by the mail composer

### DIFF
--- a/mail_inline_css/models/mail_template.py
+++ b/mail_inline_css/models/mail_template.py
@@ -19,6 +19,8 @@ class MailTemplate(models.Model):
 
     def generate_email(self, res_ids, fields=None):
         """Use `premailer` to convert styles to inline styles."""
+        if "body_html" not in fields:
+            fields.append("body_html")
         result = super().generate_email(res_ids, fields=fields)
         if isinstance(res_ids, int):
             result["body_html"] = self._premailer_apply_transform(result["body_html"])


### PR DESCRIPTION
* Purpose
The mail composer do not add body_html , we must add it in the fields that is required in the result