### PR TITLE
[FIX] mail_activity_team: scheduled activity

### DIFF
--- a/mail_activity_team/models/__init__.py
+++ b/mail_activity_team/models/__init__.py
@@ -1,3 +1,4 @@
 from . import mail_activity_team
 from . import mail_activity
+from . import mail_activity_mixin
 from . import res_users

--- a/mail_activity_team/models/mail_activity_mixin.py
+++ b/mail_activity_team/models/mail_activity_mixin.py
@@ -1,0 +1,32 @@
+# Copyright 2021 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import models
+
+
+class MailActivityMixin(models.AbstractModel):
+    _inherit = "mail.activity.mixin"
+
+    def activity_schedule(
+        self, act_type_xmlid="", date_deadline=None, summary="", note="", **act_values
+    ):
+        """With automatic activities, the user onchange won't act so we must
+        ensure the right group is set and no exceptions are raised due to
+        user-team missmatch. We can hook onto `act_values` dict as it's passed
+        to the create activity method.
+        """
+        user_id = act_values.get("user_id")
+        if user_id:
+            team = (
+                self.env["mail.activity"]
+                .with_context(default_res_model=self._name,)
+                ._get_default_team_id(user_id=user_id)
+            )
+            if team:
+                act_values.update({"team_id": team.id})
+        return super().activity_schedule(
+            act_type_xmlid=act_type_xmlid,
+            date_deadline=date_deadline,
+            summary=summary,
+            note=note,
+            **act_values
+        )

--- a/mail_activity_team/readme/CONTRIBUTORS.rst
+++ b/mail_activity_team/readme/CONTRIBUTORS.rst
@@ -3,3 +3,6 @@
   * Jordi Ballester Alomar (jordi.ballester@forgeflow.com)
   * Miquel Raïch (miquel.raich@forgeflow.com)
   * Pedro Gonzalez (pedro.gonzalez@pesol.es)
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * David Vidal

--- a/mail_activity_team/tests/test_mail_activity_team.py
+++ b/mail_activity_team/tests/test_mail_activity_team.py
@@ -179,3 +179,13 @@ class TestMailActivityTeam(TransactionCase):
         self.act2.team_id = self.team2
         self.team2.member_ids = [(3, self.act2.user_id.id)]
         self.act2._onchange_team_id()
+
+    def test_schedule_activity(self):
+        """Correctly assign teams to auto scheduled activities. Those won't
+        trigger onchanges and could raise constraints and team missmatches"""
+        partner_record = self.employee.partner_id.sudo(self.employee.id)
+        activity = partner_record.activity_schedule(
+            user_id=self.employee2.id,
+            activity_type_id=self.env.ref("mail.mail_activity_data_call").id,
+        )
+        self.assertEqual(activity.team_id, self.team2)


### PR DESCRIPTION
When an activity is scheduled due to automatic processes the onchanges
won't adapt the proper user team, so we could have a mismatch that
provokes an exceptions due to the designed constaints

fw-port from https://github.com/OCA/social/commit/6a96684e50a12b067d03eb7da381a5b812e1fa04

cc @Tecnativa TT28781