### PR TITLE
pre-commit pylint error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
   - id: mixed-line-ending
     args: ["--fix=lf"]
 - repo: https://github.com/pre-commit/mirrors-pylint
-  rev: v2.3.1
+  rev: v2.3.5
   hooks:
   - id: pylint
     name: pylint with optional checks


### PR DESCRIPTION
I get this error on pre-commit:

    The conflict is caused by:
        pre-commit-dummy-package 0.0.0 depends on pylint==2.3.1
        pylint-odoo 3.5.0 depends on pylint==2.5.3; python_version >= "3"