### PR TITLE
[FIX] mass_mailing_partner: Use correct button class

### DIFF
--- a/mass_mailing_partner/views/res_partner_view.xml
+++ b/mass_mailing_partner/views/res_partner_view.xml
@@ -22,7 +22,7 @@
                     context="{'search_default_partner_id': active_id,
                                   'default_partner_id': active_id}"
                     type="action"
-                    class="oe_stat_button oe_inline"
+                    class="oe_stat_button"
                     icon="fa-envelope-o"
                 >
                     <field
@@ -36,7 +36,7 @@
                     context="{'search_default_partner_id': active_id,
                                   'default_partner_id': active_id}"
                     type="action"
-                    class="oe_stat_button oe_inline"
+                    class="oe_stat_button"
                     icon="fa-envelope-o"
                 >
                     <field


### PR DESCRIPTION
Before this commit, the buttons are displayed incorrectly in mobile dropdown buttons menu

cc @tecnativa TT29734