### PR TITLE
[13.0][FIX] mail_optional_follower_notification: change reference mode

### DIFF
--- a/mail_optional_follower_notification/wizard/mail_compose_message_view.xml
+++ b/mail_optional_follower_notification/wizard/mail_compose_message_view.xml
@@ -5,19 +5,19 @@
         <field name="model">mail.compose.message</field>
         <field name="inherit_id" ref="mail.email_compose_message_wizard_form" />
         <field name="arch" type="xml">
-            <span name="document_followers_text" position="before">
+            <xpath expr="//span[@name='document_followers_text']" position="before">
                 <field
                     name="notify_followers"
                     attrs="{'invisible': [('composition_mode', '=', 'mass_mail')]}"
                 />
-            </span>
-            <span name="document_followers_text" position="after">
+            </xpath>
+            <xpath expr="//span[@name='document_followers_text']" position="after">
                 <span
                     name="no_followers_text"
                     attrs="{'invisible': [('notify_followers', '=', True)]}"
                     style="color: red;"
                 > - Warning : Followers will not be notified but they can access the notification directly from the document (if they are allowed to)</span>
-            </span>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Since an Odoo update the mail composer was crashing with the old way of referencing the 
<span name="document_followers_text"..>.
Using xpath permits to have it 'repaired' and doesn't fundamentally change the reference (only the way to do it).