### PR TITLE
[11.0][IMP] mail_activity_team: better error message

### DIFF
--- a/mail_activity_team/models/mail_activity.py
+++ b/mail_activity_team/models/mail_activity.py
@@ -64,7 +64,11 @@ class MailActivity(models.Model):
             if activity.team_id and activity.user_id and \
                     activity.user_id not in self.team_id.member_ids:
                 raise ValidationError(
-                    _('The assigned user is not member of the team.'))
+                    _(
+                        "The assigned user %s is not member of the team %s."
+                        % (activity.user_id.display_name, activity.team_id.name)
+                    )
+                )
 
     @api.multi
     def action_create_calendar_event(self):


### PR DESCRIPTION
Sometimes the activities are created by another action, when that happens knowing the name of the user and the team could be very useful to identify the actual issue in the activity creation.

@ForgeFlow