### PR TITLE
[13] [FIX] suggested restrict followers for a model

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
   - id: mixed-line-ending
     args: ["--fix=lf"]
 - repo: https://github.com/pre-commit/mirrors-pylint
-  rev: v2.3.1
+  rev: v2.5.3
   hooks:
   - id: pylint
     name: pylint with optional checks

--- a/mail_restrict_follower_selection/models/mail_followers.py
+++ b/mail_restrict_follower_selection/models/mail_followers.py
@@ -20,11 +20,10 @@ class MailFollowers(models.Model):
         existing_policy="skip",
     ):
         domain = self.env[
-            'mail.wizard.invite'
+            "mail.wizard.invite"
         ]._mail_restrict_follower_selection_get_domain(res_model=res_model)
-        partners = self.env['res.partner'].search(
-            [('id', 'in', partner_ids)] +
-            safe_eval(domain)
+        partners = self.env["res.partner"].search(
+            [("id", "in", partner_ids)] + safe_eval(domain)
         )
         _res_ids = res_ids.copy() or [0]
         new, update = super()._add_followers(

--- a/mail_restrict_follower_selection/models/mail_followers.py
+++ b/mail_restrict_follower_selection/models/mail_followers.py
@@ -20,10 +20,11 @@ class MailFollowers(models.Model):
         existing_policy="skip",
     ):
         domain = self.env[
-            "mail.wizard.invite"
-        ]._mail_restrict_follower_selection_get_domain()
-        partners = self.env["res.partner"].search(
-            [("id", "in", partner_ids)] + safe_eval(domain)
+            'mail.wizard.invite'
+        ]._mail_restrict_follower_selection_get_domain(res_model=res_model)
+        partners = self.env['res.partner'].search(
+            [('id', 'in', partner_ids)] +
+            safe_eval(domain)
         )
         _res_ids = res_ids.copy() or [0]
         new, update = super()._add_followers(

--- a/mail_restrict_follower_selection/models/mail_wizard_invite.py
+++ b/mail_restrict_follower_selection/models/mail_wizard_invite.py
@@ -13,13 +13,17 @@ class MailWizardInvite(models.TransientModel):
     @api.model
     def _mail_restrict_follower_selection_get_domain(self, res_model=None):
         if not res_model:
-            res_model = self.env.context.get('default_res_model')
-        parameter_name = 'mail_restrict_follower_selection.domain'
-        return self.env['ir.config_parameter'].sudo().get_param(
-            "{0}.{1}".format(parameter_name,
-                             res_model),
-            self.env['ir.config_parameter'].sudo().get_param(
-                parameter_name, default='[]')
+            res_model = self.env.context.get("default_res_model")
+        parameter_name = "mail_restrict_follower_selection.domain"
+        return (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param(
+                "{}.{}".format(parameter_name, res_model),
+                self.env["ir.config_parameter"]
+                .sudo()
+                .get_param(parameter_name, default="[]"),
+            )
         )
 
     @api.model

--- a/mail_restrict_follower_selection/models/mail_wizard_invite.py
+++ b/mail_restrict_follower_selection/models/mail_wizard_invite.py
@@ -11,19 +11,15 @@ class MailWizardInvite(models.TransientModel):
     _inherit = "mail.wizard.invite"
 
     @api.model
-    def _mail_restrict_follower_selection_get_domain(self):
-        parameter_name = "mail_restrict_follower_selection.domain"
-        return (
-            self.env["ir.config_parameter"]
-            .sudo()
-            .get_param(
-                "{}.{}".format(
-                    parameter_name, self.env.context.get("default_res_model")
-                ),
-                self.env["ir.config_parameter"]
-                .sudo()
-                .get_param(parameter_name, default="[]"),
-            )
+    def _mail_restrict_follower_selection_get_domain(self, res_model=None):
+        if not res_model:
+            res_model = self.env.context.get('default_res_model')
+        parameter_name = 'mail_restrict_follower_selection.domain'
+        return self.env['ir.config_parameter'].sudo().get_param(
+            "{0}.{1}".format(parameter_name,
+                             res_model),
+            self.env['ir.config_parameter'].sudo().get_param(
+                parameter_name, default='[]')
         )
 
     @api.model

--- a/mail_restrict_follower_selection/tests/test_mail_restrict_follower_selection.py
+++ b/mail_restrict_follower_selection/tests/test_mail_restrict_follower_selection.py
@@ -65,3 +65,19 @@ class TestMailRestrictFollowerSelection(TransactionCase):
         self.assertNotIn(
             self.partner, self.partner.message_follower_ids.mapped("partner_id")
         )
+
+    def test_message_add_suggested_recipient(self):
+        res = self.partner.with_context(
+            test_restrict_follower=True
+        )._message_add_suggested_recipient({self.partner.id: []}, partner=self.partner)
+        self.assertEqual(res[self.partner.id][0][0], self.partner.id)
+        self.env["ir.config_parameter"].create(
+            {
+                "key": "mail_restrict_follower_selection.domain.res.partner",
+                "value": "[('category_id.name', '!=', 'Employees')]",
+            }
+        )
+        new_res = self.partner.with_context(
+            test_restrict_follower=True
+        )._message_add_suggested_recipient({self.partner.id: []})
+        self.assertFalse(new_res[self.partner.id][0][0])


### PR DESCRIPTION
With module mail_restrict_follower_selection.

You can restrict only the followers for a certain record type (or have different restrictions for different record types), creating a parameter `mail_restrict_follower_selection.domain.$your_model`

This will work on wizard invite, but do not work on mail.thread _message_add_suggested_recipient...

I update this method to pass context, this way _mail_restrict_follower_selection_get_domain method know model to apply domain.