### PR TITLE
[13.0][FIX] mass_mailing_list_dynamic: Prevent ValidationError when merge contacts

### DIFF
--- a/mass_mailing_list_dynamic/readme/CONTRIBUTORS.rst
+++ b/mass_mailing_list_dynamic/readme/CONTRIBUTORS.rst
@@ -1,9 +1,10 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
-  * Jairo Llopis <jairo.llopis@tecnativa.com>
-  * Pedro M. Baeza <pedro.baeza@tecnativa.com>
-  * David Vidal <david.vidal@tecnativa.com>
-  * Victor M.M. Torres <victor.martin@tecnativa.com>
+  * Jairo Llopis
+  * Pedro M. Baeza
+  * David Vidal
+  * Victor M.M. Torres
+  * Víctor Martínez
 
 * `Hibou Corp. <https://hibou.io>`_:
 

--- a/mass_mailing_list_dynamic/tests/test_dynamic_lists.py
+++ b/mass_mailing_list_dynamic/tests/test_dynamic_lists.py
@@ -1,5 +1,6 @@
 # Copyright 2017 Tecnativa - Jairo Llopis
 # Copyright 2020 Hibou Corp. - Jared Kipe
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from mock import patch
@@ -141,3 +142,44 @@ class DynamicListCase(common.SavepointCase):
         self.assertFalse(self.list.is_synced)
         self.list.action_sync()
         self.assertTrue(self.list.is_synced)
+
+    def test_partners_merge(self):
+        tag2 = self.tag.copy({"name": "Tag 2"})
+        self.list.sync_method = "full"
+        list2 = self.list.copy(
+            {
+                "name": "test list 2",
+                "sync_domain": repr([("category_id", "in", tag2.ids)]),
+            }
+        )
+        partner_1 = self.partners.create(
+            {
+                "name": "Demo 1",
+                "email": "demo1@demo.com",
+                "category_id": [(4, self.tag.id, False)],
+            }
+        )
+        partner_2 = self.partners.create(
+            {
+                "name": "Demo 2",
+                "email": "demo2@demo.com",
+                "category_id": [(4, self.tag.id, False), (4, tag2.id, False)],
+            }
+        )
+        self.list.action_sync()
+        list2.action_sync()
+        self.assertTrue(partner_1.id in self.list.contact_ids.mapped("partner_id").ids)
+        self.assertTrue(partner_2.id in self.list.contact_ids.mapped("partner_id").ids)
+        self.assertFalse(partner_1.id in list2.contact_ids.mapped("partner_id").ids)
+        self.assertTrue(partner_2.id in list2.contact_ids.mapped("partner_id").ids)
+        # Wizard partner merge (partner_1 + partner_2) in partner_i1
+        wizard = self.env["base.partner.merge.automatic.wizard"].create(
+            {
+                "state": "option",
+                "dst_partner_id": partner_1.id,
+                "partner_ids": [(4, partner_1.id), (4, partner_2.id)],
+            }
+        )
+        wizard.action_merge()
+        self.assertTrue(partner_1.id in self.list.contact_ids.mapped("partner_id").ids)
+        self.assertTrue(partner_1.id in list2.contact_ids.mapped("partner_id").ids)

--- a/mass_mailing_list_dynamic/wizards/__init__.py
+++ b/mass_mailing_list_dynamic/wizards/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import mailing_load_filter
+from . import partner_merge

--- a/mass_mailing_list_dynamic/wizards/partner_merge.py
+++ b/mass_mailing_list_dynamic/wizards/partner_merge.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class BasePartnerMergeAutomaticWizard(models.TransientModel):
+    _inherit = "base.partner.merge.automatic.wizard"
+
+    def _merge(self, partner_ids, dst_partner=None, extra_checks=True):
+        return super(
+            BasePartnerMergeAutomaticWizard, self.with_context(syncing=True)
+        )._merge(
+            partner_ids=partner_ids, dst_partner=dst_partner, extra_checks=extra_checks,
+        )


### PR DESCRIPTION
Prevent ValidationError when merge contacts wizard related to dynamic and full sync list.
Similar to https://github.com/OCA/social/pull/633

It's related to 12.0: https://github.com/OCA/social/pull/689

Please @pedrobaeza and @chienandalu  can you review it?

@Tecnativa TT28777