### PR TITLE
[FIX] extract-msg: Error in version 0.27.6, define max version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # mail_inline_css
 premailer
-extract-msg
+extract-msg<=0.27.4

--- a/setup/mail_drop_target/setup.py
+++ b/setup/mail_drop_target/setup.py
@@ -3,4 +3,7 @@ import setuptools
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
     odoo_addon=True,
+    install_requires=[
+        'extract-msg<=0.27.4'
+    ]
 )


### PR DESCRIPTION
Error in last version of extract-msg dependency 0.27.6 (https://pypi.org/project/extract-msg/0.27.6/) and 0.27.5.
Define max version in requirements.txt about it.

Please, @pedrobaeza  @joao-p-marques review it.

@Tecnativa TT26362