### PR TITLE
[13.0][FIX] base_search_mail_content: Don't fail on views with searchpanel

### DIFF
--- a/base_search_mail_content/models/mail_thread.py
+++ b/base_search_mail_content/models/mail_thread.py
@@ -50,8 +50,7 @@ class MailThread(models.AbstractModel):
             res["fields"].update(
                 {"message_content": {"type": "char", "string": _("Message Content")}}
             )
-
-            for node in doc.xpath("//field[last()]"):
+            for node in doc.xpath("/search/field[last()]"):
                 # Add message_content in search view
                 elem = etree.Element("field", {"name": "message_content"})
                 node.addnext(elem)


### PR DESCRIPTION
On views with a searchpanel, xpath `//field[last()]` may select an element inside the search panel, provoking the error "Only types ['many2one'] are supported for category (found type text)".

This fix uses an stricter xpath for avoiding this situation.

Fixes #603 

@Tecnativa TT25796