### PR TITLE
[12.0] mail_tracking: avoid common users accessing to general trackings

### DIFF
--- a/mail_tracking/controllers/main.py
+++ b/mail_tracking/controllers/main.py
@@ -67,7 +67,7 @@ class MailTrackingController(MailController):
         metadata = self._request_metadata()
         with db_env(db) as env:
             try:
-                tracking_email = env['mail.tracking.email'].search([
+                tracking_email = env['mail.tracking.email'].sudo().search([
                     ('id', '=', tracking_email_id),
                     ('token', '=', token),
                 ])

--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -8,7 +8,8 @@ import re
 import uuid
 from datetime import datetime
 
-from odoo import models, api, fields, tools
+from odoo import _, models, api, fields, tools
+from odoo.exceptions import AccessError
 import odoo.addons.decimal_precision as dp
 
 _logger = logging.getLogger(__name__)
@@ -117,11 +118,84 @@ class MailTrackingEmail(models.Model):
                 'mail_tracking_needs_action': True,
             })
 
+    def _find_allowed_tracking_ids(self):
+        """Filter trackings based on related records ACLs"""
+        # Admins passby this filter
+        if not self or self.env.user.has_group("base.group_system"):
+            return self.ids
+        # Override ORM to get the values directly
+        self._cr.execute(
+            """
+            SELECT id, mail_message_id, mail_id, partner_id
+            FROM mail_tracking_email WHERE id IN %s
+            """, (tuple(self.ids),)
+        )
+        msg_linked = self._cr.fetchall()
+        if not msg_linked:
+            return []
+        ids, msg_ids, mail_ids, partner_ids = zip(*msg_linked)
+        # Filter messages with their ACL rules
+        msg_ids = self.env["mail.message"]._search([("id", "in", msg_ids)])
+        mail_ids = self.env["mail.mail"]._search([("id", "in", mail_ids)])
+        partner_ids = self.env["res.partner"]._search([("id", "in", partner_ids)])
+        return [
+            x[0] for x in msg_linked
+            if (x[1] in msg_ids)  # We can read the linked message
+            or (x[2] in mail_ids)  # We can read the linked mail
+            or (
+                not any({x[1], x[2]})
+                and x[3] in partner_ids
+            )  # No linked msg/mail but we can read the linked partner
+            or (not any({x[1], x[2], x[3]}))  # No linked record
+        ]
+
+    @api.model
+    def _search(
+        self, args, offset=0, limit=None, order=None, count=False,
+        access_rights_uid=None
+    ):
+        """Filter ids based on related records ACLs"""
+        ids = super()._search(
+            args, offset, limit, order, count=count,
+            access_rights_uid=access_rights_uid
+        )
+        if not self.env.user.has_group("base.group_system") and not count:
+            ids = self.browse(ids)._find_allowed_tracking_ids()
+        return ids
+
+    def check_access_rule(self, operation):
+        """Rely on related messages ACLs"""
+        super().check_access_rule(operation)
+        allowed_ids = self._search([("id", "in", self._find_allowed_tracking_ids())])
+        disallowed_ids = set(self.exists().ids).difference(set(allowed_ids))
+        if not disallowed_ids:
+            return
+        raise AccessError(
+            _(
+                "The requested operation cannot be completed due to security "
+                "restrictions. Please contact your system administrator.\n\n"
+                "(Document type: %s, Operation: %s)"
+            ) % (self._description, operation)
+            + " - ({} {}, {} {})".format(
+                _("Records:"),
+                list(disallowed_ids),
+                _("User:"), self._uid
+            )
+        )
+
+    def read(self, fields=None, load="_classic_read"):
+        """Override to explicitly call check_access_rule, that is not called
+        by the ORM. It instead directly fetches ir.rules and apply them.
+        """
+        if not self.env.user.has_group("base.group_system"):
+            self.check_access_rule("read")
+        return super().read(fields=fields, load=load)
+
     @api.model
     def email_is_bounced(self, email):
         if not email:
             return False
-        res = self._email_last_tracking_state(email)
+        res = self.sudo()._email_last_tracking_state(email)
         return res and res[0].get('state', '') in {'rejected', 'error',
                                                    'spam', 'bounced'}
 
@@ -134,10 +208,12 @@ class MailTrackingEmail(models.Model):
     def email_score_from_email(self, email):
         if not email:
             return 0.
-        data = self.read_group([('recipient_address', '=', email.lower())],
-                               ['recipient_address', 'state'], ['state'])
+        data = self.sudo().read_group([
+            ('recipient_address', '=', email.lower())],
+            ['recipient_address', 'state'], ['state']
+        )
         mapped_data = {state['state']: state['state_count'] for state in data}
-        return self.with_context(mt_states=mapped_data).email_score()
+        return self.with_context(mt_states=mapped_data).sudo().email_score()
 
     @api.model
     def _email_score_weights(self):
@@ -342,7 +418,7 @@ class MailTrackingEmail(models.Model):
             ]
             if event_type == 'click':
                 domain.append(('url', '=', metadata.get('url', False)))
-            concurrent_event_ids = m_event.search(domain)
+            concurrent_event_ids = m_event.sudo().search(domain)
         return concurrent_event_ids
 
     @api.multi

--- a/mail_tracking/views/res_partner_view.xml
+++ b/mail_tracking/views/res_partner_view.xml
@@ -19,7 +19,9 @@
                     attrs="{'invisible': [('email', '=', False)]}">
                 <field name="tracking_emails_count"
                        widget="statinfo"
-                       string="Tracking emails"/>
+                       string="Tracking emails"
+                       attrs="{'invisible': [('tracking_emails_count', '=', False)]}"
+                />
             </button>
         </div>
         <xpath expr="//field[@name='email']/.." position="after">


### PR DESCRIPTION
A user accessing to all trackings with no restrictions could view some sensible informations contained in the mail tracking mail subject. For example, employees leave causes.

Refine which mail tracking record is allowed to see. We can rely on the ACLs of the related records so we minimize inconvenient message subject leaks.

A regular user can read these mail.tracking.email records:

- Those with a linked mail.message that the user can read.
- Those with a linked mail.mail that the user can read.
- Those with no message/mail link but a linked partner that the user can read.
- Those with no linked records.

TT31399

cc @Tecnativa