### PR TITLE
[14.0] [FIX] mail_notification_custom_subject: drop `subtype_id` kwarg check

### DIFF
--- a/mail_notification_custom_subject/models/mail_thread.py
+++ b/mail_notification_custom_subject/models/mail_thread.py
@@ -28,7 +28,6 @@ class MailThread(models.AbstractModel):
         record_name=False,
         **kwargs
     ):
-        subtype_id = kwargs.get("subtype_id", False)
         if not subtype_id and subtype_xmlid:
             subtype_id = self.env["ir.model.data"].xmlid_to_res_id(
                 subtype_xmlid,


### PR DESCRIPTION
As `subtype_id` is not in the signature of `message_post`, `subtype_id = kwargs.get('subtype_id', False)` results in `subtype_id`always being `False` (as it will never be in `kwargs`) and the actual value passed via `signature_id` is not used.

This was introduced in migration from 13.0: https://github.com/OCA/social/pull/757 as the signature of `message_post` was updated to reflect the signature in Odoo core.