### PR TITLE
[13.0][FIX] mail_notification_custom_subject: Change obaject to object in subject_template test

### DIFF
--- a/mail_notification_custom_subject/tests/test_mail_notification_custom_subject.py
+++ b/mail_notification_custom_subject/tests/test_mail_notification_custom_subject.py
@@ -140,6 +140,7 @@ class TestMailNotificationCustomSubject(common.TransactionCase):
         self.assertEquals(mail_message_1.subject, "Test and something more")
 
     def test_bad_template_does_not_break(self):
+        """Create template with error (obaject) to test error."""
         self.env["mail.message.custom.subject"].create(
             {
                 "name": "Test bad template 1",


### PR DESCRIPTION
Change obaject to object in subject_template test.

Please @joao-p-marques and @CarlosRoca13 can you review it?

@Tecnativa