### PR TITLE
[12.0][mail_outbound_static][IMP]Add alias if not defined in the mail client

### DIFF
--- a/mail_outbound_static/models/ir_mail_server.py
+++ b/mail_outbound_static/models/ir_mail_server.py
@@ -32,6 +32,10 @@ class IrMailServer(models.Model):
                 )
             else:
                 email_from = mail_server.smtp_from
+                if "Message-id" in message :
+                    mail_message=self.env['mail.mail'].search([('message_id','=',message['Message-id'])],limit=1)
+                    if len(mail_message):
+                        email_from ='"%s" <%s>' % (mail_message.author_id.name,mail_server.smtp_from)
 
             message.replace_header('From', email_from)
             bounce_alias = self.env['ir.config_parameter'].sudo().get_param(

--- a/mail_outbound_static/models/ir_mail_server.py
+++ b/mail_outbound_static/models/ir_mail_server.py
@@ -35,7 +35,7 @@ class IrMailServer(models.Model):
                 if "Message-id" in message :
                     mail_message = self.env['mail.mail'].search(
                         [('message_id', '=', message['Message-id'])], limit=1)
-                    if len(mail_message) :
+                    if len(mail_message) and len(mail_message.author_id) : 
                         email_from = '"%s" <%s>' % (mail_message.author_id.name,
                                                     mail_server.smtp_from)
 

--- a/mail_outbound_static/models/ir_mail_server.py
+++ b/mail_outbound_static/models/ir_mail_server.py
@@ -33,9 +33,11 @@ class IrMailServer(models.Model):
             else:
                 email_from = mail_server.smtp_from
                 if "Message-id" in message :
-                    mail_message=self.env['mail.mail'].search([('message_id','=',message['Message-id'])],limit=1)
-                    if len(mail_message):
-                        email_from ='"%s" <%s>' % (mail_message.author_id.name,mail_server.smtp_from)
+                    mail_message = self.env['mail.mail'].search(
+                        [('message_id', '=', message['Message-id'])], limit=1)
+                    if len(mail_message) :
+                        email_from = '"%s" <%s>' % (mail_message.author_id.name,
+                                                    mail_server.smtp_from)
 
             message.replace_header('From', email_from)
             bounce_alias = self.env['ir.config_parameter'].sudo().get_param(


### PR DESCRIPTION
Not all the mail client are forcing  user to set an alias in their account.
so that the mail receivied has this pattern mail@example.com
thanks to this we add the possibility to set it with the pattern "Name" <mail@example.com>