### PR TITLE
[FIX] mail_tracking: use recipient_address to search emails

### DIFF
--- a/mail_tracking/views/mail_tracking_email_view.xml
+++ b/mail_tracking/views/mail_tracking_email_view.xml
@@ -105,9 +105,9 @@
                     filter_domain="[('sender', 'ilike', self)]"
                 />
             <field
-                    name="recipient"
-                    string="Recipient"
-                    filter_domain="[('recipient', 'ilike', self)]"
+                    name="recipient_address"
+                    string="Recipient Address"
+                    filter_domain="[('recipient_address', '=', self)]"
                 />
             <field name="name" string="Subject" />
             <field name="time" string="Time" />

--- a/mail_tracking/views/res_partner_view.xml
+++ b/mail_tracking/views/res_partner_view.xml
@@ -12,8 +12,8 @@
         <div name="button_box" position="inside">
             <button
                     name="%(mail_tracking.action_view_mail_tracking_email)d"
-                    context="{'search_default_recipient': email,
-                              'default_recipient': email}"
+                    context="{'search_default_recipient_address': email,
+                              'default_recipient_address': email}"
                     type="action"
                     class="oe_stat_button"
                     icon="fa-envelope-o"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This commit creates a migration script to fix all emails computed incorrectly with old version of `email_split` 

Also, we are using the field `recipient_address` in the filter of the search view
of `mail.tracking.email` in order to use the same field used in computed
method:

https://github.com/OCA/social/blob/147eda96a56c199602c619b5bac3a9911605e918/mail_tracking/models/res_partner.py#L27

Current behavior before PR:
Inconsistencies between the counter field in partners to show the number of emails tracked and the shown when clicking on itself.

Desired behavior after PR is merged:
Show correctly the same number of emails tracked in the field in partners than the shown when clicking on itself.

Fix https://github.com/OCA/social/issues/803

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr


