### PR TITLE
[12.0][FIX] mail_activity_board: wrong typo for view extend

### DIFF
--- a/mail_activity_board/__manifest__.py
+++ b/mail_activity_board/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Activities board',
     'summary': 'Add Activity Boards',
-    'version': '12.0.1.1.0',
+    'version': '12.0.1.1.1',
     'development_status': 'Beta',
     'category': 'Social Network',
     'website': 'https://github.com/OCA/social',

--- a/mail_activity_board/static/src/xml/inherit_chatter.xml
+++ b/mail_activity_board/static/src/xml/inherit_chatter.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-extend="mail.Chatter.Buttons">
-         <t t-jquery="button.o_chatter_button_schedule_activity" t-operation="after">
-             <button t-if="schedule_activity_btn" class="btn btn-sm btn-link o_chatter_button_list_activity"
-                     title="See activities list" type="button">
-                 <i class="fa fa-list"/> Activities
-             </button>
-         </t>
+    <t t-extend="mail.chatter.Buttons">
+        <t t-jquery="button.o_chatter_button_schedule_activity" t-operation="after">
+            <button t-if="schedule_activity_btn" class="btn btn-sm btn-link o_chatter_button_list_activity"
+                    title="See activities list" type="button">
+                <i class="fa fa-list"/> Activities
+            </button>
+        </t>
     </t>
 
 </templates>


### PR DESCRIPTION
Wrongly used `mail.Chatter.Buttons` instead of `mail.chatter.Buttons`