### PR TITLE
[FIX] mail_tracking: change order of inheritance and use return

### DIFF
--- a/mail_tracking/static/src/js/discuss/discuss.js
+++ b/mail_tracking/static/src/js/discuss/discuss.js
@@ -14,7 +14,6 @@ odoo.define("mail_tracking/static/src/js/discuss/discuss.js", function (require)
         "mail/static/src/models/messaging_initializer/messaging_initializer.js",
         {
             async start() {
-                this._super(...arguments);
                 this.messaging.update({
                     failedmsg: [
                         [
@@ -28,6 +27,7 @@ odoo.define("mail_tracking/static/src/js/discuss/discuss.js", function (require)
                         ],
                     ],
                 });
+                return this._super(...arguments);
             },
             async _init({
                 channel_slots,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Currently when an invoice view is reloaded in the browser or through native redirections, an error is raised:

```
Traceback:
TypeError: Cannot read properties of undefined (reading 'id')
at Function.convertData [as _super] (https://t50084-053-islamicrelief140.dev.irc.deployv.com/web/content/1819726-9a8777a/web.assets_backend.js:5768:118)
at Function.convertData (https://t50084-053-islamicrelief140.dev.irc.deployv.com/web/content/1819726-9a8777a/web.assets_backend.js:6651:335)
at Function.Class. (https://t50084-053-islamicrelief140.dev.irc.deployv.com/web/content/1819726-9a8777a/web.assets_backend.js:6478:107)
at Function.convertData (https://t50084-053-islamicrelief140.dev.irc.deployv.com/web/content/1819726-9a8777a/web.assets_backend.js:7779:403)
at Function.Class. (https://t50084-053-islamicrelief140.dev.irc.deployv.com/web/content/1819726-9a8777a/web.assets_backend.js:6478:107)
at Function.convertData (https://t50084-053-islamicrelief140.dev.irc.deployv.com/web/content/1819726-9a8777a/web.assets_backend.js:7818:353)
at Function.Class. (https://t50084-053-islamicrelief140.dev.irc.deployv.com/web/content/1819726-9a8777a/web.assets_backend.js:6478:107)
at Function.convertData (https://t50084-053-islamicrelief140.dev.irc.deployv.com/web/content/1819726-9a8777a/web.assets_backend.js:12197:435)
at Function.Class. (https://t50084-053-islamicrelief140.dev.irc.deployv.com/web/content/1819726-9a8777a/web.assets_backend.js:6478:107)
at https://t50084-053-islamicrelief140.dev.irc.deployv.com/web/content/1819726-9a8777a/web.assets_backend.js:5790:359
```

That is because an inheritance wrong, which breaks the flow of start of model `messaging` and causes that messages execute before the init of var `messaging`:

https://github.com/OCA/social/blob/c89880d26e16e3adffb616dbac976e460e121968/mail_tracking/static/src/js/discuss/discuss.js#L17

Current behavior before PR:
Error raised when re-load the view form of invoices.

Desired behavior after PR is merged:
No errors are raised when re-load the view of the form of invoices.

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
