### PR TITLE
[12.0][FIX] mass_mailing_partner: partner merge

### DIFF
--- a/mass_mailing_partner/readme/CONTRIBUTORS.rst
+++ b/mass_mailing_partner/readme/CONTRIBUTORS.rst
@@ -8,3 +8,4 @@
     * David Vidal
     * Ernesto Tejeda
     * Victor M.M. Torres
+    * Victor Martínez

--- a/mass_mailing_partner/tests/test_mail_mass_mailing_contact.py
+++ b/mass_mailing_partner/tests/test_mail_mass_mailing_contact.py
@@ -93,3 +93,45 @@ class MailMassMailingContactCase(base.BaseCase):
             contact.partner_id = partner
             contact._onchange_partner_mass_mailing_partner()
             self.check_mailing_contact_partner(contact)
+
+    def test_partners_merge(self):
+        partner_1 = self.create_partner({
+            'name': 'Demo 1',
+            'email': 'demo1@demo.com'
+        })
+        partner_2 = self.create_partner({
+            'name': 'Demo 2',
+            'email': 'demo2@demo.com'
+        })
+        list_1 = self.create_mailing_list({
+            'name': 'List test 1'
+        })
+        list_2 = self.create_mailing_list({
+            'name': 'List test 2'
+        })
+        contact_1 = self.create_mailing_contact(
+            {
+                'email': partner_1.email,
+                'name': partner_1.name,
+                'partner_id': partner_1.id,
+                'list_ids': [(6, 0, [list_1.id])]
+            }
+        )
+        contact_2 = self.create_mailing_contact(
+            {
+                'email': partner_2.email,
+                'name': partner_2.name,
+                'partner_id': partner_2.id,
+                'list_ids': [(6, 0, [list_1.id, list_2.id])]
+            }
+        )
+        # Wizard partner merge (partner_1 + partner_2) in partner_i1
+        wizard = self.env['base.partner.merge.automatic.wizard'].create({
+            'state': 'option'
+        })
+        wizard._merge((partner_1 + partner_2).ids, partner_1)
+        contact = self.env['mail.mass_mailing.contact'].search([
+            ('id', 'in', (contact_1 + contact_2).ids)
+        ])
+        self.assertEqual(len(contact), 1)
+        self.assertEqual(contact.list_ids.ids, (list_1 + list_2).ids)

--- a/mass_mailing_partner/wizard/__init__.py
+++ b/mass_mailing_partner/wizard/__init__.py
@@ -4,3 +4,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import partner_mail_list_wizard
+from . import partner_merge

--- a/mass_mailing_partner/wizard/partner_merge.py
+++ b/mass_mailing_partner/wizard/partner_merge.py
@@ -1,0 +1,24 @@
+# Copyright 2020 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class BasePartnerMergeAutomaticWizard(models.TransientModel):
+    _inherit = "base.partner.merge.automatic.wizard"
+
+    def _merge(self, partner_ids, dst_partner=None, extra_checks=True):
+        if dst_partner:
+            contact_ids = self.env['mail.mass_mailing.contact'].search([
+                ('partner_id', 'in', partner_ids)
+            ])
+            if contact_ids:
+                contact_ids.sorted(lambda x: 1 if x.partner_id == dst_partner else 0)
+                contact_ids[0].partner_id = dst_partner
+                contact_ids[0].list_ids = [
+                    (4, x) for x in contact_ids.mapped('list_ids').ids
+                ]
+                contact_ids[1:].unlink()
+        return super()._merge(
+            partner_ids, dst_partner=dst_partner, extra_checks=extra_checks,
+        )


### PR DESCRIPTION
Solved error related to merge contacts (in update records related to partners, exists multiple mailing contact related to same partner).

**Reproduce error**
Create partner A > Add to mailing list A
Create partner B > Add to mailing list A + B
Merge partner A + B into A

**Expected result**:
Record related to Partner A > Mailing list A + B

Result (with errors):
Record related to Partner A > Mailing list A
Record related to Partner A > Mailing list A + B

@Tecnativa TT26380