### PR TITLE
[13.0][FIX] mail_preview_base: Add fieldModelName to FieldPreviewViewer according to 14.0

### DIFF
--- a/mail_preview_base/static/src/js/preview.js
+++ b/mail_preview_base/static/src/js/preview.js
@@ -73,15 +73,16 @@ odoo.define("mail_preview_base.preview", function(require) {
 
     var FieldPreviewViewer = DocumentViewer.extend({
         init: function(parent, attachments, activeAttachmentID, model, field) {
-            this.modelName = model;
+            this.fieldModelName = model;
             this.fieldName = field;
             this._super.apply(this, arguments);
+            this.modelName = model;
         },
         _onDownload: function(e) {
             e.preventDefault();
             window.location =
                 "/web/content/" +
-                this.modelName +
+                this.fieldModelName +
                 "/" +
                 this.activeAttachment.id +
                 "/" +
@@ -93,7 +94,7 @@ odoo.define("mail_preview_base.preview", function(require) {
         _getContentUrl: function(attachment) {
             return (
                 "/web/content/" +
-                this.modelName +
+                this.fieldModelName +
                 "/" +
                 attachment.id +
                 "/" +
@@ -105,7 +106,7 @@ odoo.define("mail_preview_base.preview", function(require) {
         _getImageUrl: function(attachment) {
             return (
                 "/web/image/" +
-                this.modelName +
+                this.fieldModelName +
                 "/" +
                 attachment.id +
                 "/" +


### PR DESCRIPTION
Add `fieldModelName` to `FieldPreviewViewer` according to 14.0 (similar to https://github.com/OCA/social/commit/94be8655311f2fb9ddeb426cc5f13ffa300f6911). 
It's necessary when we can use it with custom models (`dms` for example).

Please @pedrobaeza and @Yajo can you review it?

@Tecnativa TT30992