### PR TITLE
[13.0][add][mail_partner_opt_out]

### DIFF
--- a/mail_partner_opt_out/__init__.py
+++ b/mail_partner_opt_out/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/mail_partner_opt_out/__manifest__.py
+++ b/mail_partner_opt_out/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2021 ForgeFlow S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+{
+    "name": "Mail Partner Opt Out",
+    "summary": "Add the partner's email to the blackmailed list",
+    "version": "13.0.1.0.0",
+    "development_status": "Beta",
+    "category": "Social Network",
+    "website": "https://github.com/OCA/social",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "license": "LGPL-3",
+    "installable": True,
+    "data": ["views/res_partner_views.xml"],
+    "depends": ["mail"],
+}

--- a/mail_partner_opt_out/models/__init__.py
+++ b/mail_partner_opt_out/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_partner

--- a/mail_partner_opt_out/models/res_partner.py
+++ b/mail_partner_opt_out/models/res_partner.py
@@ -1,0 +1,51 @@
+# Copyright 2021 ForgeFlow S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+from odoo import _, fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    opt_out = fields.Boolean(
+        string="Opt Out",
+        compute="_compute_opt_out",
+        inverse="_inverse_opt_out",
+        search="_search_opt_out",
+        help="Setting this checkbox will add the partner's email to a "
+        "blacklist so that this email won't be considered in mailings.",
+    )
+
+    def _compute_opt_out(self):
+        blacklist = (
+            self.env["mail.blacklist"]
+            .sudo()
+            .search([("email", "in", self.mapped("email"))])
+        )
+        blacklisted_emails = blacklist.mapped("email")
+        for rec in self:
+            if rec.email in blacklisted_emails:
+                rec.opt_out = True
+            else:
+                rec.opt_out = False
+
+    def _inverse_opt_out(self):
+        for rec in self:
+            if rec.opt_out and rec.email:
+                self.env["mail.blacklist"].sudo()._add(self.email)
+            elif not rec.opt_out and rec.email:
+                self.env["mail.blacklist"].sudo()._remove(self.email)
+
+    def _is_unsupported_search_operator(self, operator):
+        return operator not in ["=", "!="]
+
+    def _search_opt_out(self, operator, value):
+        if self._is_unsupported_search_operator(operator):
+            raise ValueError(_("Unsupported search operator"))
+        blacklisted_emails = (
+            self.env["mail.blacklist"].sudo().search([]).mapped("email")
+        )
+        if (operator == "=" and value) or (operator == "!=" and not value):
+            search_operator = "in"
+        else:
+            search_operator = "not in"
+        return [("email", search_operator, blacklisted_emails)]

--- a/mail_partner_opt_out/readme/CONTRIBUTORS.rst
+++ b/mail_partner_opt_out/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* ForgeFlow, S.L. (contact@forgeflow.com)
+
+    * Jordi Ballester Alomar (jordi.ballester@forgeflow.com)

--- a/mail_partner_opt_out/readme/DESCRIPTION.rst
+++ b/mail_partner_opt_out/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module adds the capability for a user to add a partner's email address
+to the blackmail list so that she will not receive any emails from mass
+mailing campaigns.

--- a/mail_partner_opt_out/readme/USAGE.rst
+++ b/mail_partner_opt_out/readme/USAGE.rst
@@ -1,0 +1,6 @@
+Go to a partner. Next to the partner's email address you will see the
+checkbox 'Opt Out'. Once you press it the partner's email address will be
+blacklisted and the checkbox will be set. If you uncheck if the email address
+will be removed from the blacklist.
+
+You can also search for partners using the opt out as search criteria.

--- a/mail_partner_opt_out/views/res_partner_views.xml
+++ b/mail_partner_opt_out/views/res_partner_views.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <field name="email" position="before">
+                <field name="opt_out" string="Opt Out" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/setup/mail_partner_opt_out/odoo/addons/mail_partner_opt_out
+++ b/setup/mail_partner_opt_out/odoo/addons/mail_partner_opt_out
@@ -1,0 +1,1 @@
+../../../../mail_partner_opt_out

--- a/setup/mail_partner_opt_out/setup.py
+++ b/setup/mail_partner_opt_out/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module adds the capability for a user to add a partner's email address to the blackmail list so that she will not receive any emails from mass mailing campaigns.

Usage
--------
Go to a partner. Next to the partner's email address you will see the
checkbox 'Opt Out'. Once you press it the partner's email address will be
blacklisted and the checkbox will be set. If you uncheck if the email address
will be removed from the blacklist.

You can also search for partners using the opt out as search criteria.

One of the benefits of this approach is that it keeps the field 'opt_out' from previous version. If a company used this field in a past mass completed mail campaign during migration the system will respect the domain that was used. 

![image](https://user-images.githubusercontent.com/7683926/115746262-7a766980-a394-11eb-9a02-e456ef195ef1.png)
