### PR TITLE
[IMP] mail_optional_autofollow: add autofollow option on chatter composer

### DIFF
--- a/mail_optional_autofollow/__manifest__.py
+++ b/mail_optional_autofollow/__manifest__.py
@@ -16,6 +16,10 @@
     ],
     'data': [
         'wizard/mail_compose_message_view.xml',
+        'views/assets.xml',
+    ],
+    'qweb': [
+        'static/src/xml/chatter.xml',
     ],
     'installable': True,
 }

--- a/mail_optional_autofollow/static/src/js/chatter_composer_no_autofollow.js
+++ b/mail_optional_autofollow/static/src/js/chatter_composer_no_autofollow.js
@@ -1,0 +1,26 @@
+odoo.define('no_autofollow.composer', function (require) {
+    "use strict";
+    var ChatterComposer = require('mail.composer.Chatter');
+
+    ChatterComposer.include({
+        init: function (parent, model, suggested_partners, options) {
+            this._super(parent, model, suggested_partners, options);
+            this.mail_post_autofollow = this._init_autofollow();
+            this.context["mail_post_autofollow"] = this.mail_post_autofollow;
+        },
+        events: _.extend(ChatterComposer.prototype.events, {
+            'click .o_composer_no_autofollow': 'on_autofollow_click',
+        }),
+        _init_autofollow: function () {
+            return Boolean(this.context["mail_post_autofollow"]);
+        },
+        _get_autofollow: function () {
+            return Boolean(this.$('.o_composer_no_autofollow input:checked').length);
+        },
+        on_autofollow_click: function (event) {
+            this.mail_post_autofollow = this._get_autofollow();
+            this.context["mail_post_autofollow"] = this.mail_post_autofollow;
+        },
+    });
+
+});

--- a/mail_optional_autofollow/static/src/xml/chatter.xml
+++ b/mail_optional_autofollow/static/src/xml/chatter.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates id="no_autofollow" xml:space="preserve">
+<!--                   class="o_composer_no_autofollow_checkbox custom-control-input"-->
+    <t t-extend="mail.chatter.Composer">
+        <t t-jquery=".o_composer_suggested_partners" t-operation="after">
+            <div class="o_composer_no_autofollow custom-control custom-checkbox">
+                <input type="checkbox"
+                   t-attf-id="no_autofollow_checkbox"
+                   class="custom-control-input"
+                   t-att-checked="widget.mail_post_autofollow? 'checked': undefined"
+                />
+                <label
+                    t-attf-for="no_autofollow_checkbox"
+                    class="o_composer_no_autofollow_label custom-control-label"
+                >
+                    Autofollow recipients
+                </label>
+            </div>
+        </t>
+    </t>
+
+</templates>

--- a/mail_optional_autofollow/views/assets.xml
+++ b/mail_optional_autofollow/views/assets.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <template
+            id="assets_backend"
+            name="no_autofollow assets"
+            inherit_id="web.assets_backend"
+        >
+            <xpath expr="." position="inside">
+                <script
+                    type="text/javascript"
+                    src="/mail_optional_autofollow/static/src/js/chatter_composer_no_autofollow.js"
+                />
+            </xpath>
+        </template>
+
+    </data>
+</odoo>


### PR DESCRIPTION
This PR adds an "autofollow recipients" checkbox on the chatter composer.
Because mail_tracking adds the additional recipients (in CCs and such) as suggested partners,
these would end up as followers when they are replied to.
With this commit it is possible to not add them as followers from the standard composer.

Note that whatever the autofollow value on the chatter composer, the composer will end up with
autofollow set to true. 
This is because the standard always pass autofollow to true in the context: 
https://github.com/acsone/odoo/blob/047e2b28de4653f11e097e6232d7fb79d54ce3af/addons/mail/static/src/js/composers/chatter_composer.js#L270
without giving any hook to modify this behaviour.

It is probably best to live with this inconsistency, as there does not seem to be any decent way to solve it.
![autofollow](https://user-images.githubusercontent.com/35492570/96263268-1a58d200-0fc3-11eb-862d-61beac0f0ec7.png)
