### PR TITLE
[14.0][FIX] mail_debrand: pass original args to super()

### DIFF
--- a/mail_debrand/models/__init__.py
+++ b/mail_debrand/models/__init__.py
@@ -1,1 +1,2 @@
-from . import mail_render_mixinANDmail_mail
+from . import mail_render_mixin
+from . import mail_mail

--- a/mail_debrand/models/mail_mail.py
+++ b/mail_debrand/models/mail_mail.py
@@ -1,0 +1,24 @@
+# Copyright 2019 O4SB - Graeme Gellatly
+# Copyright 2019 Tecnativa - Ernesto Tejeda
+# Copyright 2020 Onestein - Andrea Stirpe
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+from lxml import etree, html
+import re
+
+
+class MailMail(models.AbstractModel):
+    _inherit = "mail.mail"
+
+    # in messages from objects is adding using Odoo that we are going to remove
+
+    @api.model_create_multi
+    def create(self, values_list):
+        for index, _value in enumerate(values_list):
+            values_list[index]["body_html"] = self.env[
+                "mail.render.mixin"
+            ].remove_href_odoo(
+                values_list[index]["body_html"], remove_parent=0, remove_before=1
+            )
+
+        return super().create(values_list)

--- a/mail_debrand/models/mail_mail.py
+++ b/mail_debrand/models/mail_mail.py
@@ -3,8 +3,6 @@
 # Copyright 2020 Onestein - Andrea Stirpe
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import api, models
-from lxml import etree, html
-import re
 
 
 class MailMail(models.AbstractModel):

--- a/mail_debrand/models/mail_render_mixin.py
+++ b/mail_debrand/models/mail_render_mixin.py
@@ -2,11 +2,9 @@
 # Copyright 2019 Tecnativa - Ernesto Tejeda
 # Copyright 2020 Onestein - Andrea Stirpe
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-import re
-
-from lxml import etree, html
-
 from odoo import api, models
+from lxml import etree, html
+import re
 
 
 class MailRenderMixin(models.AbstractModel):
@@ -88,20 +86,3 @@ class MailRenderMixin(models.AbstractModel):
             orginal_rendered[key] = self.remove_href_odoo(orginal_rendered[key])
 
         return orginal_rendered
-
-
-class MailMail(models.AbstractModel):
-    _inherit = "mail.mail"
-
-    # in messages from objects is adding using Odoo that we are going to remove
-
-    @api.model_create_multi
-    def create(self, values_list):
-        for index, _value in enumerate(values_list):
-            values_list[index]["body_html"] = self.env[
-                "mail.render.mixin"
-            ].remove_href_odoo(
-                values_list[index]["body_html"], remove_parent=0, remove_before=1
-            )
-
-        return super().create(values_list)

--- a/mail_debrand/models/mail_render_mixinANDmail_mail.py
+++ b/mail_debrand/models/mail_render_mixinANDmail_mail.py
@@ -79,9 +79,9 @@ class MailRenderMixin(models.AbstractModel):
             template_src,
             model,
             res_ids,
-            engine="jinja",
-            add_context=None,
-            post_process=False,
+            engine=engine,
+            add_context=add_context,
+            post_process=post_process,
         )
 
         for key in res_ids:

--- a/mail_debrand/tests/__init__.py
+++ b/mail_debrand/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_mail_debrand
+from . import test_mail_debrand_digest

--- a/mail_debrand/tests/test_mail_debrand_digest.py
+++ b/mail_debrand/tests/test_mail_debrand_digest.py
@@ -1,0 +1,61 @@
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# Copyright 2020 Onestein - Andrea Stirpe
+# Copyright 2021 Sodexis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import _
+from odoo.tests import common, tagged
+from werkzeug.urls import url_join
+from datetime import datetime
+
+
+@tagged('-at_install', 'post_install')
+class TestMailDebrandDigest(common.TransactionCase):
+    def setUp(self):
+        super().setUp()
+        if 'digest.digest' in self.env:
+            self.mail_digest_id = self.env['digest.digest'].create({
+                'name': 'Test Digest',
+                'user_ids': False,
+                'company_id': self.env.company.id,
+
+                'kpi_res_users_connected': True,
+                'kpi_mail_message_total': True,
+            })
+        else:
+            self.mail_digest_id = False
+
+    def test_mail_digest(self):
+        if not self.mail_digest_id:
+            self.assertEqual(True, True)
+            return
+
+        web_base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
+        rendered_body = self.env['mail.render.mixin']._render_template(
+            'digest.digest_mail_main',
+            'digest.digest',
+            self.mail_digest_id.ids,
+            engine='qweb',
+            add_context={
+                'title': self.mail_digest_id.name,
+                'top_button_label': _('Connect'),
+                'top_button_url': url_join(web_base_url, '/web/login'),
+                'company': self.env.user.company_id,
+                'user': self.env.user,
+                'tips_count': 1,
+                'formatted_date': datetime.today().strftime('%B %d, %Y'),
+                'display_mobile_banner': True,
+                'kpi_data': self.mail_digest_id.compute_kpis(self.env.user.company_id, self.env.user),
+                'tips': self.mail_digest_id.compute_tips(self.env.user.company_id, self.env.user, tips_count=1, consumed=True),
+                'preferences': self.mail_digest_id.compute_preferences(self.env.user.company_id, self.env.user),
+            },
+            post_process=True
+        )[self.mail_digest_id.id]
+
+        # ensure the template rendered correctly. if rendering failed,
+        # we sometimes end up with a string only containing the template
+        # name, or a null-ish value
+        self.assertNotEqual(rendered_body, 'digest.digest_mail_main')
+        self.assertNotEqual(rendered_body, None)
+        self.assertNotEqual(rendered_body, False)
+        self.assertNotEqual(rendered_body, '')


### PR DESCRIPTION
Previously, the kwargs `engine`, `add_context`, and `post_process` were not passed up to the super() call. This casued issues when the original caller specified those arguments.

For example, see the Digest module: https://github.com/odoo/odoo/blob/14.0/addons/digest/models/digest.py#L118

Prior to this commit, Digest emails would be blank, only containing the text _mail.digest_mail_main_.

