### PR TITLE
[FIX] mail_tracking: error when filtering by "Sent"

### DIFF
--- a/mail_tracking/views/mail_tracking_email_view.xml
+++ b/mail_tracking/views/mail_tracking_email_view.xml
@@ -104,7 +104,7 @@
             <field name="name" string="Subject" />
             <field name="time" string="Time" />
             <field name="date" string="Date" />
-            <filter name="sent" string="Sent" domain="[('state', 'in', ('sent',))]" />
+            <filter name="sent" string="Sent" domain="[('state', '=', 'sent')]" />
             <filter
                     name="deferred"
                     string="Deferred"


### PR DESCRIPTION
Problem:

~/web#action=928&cids=1&menu_id=282&model=mail.tracking.email&view_type=list

Go to: Email Marketing -> Mail Tracking -> Emails
Click Filters and select "Sent"

Error:
Odoo Server Error

Traceback (most recent call last):
  File "/opt/odoo13/odoo/odoo/http.py", line 624, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo13/odoo/odoo/http.py", line 310, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/opt/odoo13/odoo/odoo/tools/pycompat.py", line 14, in reraise
    raise value
  File "/opt/odoo13/odoo/odoo/http.py", line 669, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo13/odoo/odoo/http.py", line 350, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo13/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo13/odoo/odoo/http.py", line 339, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo13/odoo/odoo/http.py", line 915, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo13/odoo/odoo/http.py", line 515, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo13/odoo/addons/web/controllers/main.py", line 1300, in search_read
    return self.do_search_read(model, fields, offset, limit, domain, sort)
  File "/opt/odoo13/odoo/addons/web/controllers/main.py", line 1319, in do_search_read
    return Model.web_search_read(domain, fields, offset=offset, limit=limit, order=sort)
  File "/opt/odoo13/odoo/addons/web/models/models.py", line 48, in web_search_read
    records = self.search_read(domain, fields, offset=offset, limit=limit, order=order)
  File "/opt/odoo13/odoo/odoo/models.py", line 4960, in search_read
    records = self.search(domain or [], offset=offset, limit=limit, order=order)
  File "/opt/odoo13/odoo/odoo/models.py", line 1657, in search
    res = self._search(args, offset=offset, limit=limit, order=order, count=count)
  File "/opt/odoo13/odoo/odoo/models.py", line 4505, in _search
    query = self._where_calc(args)
  File "/opt/odoo13/odoo/odoo/models.py", line 4227, in _where_calc
    where_clause, where_params = e.to_sql()
  File "/opt/odoo13/odoo/odoo/osv/expression.py", line 1296, in to_sql
    q, ps = self.__leaf_to_sql(leaf)
  File "/opt/odoo13/odoo/odoo/osv/expression.py", line 1238, in __leaf_to_sql
    raise ValueError("Invalid domain term %r" % (leaf,))
ValueError: Invalid domain term ('state', 'in', 'sent')

Solution:
Minor edit to: mail.tracking.email.search