### PR TITLE
[14.0][ADD] mass_mailing_company_newsletter

### DIFF
--- a/mass_mailing_company_newsletter/__init__.py
+++ b/mass_mailing_company_newsletter/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/mass_mailing_company_newsletter/__manifest__.py
+++ b/mass_mailing_company_newsletter/__manifest__.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Mass Mailing Company Newsletter",
+    "summary": "Easily manage partner's subscriptions to your main mailing list.",
+    "version": "14.0.1.0.0",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["ivantodorovich"],
+    "website": "https://github.com/OCA/social",
+    "license": "AGPL-3",
+    "category": "Marketing",
+    "depends": [
+        "mass_mailing",
+        "mass_mailing_contact_partner",
+        "mass_mailing_subscription_date",
+    ],
+    "data": [
+        "views/res_config_settings.xml",
+        "views/res_partner.xml",
+    ],
+}

--- a/mass_mailing_company_newsletter/models/__init__.py
+++ b/mass_mailing_company_newsletter/models/__init__.py
@@ -1,0 +1,3 @@
+from . import res_config_settings
+from . import res_company
+from . import res_partner

--- a/mass_mailing_company_newsletter/models/res_company.py
+++ b/mass_mailing_company_newsletter/models/res_company.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    main_mailing_list_id = fields.Many2one(
+        "mailing.list",
+        string="Company Newsletter",
+        default=lambda self: self.env.ref(
+            "mass_mailing.mailing_list_data",
+            raise_if_not_found=False,
+        ),
+    )

--- a/mass_mailing_company_newsletter/models/res_config_settings.py
+++ b/mass_mailing_company_newsletter/models/res_config_settings.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    main_mailing_list_id = fields.Many2one(
+        related="company_id.main_mailing_list_id",
+        readonly=False,
+    )

--- a/mass_mailing_company_newsletter/models/res_partner.py
+++ b/mass_mailing_company_newsletter/models/res_partner.py
@@ -1,0 +1,191 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+from odoo.osv import expression
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    main_mailing_list_id = fields.Many2one(
+        comodel_name="mailing.list",
+        string="Company Newsletter",
+        help="Technical field: The company's Newsletter mailing list.",
+        compute="_compute_main_mailing_list_id",
+        compute_sudo=True,
+    )
+    main_mailing_list_subscription_id = fields.Many2one(
+        comodel_name="mailing.contact.subscription",
+        string="Company Newsletter Subscription",
+        help="Technical field: The company's newsletter subscription for this partner.",
+        compute="_compute_main_mailing_list_subscription_id",
+        compute_sudo=True,
+        search="_search_main_mailing_list_subscription_id",
+    )
+    main_mailing_list_subscription_state = fields.Selection(
+        string="Company Newsletter Subscription State",
+        selection=[
+            ("subscribed", "Subscribed"),
+            ("unsubscribed", "Unsubscribed"),
+        ],
+        compute="_compute_main_mailing_list_subscription_state",
+        compute_sudo=True,
+        inverse="_inverse_main_mailing_list_subscription_state",
+        search="_search_main_mailing_list_subscription_state",
+        tracking=True,
+    )
+    main_mailing_list_subscription_date = fields.Datetime(
+        related="main_mailing_list_subscription_id.subscription_date",
+        string="Company Newsletter Subscription Date",
+    )
+    main_mailing_list_unsubscription_date = fields.Datetime(
+        related="main_mailing_list_subscription_id.unsubscription_date",
+        string="Company Newsletter Unsubscription Date",
+    )
+
+    @api.depends("company_id")
+    @api.depends_context("company")
+    def _compute_main_mailing_list_id(self):
+        self.main_mailing_list_id = self.env.company.main_mailing_list_id
+
+    @api.depends("mailing_contact_id")
+    @api.depends_context("company")
+    def _compute_main_mailing_list_subscription_id(self):
+        if not self.main_mailing_list_id or not self.mailing_contact_id:
+            self.main_mailing_list_subscription_id = False
+            return
+        # Find the mailing.contact.subscription
+        subs = self.env["mailing.contact.subscription"].search(
+            [
+                ("contact_id", "in", self.mailing_contact_id.ids),
+                ("list_id", "=", self.main_mailing_list_id.id),
+            ]
+        )
+        subs_by_contact_id = {sub.contact_id.id: sub.id for sub in subs}
+        for rec in self:
+            rec.main_mailing_list_subscription_id = subs_by_contact_id.get(
+                rec.mailing_contact_id.id
+            )
+
+    def _search_main_mailing_list_subscription_id(self, operator, value):
+        # Functionally speaking, this shouldn't be necessary.
+        # But without it, Odoo would print an error log saying:
+        # Non-stored field main_mailing_list_subscription_id cannot be searched.
+        # Even though we're not explicitly searching on it, the following line is:
+        # https://github.com/odoo/odoo/blob/c9b6b030f/odoo/models.py#L5860
+        if operator != "in":  # pragma: no cover
+            return NotImplementedError()
+        # Rely on the fact that search takes a query as value since Odoo 14.0
+        # See https://github.com/odoo/odoo/commit/69869ab68
+        mailing_list = self.env.company.main_mailing_list_id
+        search = self.env["mailing.contact.subscription"]._search(
+            [
+                ("list_id", "=", mailing_list.id),
+                ("id", "in", value),
+            ]
+        )
+        return [("mailing_contact_id.subscription_list_ids", "in", search)]
+
+    @api.depends("main_mailing_list_subscription_id.opt_out")
+    def _compute_main_mailing_list_subscription_state(self):
+        """Compute mass mailing state
+
+        There are basically 3 possible values:
+        * False: The mailing.contact.subscription record doesn't exist.
+        * Subscribed: The subscription exists and it's active.
+        * Unsubscribed: The subscription exists and but it's opt_out.
+        """
+        for rec in self:
+            if not rec.main_mailing_list_subscription_id:
+                rec.main_mailing_list_subscription_state = False
+            elif rec.main_mailing_list_subscription_id.opt_out:
+                rec.main_mailing_list_subscription_state = "unsubscribed"
+            else:
+                rec.main_mailing_list_subscription_state = "subscribed"
+
+    def _search_main_mailing_list_subscription_state(self, operator, value):
+        if operator != "=" or value not in [False, "subscribed", "unsubscribed"]:
+            # pragma: no cover
+            raise NotImplementedError()
+        mailing_list = self.env.company.main_mailing_list_id
+        # No company newsletter
+        if not mailing_list:  # pragma: no cover
+            return expression.TRUE_DOMAIN if value is False else expression.FALSE_DOMAIN
+        # Registration is not set
+        if value is False:
+            return [
+                "|",
+                ("mailing_contact_id", "=", False),
+                ("mailing_contact_id.list_ids", "!=", mailing_list.id),
+            ]
+        # Rely on the fact that search takes a query as value since Odoo 14.0
+        # See https://github.com/odoo/odoo/commit/69869ab68
+        search = self.env["mailing.contact.subscription"]._search(
+            [
+                ("list_id", "=", mailing_list.id),
+                ("opt_out", "=", False if value == "subscribed" else True),
+            ]
+        )
+        return [("mailing_contact_id.subscription_list_ids", "in", search)]
+
+    def _inverse_main_mailing_list_subscription_state(self):
+        if not self.env.company.main_mailing_list_id:  # pragma: no cover
+            raise ValidationError(
+                _(
+                    "You need to configure a main newsletter for company '%s'.\n"
+                    "To do so, go to Mass Mailing general settings."
+                )
+            )
+        for rec in self:
+            value = rec.main_mailing_list_subscription_state
+            contact = rec.mailing_contact_id
+            subscription = rec.main_mailing_list_subscription_id
+            # Setting back to null: remove subscription record
+            if value is False:
+                subscription.unlink()
+                continue
+            # Create contact if it's missing
+            if not contact:
+                rec._create_mailing_contact()
+            # Update or create subscription
+            if not subscription:
+                if value == "subscribed":
+                    rec._create_mailing_contact_subscription()
+                else:
+                    rec._create_mailing_contact_subscription(opt_out=True)
+            else:
+                if value == "subscribed":
+                    subscription.opt_out = False
+                elif value == "unsubscribed":
+                    subscription.opt_out = True
+
+    def _create_mailing_contact(self):
+        self.ensure_one()
+        if not self.email:  # pragma: no cover
+            raise ValidationError(_("Email is required to subscribe to the Newsletter"))
+        return self.env["mailing.contact"].create(
+            {
+                "name": self.name or self.email,
+                "email": self.email,
+                "title_id": self.title.id,
+                "country_id": self.country_id.id,
+                "tag_ids": [(6, 0, self.category_id.ids)],
+            }
+        )
+
+    def _create_mailing_contact_subscription(self, **kwargs):
+        self.ensure_one()
+        assert self.mailing_contact_id
+        assert self.env.company.main_mailing_list_id
+        vals = {
+            "contact_id": self.mailing_contact_id.id,
+            "list_id": self.env.company.main_mailing_list_id.id,
+        }
+        if kwargs is not None:
+            vals.update(kwargs)
+        subs = self.env["mailing.contact.subscription"].create(vals)
+        self.invalidate_cache(["main_mailing_list_subscription_id"])
+        return subs

--- a/mass_mailing_company_newsletter/readme/CONFIGURE.rst
+++ b/mass_mailing_company_newsletter/readme/CONFIGURE.rst
@@ -1,0 +1,1 @@
+Go to Email Marketing > Settings and configure your Company Newsletter mailing list.

--- a/mass_mailing_company_newsletter/readme/CONTRIBUTORS.rst
+++ b/mass_mailing_company_newsletter/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+     * Iván Todorovich <ivan.todorovich@gmail.com>

--- a/mass_mailing_company_newsletter/readme/DESCRIPTION.rst
+++ b/mass_mailing_company_newsletter/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+This module lets you manage partner's subscriptions to your company's main mailing list
+directly from the partner form.
+
+It makes it easier to manage partner communications, specially if you only use a single
+mailing list.

--- a/mass_mailing_company_newsletter/tests/__init__.py
+++ b/mass_mailing_company_newsletter/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_company_newsletter

--- a/mass_mailing_company_newsletter/tests/test_company_newsletter.py
+++ b/mass_mailing_company_newsletter/tests/test_company_newsletter.py
@@ -1,0 +1,151 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import SavepointCase
+
+
+class TestCompanyNewsletter(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.partner_a = cls.env["res.partner"].create(
+            {
+                "name": "Contact A",
+                "email": "a@example.com",
+            }
+        )
+        cls.partner_b = cls.env["res.partner"].create(
+            {
+                "name": "Contact B",
+                "email": "b@example.com",
+            }
+        )
+        cls.partner_b_2 = cls.env["res.partner"].create(
+            {
+                "name": "Contact B2 (Same email than B)",
+                "email": "b@example.com",
+            }
+        )
+
+    def test_01_default_mailing_list(self):
+        self.assertTrue(
+            self.env.company.main_mailing_list_id,
+            "Set through default value",
+        )
+
+    def test_02_partner_subscription_workflow(self):
+        # Subscribe Partner A
+        # This should CREATE the subscription record
+        self.partner_a.main_mailing_list_subscription_state = "subscribed"
+        self.assertTrue(self.partner_a.main_mailing_list_subscription_id)
+        self.assertFalse(self.partner_a.main_mailing_list_subscription_id.opt_out)
+        # # Unsubscribe Partner A
+        # This should UPDATE the subscription record
+        self.partner_a.main_mailing_list_subscription_state = "unsubscribed"
+        self.assertTrue(self.partner_a.main_mailing_list_subscription_id)
+        self.assertTrue(self.partner_a.main_mailing_list_subscription_id.opt_out)
+        # Subscribe Partner A
+        # This should UPDATE the subscription record
+        self.partner_a.main_mailing_list_subscription_state = "subscribed"
+        self.assertTrue(self.partner_a.main_mailing_list_subscription_id)
+        self.assertFalse(self.partner_a.main_mailing_list_subscription_id.opt_out)
+        # Set back to False (should remove subscribtion record)
+        self.partner_a.main_mailing_list_subscription_state = False
+        self.assertFalse(self.partner_a.main_mailing_list_subscription_id)
+        # Unsubscribe Partner A
+        # This should CREATE the subscription record, opted out
+        self.partner_a.main_mailing_list_subscription_state = "unsubscribed"
+        self.assertTrue(self.partner_a.main_mailing_list_subscription_id)
+        self.assertTrue(self.partner_a.main_mailing_list_subscription_id.opt_out)
+
+    def test_03_partner_subscription_workflow_same_email(self):
+        # Subscribe Partner B, but check Partner B 2 (same email = same subscription)
+        self.partner_b.main_mailing_list_subscription_state = "subscribed"
+        self.assertTrue(self.partner_b_2.main_mailing_list_subscription_id)
+        self.assertFalse(self.partner_b_2.main_mailing_list_subscription_id.opt_out)
+        # Unsubscribe Partner B
+        self.partner_b.main_mailing_list_subscription_state = "unsubscribed"
+        self.assertTrue(self.partner_b_2.main_mailing_list_subscription_id)
+        self.assertTrue(self.partner_b_2.main_mailing_list_subscription_id.opt_out)
+        # Set back to False (should remove subscribtion record)
+        self.partner_b.main_mailing_list_subscription_state = False
+        self.assertFalse(self.partner_b_2.main_mailing_list_subscription_id)
+
+    def test_04_search_partner_subscription(self):
+        # Partner A is not subscribed (field is empty)
+        empty_partners = self.env["res.partner"].search(
+            [
+                ("main_mailing_list_subscription_state", "=", False),
+            ]
+        )
+        self.assertTrue(empty_partners & self.partner_a)
+        # Subscribe Partner A
+        self.partner_a.main_mailing_list_subscription_state = "subscribed"
+        subscribed_partners = self.env["res.partner"].search(
+            [
+                ("main_mailing_list_subscription_state", "=", "subscribed"),
+            ]
+        )
+        unsubscribed_partners = self.env["res.partner"].search(
+            [
+                ("main_mailing_list_subscription_state", "=", "unsubscribed"),
+            ]
+        )
+        empty_partners = self.env["res.partner"].search(
+            [
+                ("main_mailing_list_subscription_state", "=", False),
+            ]
+        )
+        self.assertTrue(subscribed_partners & self.partner_a)
+        self.assertFalse(unsubscribed_partners & self.partner_a)
+        self.assertFalse(empty_partners & self.partner_a)
+        # Unsubscribe Partner A
+        self.partner_a.main_mailing_list_subscription_state = "unsubscribed"
+        subscribed_partners = self.env["res.partner"].search(
+            [
+                ("main_mailing_list_subscription_state", "=", "subscribed"),
+            ]
+        )
+        unsubscribed_partners = self.env["res.partner"].search(
+            [
+                ("main_mailing_list_subscription_state", "=", "unsubscribed"),
+            ]
+        )
+        empty_partners = self.env["res.partner"].search(
+            [
+                ("main_mailing_list_subscription_state", "=", False),
+            ]
+        )
+        self.assertFalse(subscribed_partners & self.partner_a)
+        self.assertTrue(unsubscribed_partners & self.partner_a)
+        self.assertFalse(empty_partners & self.partner_a)
+
+    def test_05_partner_subscription_state(self):
+        # Partner is not subscribed
+        self.assertFalse(self.partner_a.main_mailing_list_subscription_state)
+        # Subscribe
+        main_mailing_list = self.env.company.main_mailing_list_id
+        contact = self.env["mailing.contact"].create(
+            {
+                "name": self.partner_a.name,
+                "email": self.partner_a.email,
+            }
+        )
+        subs = self.env["mailing.contact.subscription"].create(
+            {
+                "contact_id": contact.id,
+                "list_id": main_mailing_list.id,
+            }
+        )
+        self.assertEqual(
+            self.partner_a.main_mailing_list_subscription_state,
+            "subscribed",
+        )
+        # Opt out
+        subs.opt_out = True
+        self.assertEqual(
+            self.partner_a.main_mailing_list_subscription_state,
+            "unsubscribed",
+        )

--- a/mass_mailing_company_newsletter/views/res_config_settings.xml
+++ b/mass_mailing_company_newsletter/views/res_config_settings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2021 Camptocamp (http://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@gmail.com>
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="mass_mailing.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <div name="managa_mail_campaigns_setting_container" position="inside">
+                <div class="col-lg-6 o_setting_box col-12" name="main_mailing_list_id">
+                    <div class="o_setting_right_pane">
+                        <label for="main_mailing_list_id" />
+                        <span
+                            role="img"
+                            class="fa fa-lg fa-building-o"
+                            title="Values set here are company-specific."
+                            aria-label="Values set here are company-specific."
+                            groups="base.group_multi_company"
+                        />
+                        <div class="text-muted">
+                            If set, it allows to manage partner's subscriptions to the
+                            company newsletter directly from the partner form.
+                        </div>
+                        <div class="mt16">
+                            <field name="main_mailing_list_id" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+
+</odoo>

--- a/mass_mailing_company_newsletter/views/res_partner.xml
+++ b/mass_mailing_company_newsletter/views/res_partner.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2021 Camptocamp (http://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@gmail.com>
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//page[@name='sales_purchases']//group[@name='sale']"
+                position="inside"
+            >
+                <field name="main_mailing_list_id" invisible="1" />
+                <label
+                    for="main_mailing_list_subscription_state"
+                    string="Company Newsletter"
+                    attrs="{'invisible': [('main_mailing_list_id', '=', False)]}"
+                />
+                <div
+                    name="main_mailing_list_subscription_state"
+                    class="o_row"
+                    attrs="{'invisible': [('main_mailing_list_id', '=', False)]}"
+                >
+                    <field
+                        name="main_mailing_list_subscription_state"
+                        widget="radio"
+                        options="{'horizontal': True}"
+                        attrs="{'readonly': [('email', '=', False)]}"
+                    />
+                    <span
+                        name="main_mailing_list_subscription_date"
+                        class="text-muted oe_read_only"
+                        attrs="{'invisible': [('main_mailing_list_subscription_state', '!=', 'subscribed')]}"
+                    >
+                        on
+                        <field
+                            name="main_mailing_list_subscription_date"
+                            widget="date"
+                        />
+                    </span>
+                    <span
+                        name="main_mailing_list_unsubscription_date"
+                        class="text-muted oe_read_only"
+                        attrs="{'invisible': [('main_mailing_list_subscription_state', '!=', 'unsubscribed')]}"
+                    >
+                        on
+                        <field
+                            name="main_mailing_list_unsubscription_date"
+                            widget="date"
+                        />
+                    </span>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_partner_tree" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_tree" />
+        <field name="arch" type="xml">
+            <field name="email" position="after">
+                <field name="main_mailing_list_subscription_state" optional="hide" />
+            </field>
+        </field>
+    </record>
+
+    <record id="view_res_partner_filter" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_res_partner_filter" />
+        <field name="arch" type="xml">
+            <filter name="inactive" position="after">
+                <separator />
+                <filter
+                    name="main_mailing_list_subscribed"
+                    string="Subscribed to Company Newsletter"
+                    domain="[('main_mailing_list_subscription_state', '=', 'subscribed')]"
+                />
+            </filter>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/mass_mailing_company_newsletter/odoo/addons/mass_mailing_company_newsletter
+++ b/setup/mass_mailing_company_newsletter/odoo/addons/mass_mailing_company_newsletter
@@ -1,0 +1,1 @@
+../../../../mass_mailing_company_newsletter

--- a/setup/mass_mailing_company_newsletter/setup.py
+++ b/setup/mass_mailing_company_newsletter/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module lets you manage partner's subscriptions to your company's main mailing list directly from the partner form.
It makes it easier to manage partner mass communications, specially if you only use a single mailing list.
