### PR TITLE
[12.0][FIX] mass_mailing_partner: Mailing contact multi wite

### DIFF
--- a/mass_mailing_partner/models/mail_mass_mailing_contact.py
+++ b/mass_mailing_partner/models/mail_mass_mailing_contact.py
@@ -1,7 +1,8 @@
-# Copyright 2015 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# Copyright 2015 Tecnativa - Pedro M. Baeza
 # Copyright 2015 Antonio Espinosa <antonio.espinosa@tecnativa.com>
 # Copyright 2015 Javier Iniesta <javieria@antiun.com>
-# Copyright 2017 David Vidal <david.vidal@tecnativa.com>
+# Copyright 2017 Tecnativa - David Vidal
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import _, api, fields, models
@@ -72,7 +73,7 @@ class MailMassMailingContact(models.Model):
                 subscription_list_ids=vals.get('subscription_list_ids', False),
                 list_ids=vals.get('list_ids', False)
             )
-            super().write(new_vals)
+            super(MailMassMailingContact, contact).write(new_vals)
         return True
 
     def _get_company(self):

--- a/mass_mailing_partner/tests/test_res_partner.py
+++ b/mass_mailing_partner/tests/test_res_partner.py
@@ -1,6 +1,7 @@
-# Copyright 2015 Pedro M. Baeza <pedro.baeza@tecnativa.com>
-# Copyright 2015 Antonio Espinosa <antonio.espinosa@tecnativa.com>
+# Copyright 2015 Tecnativa - Pedro M. Baeza
+# Copyright 2015 Tecnativa - Antonio Espinosa
 # Copyright 2015 Javier Iniesta <javieria@antiun.com>
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import base
@@ -37,3 +38,20 @@ class ResPartnerCase(base.BaseCase):
         self.check_mailing_contact_partner(contact)
         with self.assertRaises(ValidationError):
             self.partner.write({'email': False})
+
+    def test_write_res_partner_multi(self):
+        self.assertEqual(len(self.partner.category_id.ids), 2)
+        partner2 = self.partner.copy({'name': 'Partner test 2'})
+        self.partner.write({'category_id': [(4, self.category_3.id)]})
+        self.assertEqual(len(self.partner.category_id.ids), 3)
+        self.assertEqual(len(partner2.category_id.ids), 2)
+        for partner in [self.partner, partner2]:
+            self.create_mailing_contact({
+                'partner_id': partner.id,
+                'list_ids': [[6, 0, [self.mailing_list.id]]]
+            })
+        self.env['res.partner'].search([
+            ('id', 'in', (self.partner.id, partner2.id))
+        ]).write({'category_id': [(4, self.category_3.id)]})
+        self.assertEqual(len(self.partner.category_id.ids), 3)
+        self.assertEqual(len(partner2.category_id.ids), 3)


### PR DESCRIPTION
Fix error happen when write info related to multi-partner (constraint error related to partner_id duplicate).

In 13.0 work fine: https://github.com/OCA/social/blob/13.0/mass_mailing_partner/models/mailing_contact.py#L73

Please, @chienandalu review it. (remove it in https://github.com/OCA/social/pull/579)

@Tecnativa TT28197