### PR TITLE
[14.0][FIX] mass_mailing_subscription_email: /unsubscribe_from_list link

### DIFF
--- a/mass_mailing_subscription_email/__init__.py
+++ b/mass_mailing_subscription_email/__init__.py
@@ -1,2 +1,3 @@
+from . import controllers
 from . import models
 from .hooks import post_init_hook

--- a/mass_mailing_subscription_email/__manifest__.py
+++ b/mass_mailing_subscription_email/__manifest__.py
@@ -16,6 +16,5 @@
         "data/mail_template.xml",
         "views/mailing_list.xml",
     ],
-    "demo": ["demo/mailing_list.xml"],
     "post_init_hook": "post_init_hook",
 }

--- a/mass_mailing_subscription_email/controllers/__init__.py
+++ b/mass_mailing_subscription_email/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/mass_mailing_subscription_email/controllers/main.py
+++ b/mass_mailing_subscription_email/controllers/main.py
@@ -1,0 +1,27 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import http
+from odoo.exceptions import AccessDenied
+from odoo.http import request
+from odoo.tools import consteq
+
+from odoo.addons.mass_mailing.controllers.main import MassMailController
+
+
+class MassMailSubscriptionEmailController(MassMailController):
+    @http.route(
+        "/mail/mailing/contact/<int:res_id>/unsubscribe",
+        type="http",
+        website=True,
+        auth="public",
+    )
+    def mailing_contact_unsubscribe(self, res_id, email=None, token="", **post):
+        subscription = request.env["mailing.contact.subscription"].sudo().browse(res_id)
+        if not subscription.exists():  # pragma: no cover
+            return request.redirect("/web")
+        if not consteq(subscription._unsubscribe_token(), token):  # pragma: no cover
+            raise AccessDenied()
+        subscription.opt_out = True
+        return request.render("mass_mailing.page_unsubscribed")

--- a/mass_mailing_subscription_email/models/__init__.py
+++ b/mass_mailing_subscription_email/models/__init__.py
@@ -1,2 +1,3 @@
+from . import mail_mail
 from . import mailing_list
 from . import mailing_contact_subscription

--- a/mass_mailing_subscription_email/models/mail_mail.py
+++ b/mass_mailing_subscription_email/models/mail_mail.py
@@ -1,0 +1,20 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class MailMail(models.Model):
+    _inherit = "mail.mail"
+
+    def _send_prepare_values(self, partner=None):
+        # OVERRIDE to replace /unsubscribe_from_list url
+        res = super()._send_prepare_values(partner)
+        if self.model == "mailing.contact.subscription":
+            subscription = self.env["mailing.contact.subscription"].browse(self.res_id)
+            url_to_replace = "/unsubscribe_from_list"
+            url_to_replace_with = subscription._get_unsubscribe_url() or "#"
+            if url_to_replace in res["body"]:
+                res["body"] = res["body"].replace(url_to_replace, url_to_replace_with)
+        return res

--- a/mass_mailing_subscription_email/tests/__init__.py
+++ b/mass_mailing_subscription_email/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_subscription_email
+from . import test_unsubscribe_from_list

--- a/mass_mailing_subscription_email/tests/test_subscription_email.py
+++ b/mass_mailing_subscription_email/tests/test_subscription_email.py
@@ -22,15 +22,14 @@ class TestSubscriptionEmail(SavepointCase, MockEmail):
         module_name = "mass_mailing_subscription_email"
         cls.subscribe_tmpl = cls.env.ref(f"{module_name}.mailing_list_subscribe")
         cls.unsubscribe_tmpl = cls.env.ref(f"{module_name}.mailing_list_unsubscribe")
+        # Set some tmpl values to ease tests
+        cls.email_from = "your-company@example.com"
+        cls.subscribe_tmpl.email_from = cls.email_from
+        cls.subscribe_tmpl.subject = "SUBSCRIBED"
+        cls.unsubscribe_tmpl.email_from = cls.email_from
+        cls.unsubscribe_tmpl.subject = "UNSUBSCRIBED"
 
     def test_subscription_email(self):
-        # Set some tmpl values to ease tests
-        email_from = "your-company@example.com"
-        email_to = self.mailing_contact.email
-        self.subscribe_tmpl.email_from = email_from
-        self.unsubscribe_tmpl.email_from = email_from
-        self.subscribe_tmpl.subject = "SUBSCRIBED"
-        self.unsubscribe_tmpl.subject = "UNSUBSCRIBED"
         # Create subscription
         with self.mock_mail_gateway():
             subs = self.env["mailing.contact.subscription"].create(
@@ -39,26 +38,26 @@ class TestSubscriptionEmail(SavepointCase, MockEmail):
                     "list_id": self.mailing_list.id,
                 }
             )
-        self.assertEqual(self._new_mails.email_from, email_from)
-        self.assertEqual(self._new_mails.email_to, email_to)
+        self.assertEqual(self._new_mails.email_from, self.email_from)
+        self.assertEqual(self._new_mails.email_to, self.mailing_contact.email)
         self.assertEqual(self._new_mails.subject, "SUBSCRIBED")
         # Unsubscribe
         with self.mock_mail_gateway():
             subs.opt_out = True
-        self.assertEqual(self._new_mails.email_from, email_from)
-        self.assertEqual(self._new_mails.email_to, email_to)
+        self.assertEqual(self._new_mails.email_from, self.email_from)
+        self.assertEqual(self._new_mails.email_to, self.mailing_contact.email)
         self.assertEqual(self._new_mails.subject, "UNSUBSCRIBED")
         # Subscribe again
         with self.mock_mail_gateway():
             subs.opt_out = False
-        self.assertEqual(self._new_mails.email_from, email_from)
-        self.assertEqual(self._new_mails.email_to, email_to)
+        self.assertEqual(self._new_mails.email_from, self.email_from)
+        self.assertEqual(self._new_mails.email_to, self.mailing_contact.email)
         self.assertEqual(self._new_mails.subject, "SUBSCRIBED")
         # Unsubscribe through unlinking
         with self.mock_mail_gateway():
             subs.unlink()
-        self.assertEqual(self._new_mails.email_from, email_from)
-        self.assertEqual(self._new_mails.email_to, email_to)
+        self.assertEqual(self._new_mails.email_from, self.email_from)
+        self.assertEqual(self._new_mails.email_to, self.mailing_contact.email)
         self.assertEqual(self._new_mails.subject, "UNSUBSCRIBED")
 
     def test_subscription_email_disabled(self):

--- a/mass_mailing_subscription_email/tests/test_unsubscribe_from_list.py
+++ b/mass_mailing_subscription_email/tests/test_unsubscribe_from_list.py
@@ -1,0 +1,41 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from lxml import etree
+
+from odoo.tests import HttpCase, tagged
+
+from odoo.addons.mail.tests.common import MockEmail
+
+
+@tagged("-at_install", "post_install")
+class WebsiteSaleHttpCase(HttpCase, MockEmail):
+    def setUp(self):
+        super().setUp()
+        self.env = self.env(context=dict(self.env.context, tracking_disable=True))
+        self.mailing_list = self.env.ref("mass_mailing.mailing_list_data")
+        self.mailing_contact = self.env["mailing.contact"].create(
+            {
+                "name": "John Doe",
+                "email": "john.doe@example.com",
+            }
+        )
+
+    def test_subscription_email_unsubscribe_from_list(self):
+        # Create subscription
+        with self.mock_mail_gateway():
+            subs = self.env["mailing.contact.subscription"].create(
+                {
+                    "contact_id": self.mailing_contact.id,
+                    "list_id": self.mailing_list.id,
+                }
+            )
+        body = self._new_mails._send_prepare_values()["body"]
+        root = etree.fromstring(body, etree.HTMLParser())
+        anchor = root.xpath("//a[@href]")[0]
+        unsubscribe_url = anchor.attrib["href"]
+        web_base_url = self.env["ir.config_parameter"].sudo().get_param("web.base.url")
+        self.url_open(unsubscribe_url.replace(web_base_url, ""))
+        subs.invalidate_cache()
+        self.assertEqual(subs.opt_out, True)


### PR DESCRIPTION
This fixes the case where `/unsubcribe_from_list` is added to the subscription email notification.

As the subscribe notification is sent through a `mail.template`, and not through a `mailing.mailing` record, odoo won't automagically handle the href replacement.

Moreover, the core controller only works with an actual `mailing.mailing` record, that may not even exist at the time the notification is sent. So, a new controller is added to handle this unsubscribe.