### PR TITLE
[14.0][ADD] mass_mailing_contact_partner

### DIFF
--- a/mass_mailing_contact_partner/__init__.py
+++ b/mass_mailing_contact_partner/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/mass_mailing_contact_partner/__manifest__.py
+++ b/mass_mailing_contact_partner/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Mass Mailing Contact Partner",
+    "summary": "Links mailing.contacts with res.partners.",
+    "version": "14.0.1.0.0",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["ivantodorovich"],
+    "website": "https://github.com/OCA/social",
+    "license": "AGPL-3",
+    "category": "Marketing",
+    "depends": ["mass_mailing"],
+    "data": ["views/mailing_contact.xml"],
+}

--- a/mass_mailing_contact_partner/models/__init__.py
+++ b/mass_mailing_contact_partner/models/__init__.py
@@ -1,0 +1,2 @@
+from . import mailing_contact
+from . import res_partner

--- a/mass_mailing_contact_partner/models/mailing_contact.py
+++ b/mass_mailing_contact_partner/models/mailing_contact.py
@@ -1,0 +1,74 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class MailingContact(models.Model):
+    _inherit = "mailing.contact"
+
+    partner_ids = fields.One2many(
+        "res.partner",
+        "mailing_contact_id",
+        string="Partners",
+        readonly=True,
+    )
+    partner_count = fields.Integer(
+        string="Partners Count",
+        compute="_compute_partner_count",
+    )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # Try to relate partners with the same email.
+        records = super().create(vals_list)
+        records._recompute_partner_relation()
+        return records
+
+    def write(self, vals):
+        # If email is updated, it may render the partner relations outdated.
+        # Recompute all partners with prev and current email.
+        if "email" in vals:
+            prev_emails = [rec.email_normalized for rec in self]
+        res = super().write(vals)
+        if "email" in vals:
+            self._recompute_partner_relation(include_emails=prev_emails)
+        return res
+
+    def _recompute_partner_relation(self, include_emails=None):
+        """Recomputes partner mailing_contact_id relation
+
+        Our relation is based on the email field, not a real FK.
+
+        In case new records are created, or their emails are updated,
+        we need to also update the related partners relations.
+        """
+        emails = self.mapped("email_normalized")
+        if include_emails:
+            emails += include_emails
+        # Make sure they're unique
+        emails = list(set(emails))
+        if not emails:  # pragma: no cover
+            return
+        partners = self.env["res.partner"].search([("email_normalized", "in", emails)])
+        partners._compute_mailing_contact_id()
+
+    @api.depends("partner_ids")
+    def _compute_partner_count(self):
+        results = self.env["res.partner"].read_group(
+            [("mailing_contact_id", "in", self.ids)],
+            fields=["mailing_contact_id"],
+            groupby=["mailing_contact_id"],
+        )
+        count_map = {
+            x["mailing_contact_id"][0]: x["mailing_contact_id_count"] for x in results
+        }
+        for rec in self:
+            rec.partner_count = count_map.get(rec.id, 0)
+
+    def action_view_partner_ids(self):
+        action = self.env["ir.actions.actions"]._for_xml_id("base.action_partner_form")
+        action["domain"] = [("mailing_contact_id", "in", self.ids)]
+        action["context"] = False
+        return action

--- a/mass_mailing_contact_partner/models/res_partner.py
+++ b/mass_mailing_contact_partner/models/res_partner.py
@@ -1,0 +1,37 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    mailing_contact_id = fields.Many2one(
+        comodel_name="mailing.contact",
+        string="Mass Mailing Contact",
+        help="The mailing list contact that matches this partner's email.",
+        compute="_compute_mailing_contact_id",
+        store=True,
+    )
+
+    @api.depends("email_normalized")
+    def _compute_mailing_contact_id(self):
+        # Unique list of normalized email addresses
+        emails = {m for m in self.mapped("email_normalized") if m}
+        if not emails:
+            self.mailing_contact_id = False
+            return
+        query = """
+            SELECT email_normalized, id
+            FROM mailing_contact
+            WHERE email_normalized IN %s
+        """
+        self.env["mailing.contact"].flush(["email_normalized"])
+        self.env.cr.execute(query, (tuple(emails),))
+        mailing_contact_id_by_email = dict(self.env.cr.fetchall())
+        for rec in self:
+            rec.mailing_contact_id = mailing_contact_id_by_email.get(
+                rec.email_normalized
+            )

--- a/mass_mailing_contact_partner/readme/CONTRIBUTORS.rst
+++ b/mass_mailing_contact_partner/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+     * Iván Todorovich <ivan.todorovich@gmail.com>

--- a/mass_mailing_contact_partner/readme/DESCRIPTION.rst
+++ b/mass_mailing_contact_partner/readme/DESCRIPTION.rst
@@ -1,0 +1,9 @@
+This module links mailing.contacts with res.partners.
+
+The same mailing.contact can be linked to multiple partners, if they
+share the same email address.
+
+This module is different than `mass_mailing_partner` because the relationship
+is in the opposite direction.
+
+It's recommended to use it with `mass_mailing_contact_unique` module.

--- a/mass_mailing_contact_partner/tests/__init__.py
+++ b/mass_mailing_contact_partner/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_mass_mailing_contact_partner

--- a/mass_mailing_contact_partner/tests/test_mass_mailing_contact_partner.py
+++ b/mass_mailing_contact_partner/tests/test_mass_mailing_contact_partner.py
@@ -1,0 +1,58 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import SavepointCase
+
+
+class TestContactPartner(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.mailing_contact = cls.env["mailing.contact"].create(
+            {
+                "name": "John Doe",
+                "email": "john.doe@example.com",
+            }
+        )
+        cls.partner_john = cls.env["res.partner"].create(
+            {
+                "name": "John Doe",
+                "email": "john.doe@example.com",
+            }
+        )
+        cls.partner_jane = cls.env["res.partner"].create(
+            {
+                "name": "Jane Doe",
+                "email": "jane.doe@example.com",
+            }
+        )
+
+    def test_contact_partner(self):
+        self.assertEqual(self.mailing_contact.partner_count, 1)
+        self.assertEqual(self.mailing_contact.partner_ids, self.partner_john)
+        # Create a jane.doe contact
+        contact = self.env["mailing.contact"].create(
+            {
+                "name": "Jane Doe",
+                "email": "jane.doe@example.com",
+            }
+        )
+        self.assertEqual(contact.partner_count, 1)
+        self.assertEqual(contact.partner_ids, self.partner_jane)
+        # Change jane's address to be the same than john
+        self.partner_jane.email = "John.DOE@example.com"
+        self.assertEqual(self.mailing_contact.partner_count, 2)
+        self.assertEqual(
+            self.mailing_contact.partner_ids,
+            self.partner_john | self.partner_jane,
+        )
+        # Change mailing.contact address
+        self.mailing_contact.email = "unknown@example.com"
+        self.assertEqual(self.mailing_contact.partner_count, 0)
+
+    def test_contact_partner_action(self):
+        action = self.mailing_contact.action_view_partner_ids()
+        partners = self.env["res.partner"].search(action["domain"])
+        self.assertEqual(partners, self.partner_john)

--- a/mass_mailing_contact_partner/views/mailing_contact.xml
+++ b/mass_mailing_contact_partner/views/mailing_contact.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2021 Camptocamp (http://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@gmail.com>
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="mailing_contact_view_tree" model="ir.ui.view">
+        <field name="model">mailing.contact</field>
+        <field name="inherit_id" ref="mass_mailing.mailing_contact_view_tree" />
+        <field name="arch" type="xml">
+            <field name="email" position="after">
+                <field name="partner_ids" widget="many2many_tags" optional="show" />
+            </field>
+        </field>
+    </record>
+
+    <record id="mailing_contact_view_form" model="ir.ui.view">
+        <field name="model">mailing.contact</field>
+        <field name="inherit_id" ref="mass_mailing.mailing_contact_view_form" />
+        <field name="arch" type="xml">
+            <div class="oe_title" position="before">
+                <div name="button_box" class="oe_button_box">
+                    <button
+                        class="oe_stat_button"
+                        name="action_view_partner_ids"
+                        type="object"
+                        attrs="{'invisible':[('partner_count', '=', 0)]}"
+                        icon="fa-users"
+                    >
+                        <field
+                            name="partner_count"
+                            string="Partners"
+                            widget="statinfo"
+                        />
+                    </button>
+                </div>
+            </div>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/mass_mailing_contact_partner/odoo/addons/mass_mailing_contact_partner
+++ b/setup/mass_mailing_contact_partner/odoo/addons/mass_mailing_contact_partner
@@ -1,0 +1,1 @@
+../../../../mass_mailing_contact_partner

--- a/setup/mass_mailing_contact_partner/setup.py
+++ b/setup/mass_mailing_contact_partner/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module links mailing.contacts with res.partners.

This module is different than `mass_mailing_partner` because the relationship is in the opposite direction.
The same mailing.contact can be linked to multiple partners, if they share the same email address.

It's recommended to use it with `mass_mailing_unique` module (https://github.com/OCA/social/pull/773).
