### PR TITLE
[14.0][FIX] mail_tracking: Change operator to 'ilike' in partner smartbutton

### DIFF
--- a/mail_tracking/views/mail_tracking_email_view.xml
+++ b/mail_tracking/views/mail_tracking_email_view.xml
@@ -102,12 +102,12 @@
             <field
                     name="sender"
                     string="Sender"
-                    filter_domain="[('sender', '=', self)]"
+                    filter_domain="[('sender', 'ilike', self)]"
                 />
             <field
                     name="recipient"
                     string="Recipient"
-                    filter_domain="[('recipient', '=', self)]"
+                    filter_domain="[('recipient', 'ilike', self)]"
                 />
             <field name="name" string="Subject" />
             <field name="time" string="Time" />


### PR DESCRIPTION
This is the result with the actual attribute **` filter_domain="[('recipient', '=', self)]"`** in the recipient and sender field:
![GIF 22-09-2021 23-37-44](https://user-images.githubusercontent.com/43784849/134426383-c1b6e2f0-076b-45f8-8c11-467c1397a1db.gif)

So I change the operator to "ilike"(**` filter_domain="[('recipient', 'ilike', self)]"`**) because I think it is the right thing to do when filtering by char fields. 
![GIF 22-09-2021 23-40-11](https://user-images.githubusercontent.com/43784849/134426003-29c11fb7-3d5f-4dd4-a2a1-2b68389b90e5.gif)

