### PR TITLE
[14.0][ADD] mass_mailing_subscription_date

### DIFF
--- a/mass_mailing_subscription_date/__init__.py
+++ b/mass_mailing_subscription_date/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from .hooks import post_init_hook

--- a/mass_mailing_subscription_date/__manifest__.py
+++ b/mass_mailing_subscription_date/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Mass Mailing Subscription Date",
+    "summary": "Track contact's subscription date to mailing lists",
+    "version": "14.0.1.0.0",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["ivantodorovich"],
+    "website": "https://github.com/OCA/social",
+    "license": "AGPL-3",
+    "category": "Marketing",
+    "depends": ["mass_mailing"],
+    "data": ["views/mailing_contact_subscription.xml"],
+    "post_init_hook": "post_init_hook",
+}

--- a/mass_mailing_subscription_date/hooks.py
+++ b/mass_mailing_subscription_date/hooks.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+def post_init_hook(cr, registry):
+    cr.execute(
+        """
+        UPDATE mailing_contact_list_rel
+        SET subscription_date = create_date
+        WHERE NOT opt_out
+        """
+    )

--- a/mass_mailing_subscription_date/models/__init__.py
+++ b/mass_mailing_subscription_date/models/__init__.py
@@ -1,0 +1,1 @@
+from . import mailing_contact_subscription

--- a/mass_mailing_subscription_date/models/mailing_contact_subscription.py
+++ b/mass_mailing_subscription_date/models/mailing_contact_subscription.py
@@ -1,0 +1,21 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class MailingContactSubscription(models.Model):
+    _inherit = "mailing.contact.subscription"
+
+    subscription_date = fields.Datetime(readonly=True)
+
+    @api.model
+    def create(self, vals):
+        vals["subscription_date"] = not vals.get("opt_out") and fields.Datetime.now()
+        return super().create(vals)
+
+    def write(self, vals):
+        if "opt_out" in vals:
+            vals["subscription_date"] = not vals["opt_out"] and fields.Datetime.now()
+        return super().write(vals)

--- a/mass_mailing_subscription_date/readme/CONTRIBUTORS.rst
+++ b/mass_mailing_subscription_date/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+     * Iván Todorovich <ivan.todorovich@gmail.com>

--- a/mass_mailing_subscription_date/readme/DESCRIPTION.rst
+++ b/mass_mailing_subscription_date/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+Track mailing contact's subscription date to mailing lists.
+
+In core, the unsubscription date is tracked, but not the subscription date.

--- a/mass_mailing_subscription_date/tests/__init__.py
+++ b/mass_mailing_subscription_date/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_subscription_date

--- a/mass_mailing_subscription_date/tests/test_subscription_date.py
+++ b/mass_mailing_subscription_date/tests/test_subscription_date.py
@@ -1,0 +1,46 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import SavepointCase
+
+
+class TestSubscriptionDate(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.mailing_list = cls.env.ref("mass_mailing.mailing_list_data")
+        cls.mailing_contact = cls.env["mailing.contact"].create(
+            {
+                "name": "John Doe",
+                "email": "john.doe@example.com",
+            }
+        )
+
+    def test_subscription_date(self):
+        # Create subscription
+        subs = self.env["mailing.contact.subscription"].create(
+            {
+                "contact_id": self.mailing_contact.id,
+                "list_id": self.mailing_list.id,
+            }
+        )
+        self.assertTrue(subs.subscription_date)
+        # Opt out
+        subs.opt_out = True
+        self.assertFalse(subs.subscription_date)
+
+    def test_subscription_date_opt_out(self):
+        # Create subscription already opted out
+        subs = self.env["mailing.contact.subscription"].create(
+            {
+                "contact_id": self.mailing_contact.id,
+                "list_id": self.mailing_list.id,
+                "opt_out": True,
+            }
+        )
+        self.assertFalse(subs.subscription_date)
+        # Subscribe (opt_out = False)
+        subs.opt_out = False
+        self.assertTrue(subs.subscription_date)

--- a/mass_mailing_subscription_date/views/mailing_contact_subscription.xml
+++ b/mass_mailing_subscription_date/views/mailing_contact_subscription.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2021 Camptocamp (http://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@gmail.com>
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="mailing_contact_subscription_view_form" model="ir.ui.view">
+        <field name="model">mailing.contact.subscription</field>
+        <field
+            name="inherit_id"
+            ref="mass_mailing.mailing_contact_subscription_view_form"
+        />
+        <field name="arch" type="xml">
+            <field name="unsubscription_date" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': [('opt_out', '=', False)]}</attribute>
+            </field>
+            <field name="unsubscription_date" position="before">
+                <field
+                    name="subscription_date"
+                    attrs="{'invisible': [('opt_out', '=', True)]}"
+                />
+            </field>
+        </field>
+    </record>
+
+    <record id="mailing_contact_subscription_view_tree" model="ir.ui.view">
+        <field name="model">mailing.contact.subscription</field>
+        <field
+            name="inherit_id"
+            ref="mass_mailing.mailing_contact_subscription_view_tree"
+        />
+        <field name="arch" type="xml">
+            <field name="unsubscription_date" position="before">
+                <field name="subscription_date" />
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/mass_mailing_subscription_date/odoo/addons/mass_mailing_subscription_date
+++ b/setup/mass_mailing_subscription_date/odoo/addons/mass_mailing_subscription_date
@@ -1,0 +1,1 @@
+../../../../mass_mailing_subscription_date

--- a/setup/mass_mailing_subscription_date/setup.py
+++ b/setup/mass_mailing_subscription_date/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Track mailing contact's subscription date to mailing lists.

Without this module, the unsubscription date is tracked, but not the subscription date.
