### PR TITLE
[ADD]mail_backup_user: new module

### DIFF
--- a/mail_forwarding/README.rst
+++ b/mail_forwarding/README.rst
@@ -1,0 +1,54 @@
+================
+Mail Forwarding
+================
+
+This module allows to select a related user (called "Forwarding user") in each user in order to send all the notifications to the Forwarding user.
+
+Usage
+=====
+
+To use this module, you need to:
+
+* Install it.
+* Set a Forwarding user in your user.
+* Your Forwarding user also will be notify of your notifications
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/social/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed
+`feedback <https://github.com/OCA/social/issues/new?body=module:%20mail_debrand%0Aversion:%2013.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Do not contact contributors directly about support or help with technical issues.
+
+Credits
+=======
+
+Authors
+~~~~~~~
+
+* AdHoc SA
+
+Contributors
+~~~~~~~~~~~~
+
+* Pablo Paez <pp@adhoc.com.ar>
+
+Maintainers
+~~~~~~~~~~~
+
+This module is maintained by the OCA.
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+This module is part of the `OCA/social <https://github.com/OCA/social/tree/13.0/mail_backup_user>`_ project on GitHub.
+
+You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.

--- a/mail_forwarding/__init__.py
+++ b/mail_forwarding/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/mail_forwarding/__manifest__.py
+++ b/mail_forwarding/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2022 AdHoc SA - Pablo Paez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Mail Fowarding",
+    "summary": "cc user for notifications",
+    "version": "13.0.1.0.0",
+    "category": "Social Network",
+    "website": "https://github.com/OCA/social",
+    "author": "AdHoc SA, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "installable": True,
+    "depends": ["mail"],
+    "data": ["views/res_user_views.xml"],
+    "development_status": "Production/Stable",
+    "maintainers": [],
+}

--- a/mail_forwarding/models/__init__.py
+++ b/mail_forwarding/models/__init__.py
@@ -1,0 +1,2 @@
+from . import res_user
+from . import mail_thread

--- a/mail_forwarding/models/mail_thread.py
+++ b/mail_forwarding/models/mail_thread.py
@@ -1,0 +1,21 @@
+from odoo import api, models
+
+
+class MailThread(models.AbstractModel):
+    _inherit = "mail.thread"
+
+    @api.returns("mail.message", lambda value: value.id)
+    def message_post(self, **kwargs):
+        if kwargs.get("partner_ids", False):
+            users = self.env["res.users"].search(
+                [
+                    ("partner_id", "in", kwargs["partner_ids"]),
+                    ("share", "=", False),
+                    ("forwarding_user_id", "!=", False),
+                    ("forwarding_user_id.partner_id", "not in", kwargs["partner_ids"]),
+                ]
+            )
+            kwargs["partner_ids"].append(
+                users.mapped("forwarding_user_id.partner_id").ids
+            )
+        return super().message_post(**kwargs)

--- a/mail_forwarding/models/res_user.py
+++ b/mail_forwarding/models/res_user.py
@@ -1,0 +1,15 @@
+from odoo import fields, models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    forwarding_user_id = fields.Many2one("res.users", string="Forwarding User")
+
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + ["forwarding_user_id"]
+
+    @property
+    def SELF_WRITEABLE_FIELDS(self):
+        return super().SELF_WRITEABLE_FIELDS + ["forwarding_user_id"]

--- a/mail_forwarding/views/res_user_views.xml
+++ b/mail_forwarding/views/res_user_views.xml
@@ -1,0 +1,31 @@
+<!-- Copyright 2022 AdHoc SA - Pablo Paez - <pp@adhoc.com.ar>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+<odoo>
+
+    <record id="view_users_form_mail" model="ir.ui.view">
+        <field name="name">res.users.form.user.forwarding</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form" />
+        <field name="arch" type="xml">
+            <field name="email" position="after">
+                <field name="forwarding_user_id" domain="[('share', '=', False)]" />
+            </field>
+        </field>
+    </record>
+
+    <record id="view_users_form_mail_preferences" model="ir.ui.view">
+        <field name="name">res.users.form.user.forwarding.preferences</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form_simple_modif" />
+        <field name="arch" type="xml">
+            <field name="email" position="after">
+                <field
+                    name="forwarding_user_id"
+                    domain="[('share', '=', False)]"
+                    readonly="0"
+                />
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This module makes possible that each internal user could select (in his preferences) another internal user which will receive all messages notifications from the first user. Also this can be changed in the user form view