### PR TITLE
[13.0] Fixed fetchmail_thread_default context value

### DIFF
--- a/fetchmail_thread_default/models/mail_thread.py
+++ b/fetchmail_thread_default/models/mail_thread.py
@@ -18,7 +18,7 @@ class MailThread(models.AbstractModel):
         thread_id=None,
     ):
         server = self.env["fetchmail.server"].browse(
-            self.env.context.get("fetchmail_server_id")
+            self.env.context.get("default_fetchmail_server_id")
         )
         if server.default_thread_id and not (model or thread_id):
             model = server.default_thread_id._name


### PR DESCRIPTION
On fetchmail_thread_default when creating a new mail.message it says the context["fetchmail_server_id"] is None, the field value is context["default_fetchmail_server_id"].