### PR TITLE
[13.0][FIX] mass_mailing_partner: Add sudo() to prevent user without mailing access try to merge contacts

### DIFF
--- a/mass_mailing_partner/wizard/partner_merge.py
+++ b/mass_mailing_partner/wizard/partner_merge.py
@@ -9,8 +9,10 @@ class BasePartnerMergeAutomaticWizard(models.TransientModel):
 
     def _merge(self, partner_ids, dst_partner=None, extra_checks=True):
         if dst_partner:
-            contacts = self.env["mailing.contact"].search(
-                [("partner_id", "in", partner_ids)]
+            contacts = (
+                self.env["mailing.contact"]
+                .sudo()
+                .search([("partner_id", "in", partner_ids)])
             )
             if contacts:
                 contacts = contacts.sorted(


### PR DESCRIPTION
Add `sudo()` to prevent user without mailing access try to merge contacts.

Steps to reproduce:

- Create _demo1_ and _demo2_ partners.
- Create _demo_ mailing list.
- Go to **Contacts** list and select _demo1_ and _demo2 to_ add "demo" list.
- Access with demo user (without mailing access).
- Go to **Contacts** and select _demo1_ and _demo2_ and try to "_merge_" contacts in "_demo1_".

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT29268