### PR TITLE
[14.0][IMP] mail_debrand: Ensure links to users website are not stripped

### DIFF
--- a/mail_debrand/models/__init__.py
+++ b/mail_debrand/models/__init__.py
@@ -1,1 +1,2 @@
-from . import mail_render_mixinANDmail_mail
+from . import mail_render_mixin
+from . import mail_mail

--- a/mail_debrand/models/mail_mail.py
+++ b/mail_debrand/models/mail_mail.py
@@ -1,0 +1,24 @@
+# Copyright 2019 O4SB - Graeme Gellatly
+# Copyright 2019 Tecnativa - Ernesto Tejeda
+# Copyright 2020 Onestein - Andrea Stirpe
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+from lxml import etree, html
+import re
+
+
+class MailMail(models.AbstractModel):
+    _inherit = "mail.mail"
+
+    # in messages from objects is adding using Odoo that we are going to remove
+
+    @api.model_create_multi
+    def create(self, values_list):
+        for index, _value in enumerate(values_list):
+            values_list[index]["body_html"] = self.env[
+                "mail.render.mixin"
+            ].remove_href_odoo(
+                values_list[index]["body_html"], remove_parent=0, remove_before=1
+            )
+
+        return super().create(values_list)

--- a/mail_debrand/models/mail_mail.py
+++ b/mail_debrand/models/mail_mail.py
@@ -3,8 +3,6 @@
 # Copyright 2020 Onestein - Andrea Stirpe
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import api, models
-from lxml import etree, html
-import re
 
 
 class MailMail(models.AbstractModel):

--- a/mail_debrand/models/mail_render_mixin.py
+++ b/mail_debrand/models/mail_render_mixin.py
@@ -2,11 +2,9 @@
 # Copyright 2019 Tecnativa - Ernesto Tejeda
 # Copyright 2020 Onestein - Andrea Stirpe
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-import re
-
-from lxml import etree, html
-
 from odoo import api, models
+from lxml import etree, html
+import re
 
 
 class MailRenderMixin(models.AbstractModel):
@@ -88,20 +86,3 @@ class MailRenderMixin(models.AbstractModel):
             orginal_rendered[key] = self.remove_href_odoo(orginal_rendered[key])
 
         return orginal_rendered
-
-
-class MailMail(models.AbstractModel):
-    _inherit = "mail.mail"
-
-    # in messages from objects is adding using Odoo that we are going to remove
-
-    @api.model_create_multi
-    def create(self, values_list):
-        for index, _value in enumerate(values_list):
-            values_list[index]["body_html"] = self.env[
-                "mail.render.mixin"
-            ].remove_href_odoo(
-                values_list[index]["body_html"], remove_parent=0, remove_before=1
-            )
-
-        return super().create(values_list)

--- a/mail_debrand/models/mail_render_mixinANDmail_mail.py
+++ b/mail_debrand/models/mail_render_mixinANDmail_mail.py
@@ -79,9 +79,9 @@ class MailRenderMixin(models.AbstractModel):
             template_src,
             model,
             res_ids,
-            engine="jinja",
-            add_context=None,
-            post_process=False,
+            engine=engine,
+            add_context=add_context,
+            post_process=post_process,
         )
 
         for key in res_ids:


### PR DESCRIPTION
See #713 for more details.

The original regexes were naively searching for domains that matched `odoo.com`. This included Odoo.sh/Odoo Online users (`my-company.odoo.com`). The final-pass regex was also matching text snippets it shouldn't (e.g. `https://odoo.mycompany.com` -> `https:/.mycompany.com`, note the missing `/` because `/odoo` was matched).

The new regexes:
 - [Search the doc to find any `href="odoo.com"`-like snippets](https://regex101.com/r/o01Rfz/3)
 - [Search for an `<a>` element where the `href` attribute is like "odoo.com"](https://regex101.com/r/o01Rfz/5)
 - [Final pass - search for any occurances of `odoo`, and delete them](https://regex101.com/r/FLTxID/11)

I'm not 100% convinced this is the best approach, because it can leave things a bit... weird. For example:
`This website is powered by Odoo!` -> `This website is powered by!`. A more in-depth analysis of Odoo branding on email templates would probably be good.

But at least now it isn't breaking client URLs!