### PR TITLE
[FIX] mail_activity_team: scheduled activity

### DIFF
--- a/mail_activity_team/models/mail_activity_mixin.py
+++ b/mail_activity_team/models/mail_activity_mixin.py
@@ -1,4 +1,5 @@
 # Copyright 2018 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2021 Tecnativa - David Vidal
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import api, models, fields
 
@@ -21,3 +22,24 @@ class MailActivityMixin(models.AbstractModel):
     @api.model
     def _search_activity_team_user_ids(self, operator, operand):
         return [('activity_ids.team_id.member_ids', operator, operand)]
+
+    def activity_schedule(
+        self, act_type_xmlid="", date_deadline=None, summary="",
+        note="", **act_values
+    ):
+        """With automatic activities, the user onchange won't act so we must
+        ensure the right group is set and no exceptions are raised due to
+        user-team missmatch. We can hook onto `act_values` dict as it's passed
+        to the create activity method.
+        """
+        user_id = act_values.get("user_id")
+        if user_id:
+            team = self.env["mail.activity"].with_context(
+                default_res_model=self._name,
+            )._get_default_team_id(user_id=user_id)
+            if team:
+                act_values.update({"team_id": team.id})
+        return super().activity_schedule(
+            act_type_xmlid=act_type_xmlid, date_deadline=date_deadline,
+            summary=summary, note=note, **act_values
+        )

--- a/mail_activity_team/readme/CONTRIBUTORS.rst
+++ b/mail_activity_team/readme/CONTRIBUTORS.rst
@@ -4,3 +4,6 @@
   * Miquel Raïch (miquel.raich@eficent.com)
 
 * Enric Tobella <etobella@creublanca.es>
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * David Vidal

--- a/mail_activity_team/tests/test_mail_activity_team.py
+++ b/mail_activity_team/tests/test_mail_activity_team.py
@@ -176,3 +176,13 @@ class TestMailActivityTeam(SavepointCase):
             {'team_activities': True}
         ).systray_get_activities()
         self.assertEqual(res[0]['total_count'], 0)
+
+    def test_schedule_activity(self):
+        """Correctly assign teams to auto scheduled activities. Those won't
+        trigger onchanges and could raise constraints and team missmatches"""
+        partner_record = self.employee.partner_id.sudo(self.employee.id)
+        activity = partner_record.activity_schedule(
+            user_id=self.employee2.id,
+            activity_type_id=self.env.ref("mail.mail_activity_data_call").id,
+        )
+        self.assertEqual(activity.team_id, self.team2)


### PR DESCRIPTION
Original issue: https://github.com/OCA/social/issues/688

When an activity is scheduled due to automatic processes the onchanges
won't adapt the proper user team, so we could have a mismatch that
provokes an exceptions due to the designed constaints

cc @Tecnativa TT28781