### PR TITLE
[FIX] mail_activity_team: archived users

### DIFF
--- a/mail_activity_team/models/mail_activity.py
+++ b/mail_activity_team/models/mail_activity.py
@@ -66,10 +66,16 @@ class MailActivity(models.Model):
             # (for example with exception type activity, with no backorder).
             # SUPERUSER is inactive and then even if you add it
             # to member_ids it's not taken account
-            # To not be blocked we must add it to constraint condition
-            if activity.user_id.id != SUPERUSER_ID and activity.team_id and \
-                    activity.user_id and \
-                    activity.user_id not in activity.team_id.member_ids:
+            # To not be blocked we must add it to constraint condition.
+            # We must consider also users that could be archived but come from
+            # an automatic scheduled activity
+            if (
+                activity.user_id.id != SUPERUSER_ID
+                and activity.team_id and activity.user_id
+                and activity.user_id not in activity.team_id.with_context(
+                    active_test=False
+                ).member_ids
+            ):
                 raise ValidationError(
                     _('The assigned user is not member of the team.'))
 

--- a/mail_activity_team/models/mail_activity_mixin.py
+++ b/mail_activity_team/models/mail_activity_mixin.py
@@ -37,8 +37,8 @@ class MailActivityMixin(models.AbstractModel):
             team = self.env["mail.activity"].with_context(
                 default_res_model=self._name,
             )._get_default_team_id(user_id=user_id)
-            if team:
-                act_values.update({"team_id": team.id})
+            # Even if it comes empty, we don't want to mismatch the user's team
+            act_values.update({"team_id": team.id})
         return super().activity_schedule(
             act_type_xmlid=act_type_xmlid, date_deadline=date_deadline,
             summary=summary, note=note, **act_values


### PR DESCRIPTION
- If a user is archived but there's an automatic activity, the team
check wouldn't locate him. We have to ensure the context.
- When the automatic activity gets a user with no team, we should set
the team to a void one as well.

cc @Tecnativa TT30470

please review @sergio-teruel @MiquelRForgeFlow 