### PR TITLE
[12.0][FIX] mass_mailing_list_dynamic: Prevent ValidationError when merge contacts

### DIFF
--- a/mass_mailing_list_dynamic/models/mail_mass_mailing_contact.py
+++ b/mass_mailing_list_dynamic/models/mail_mass_mailing_contact.py
@@ -11,7 +11,10 @@ class MassMailingContact(models.Model):
     _inherit = "mail.mass_mailing.contact"
 
     def _check_dynamic_full_sync_list(self, mailing_list):
-        if mailing_list.dynamic and mailing_list.sync_method == "full":
+        if (
+            mailing_list.dynamic and mailing_list.sync_method == "full"
+            and not self.env.context.get("bypass_dynamic_list_check")
+        ):
             raise ValidationError(_(
                 "Cannot edit manually contacts in a fully "
                 "synchronized list. Change its sync method or execute "

--- a/mass_mailing_list_dynamic/readme/CONTRIBUTORS.rst
+++ b/mass_mailing_list_dynamic/readme/CONTRIBUTORS.rst
@@ -1,6 +1,7 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
-  * Jairo Llopis <jairo.llopis@tecnativa.com>
-  * Pedro M. Baeza <pedro.baeza@tecnativa.com>
-  * David Vidal <david.vidal@tecnativa.com>
-  * Victor M.M. Torres <victor.martin@tecnativa.com>
+  * Jairo Llopis
+  * Pedro M. Baeza
+  * David Vidal
+  * Victor M.M. Torres
+  * Victor Nartínez

--- a/mass_mailing_list_dynamic/wizards/__init__.py
+++ b/mass_mailing_list_dynamic/wizards/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import mail_mass_mailing_load_filter
+from . import partner_merge

--- a/mass_mailing_list_dynamic/wizards/partner_merge.py
+++ b/mass_mailing_list_dynamic/wizards/partner_merge.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class BasePartnerMergeAutomaticWizard(models.TransientModel):
+    _inherit = "base.partner.merge.automatic.wizard"
+
+    def _merge(self, partner_ids, dst_partner=None, extra_checks=True):
+        return super(
+            BasePartnerMergeAutomaticWizard, self.with_context(
+                bypass_dynamic_list_check=True
+            )
+        )._merge(
+            partner_ids=partner_ids, dst_partner=dst_partner, extra_checks=extra_checks,
+        )


### PR DESCRIPTION
Prevent ValidationError when merge contacts wizard related to dynamic and full sync list.
Similar to https://github.com/OCA/social/pull/633

Need to be fixed in 13.0 too.

Please @pedrobaeza and @chienandalu  can you review it?

@Tecnativa TT28777