### PR TITLE
[15.0][IMP][mail_show_follower] Customize notification appearance

### DIFF
--- a/mail_show_follower/README.rst
+++ b/mail_show_follower/README.rst
@@ -41,8 +41,11 @@ Configuration
 
 To configure this module, you need to:
 
-#. Go General settings/Discuss/Show Internal Users CC and set if want to show or not internal users in cc details.
+#. Go General settings/Discuss/Show Followers on mails/Show Internal Users CC and set if want to show or not internal users in cc details.
 #. Go Settings/Users & Company salect any user in 'Preferences' check or not the 'Show in CC' field if this user need to appear in the cc note.
+#. Go General settings/Discuss/Show Followers on mails/Text 'Sent to' and set the initial part of the message.
+#. Go General settings/Discuss/Show Followers on mails/Partner format and choose desired fields to show on CC recipients.
+#. Go General settings/Discuss/Show Followers on mails/Text 'Replies' and choose desired warn message
 
 Usage
 =====
@@ -68,12 +71,14 @@ Authors
 ~~~~~~~
 
 * Sygel
+* Moduon
 
 Contributors
 ~~~~~~~~~~~~
 
 * Valentin Vinagre <valentin.vinagre@sygel.es>
 * Lorenzo Battistini
+* Eduardo de Miguel <edu@moduon.team>
 
 Maintainers
 ~~~~~~~~~~~

--- a/mail_show_follower/__manifest__.py
+++ b/mail_show_follower/__manifest__.py
@@ -1,13 +1,14 @@
 # Copyright 2020 Valentin Vinagre <valentin.vinagre@sygel.es>
+# Copyright 2022 Eduardo de Miguel <edu@moduon.team>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {
     "name": "Mail Show Follower",
     "summary": "Show CC document followers in mails.",
-    "version": "15.0.1.0.0",
+    "version": "15.0.1.1.0",
     "category": "Mail",
     "website": "https://github.com/OCA/social",
-    "author": "Sygel, Odoo Community Association (OCA)",
+    "author": "Sygel, Moduon, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,
     "installable": True,

--- a/mail_show_follower/models/res_company.py
+++ b/mail_show_follower/models/res_company.py
@@ -5,5 +5,24 @@ class ResCompany(models.Model):
     _inherit = "res.company"
 
     show_internal_users_cc = fields.Boolean(
-        string="Show Internal Users CC", default=True
+        string="Show Internal Users CC",
+        default=True,
+    )
+    show_followers_message_sent_to = fields.Html(
+        string="Text 'Sent to'",
+        translate=True,
+        default="This message has been sent to",
+    )
+    show_followers_partner_format = fields.Char(
+        string="Partner format",
+        default="%(partner_name)s",
+        help="Supported parameters:\n"
+        "%(partner_name)s = Partner Name\n"
+        "%(partner_email)s = Partner Email\n"
+        "%(partner_email_domain)s = Partner Email Domain",
+    )
+    show_followers_message_response_warning = fields.Html(
+        string="Text 'Replies'",
+        translate=True,
+        default="Notice: Replies to this email will be sent to all recipients",
     )

--- a/mail_show_follower/models/res_config_settings.py
+++ b/mail_show_follower/models/res_config_settings.py
@@ -1,11 +1,51 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
     show_internal_users_cc = fields.Boolean(
-        string="Show Internal Users CC",
         related="company_id.show_internal_users_cc",
         readonly=False,
     )
+    show_followers_message_sent_to = fields.Html(
+        related="company_id.show_followers_message_sent_to",
+        readonly=False,
+    )
+    show_followers_partner_format = fields.Char(
+        related="company_id.show_followers_partner_format",
+        readonly=False,
+        help="Supported parameters:\n"
+        "%(partner_name)s = Partner Name\n"
+        "%(partner_email)s = Partner Email\n"
+        "%(partner_email_domain)s = Partner Email Domain",
+    )
+    show_followers_message_response_warning = fields.Html(
+        related="company_id.show_followers_message_response_warning",
+        readonly=False,
+    )
+    show_followers_message_preview = fields.Html(
+        string="Message preview",
+        readonly=True,
+        store=False,
+    )
+
+    @api.onchange(
+        "show_followers_message_sent_to",
+        "show_followers_partner_format",
+        "show_followers_message_response_warning",
+    )
+    def onchange_show_followers_message_preview(self):
+        self.show_followers_message_preview = (
+            self.env["mail.mail"]
+            .with_context(
+                # Use current data before
+                partner_format=self.show_followers_partner_format or "",
+                msg_sent_to=self.show_followers_message_sent_to or "",
+                msg_warn=self.show_followers_message_response_warning or "",
+            )
+            ._build_cc_text(
+                # Sample partners
+                self.env["res.partner"].search([("email", "!=", False)], limit=3),
+            )
+        )

--- a/mail_show_follower/readme/CONFIGURE.rst
+++ b/mail_show_follower/readme/CONFIGURE.rst
@@ -1,4 +1,7 @@
 To configure this module, you need to:
 
-#. Go General settings/Discuss/Show Internal Users CC and set if want to show or not internal users in cc details.
+#. Go General settings/Discuss/Show Followers on mails/Show Internal Users CC and set if want to show or not internal users in cc details.
 #. Go Settings/Users & Company salect any user in 'Preferences' check or not the 'Show in CC' field if this user need to appear in the cc note.
+#. Go General settings/Discuss/Show Followers on mails/Text 'Sent to' and set the initial part of the message.
+#. Go General settings/Discuss/Show Followers on mails/Partner format and choose desired fields to show on CC recipients.
+#. Go General settings/Discuss/Show Followers on mails/Text 'Replies' and choose desired warn message

--- a/mail_show_follower/readme/CONTRIBUTORS.rst
+++ b/mail_show_follower/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Valentin Vinagre <valentin.vinagre@sygel.es>
 * Lorenzo Battistini
+* Eduardo de Miguel <edu@moduon.team>

--- a/mail_show_follower/static/description/index.html
+++ b/mail_show_follower/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Mail Show Follower</title>
 <style type="text/css">
 
@@ -392,8 +392,11 @@ In the cc, only appear when:</p>
 <h1><a class="toc-backref" href="#id1">Configuration</a></h1>
 <p>To configure this module, you need to:</p>
 <ol class="arabic simple">
-<li>Go General settings/Discuss/Show Internal Users CC and set if want to show or not internal users in cc details.</li>
+<li>Go General settings/Discuss/Show Followers on mails/Show Internal Users CC and set if want to show or not internal users in cc details.</li>
 <li>Go Settings/Users &amp; Company salect any user in ‘Preferences’ check or not the ‘Show in CC’ field if this user need to appear in the cc note.</li>
+<li>Go General settings/Discuss/Show Followers on mails/Text ‘Sent to’ and set the initial part of the message.</li>
+<li>Go General settings/Discuss/Show Followers on mails/Partner format and choose desired fields to show on CC recipients.</li>
+<li>Go General settings/Discuss/Show Followers on mails/Text ‘Replies‘ and choose desired warn message</li>
 </ol>
 </div>
 <div class="section" id="usage">
@@ -417,6 +420,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#id5">Authors</a></h2>
 <ul class="simple">
 <li>Sygel</li>
+<li>Moduon</li>
 </ul>
 </div>
 <div class="section" id="contributors">
@@ -424,6 +428,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <ul class="simple">
 <li>Valentin Vinagre &lt;<a class="reference external" href="mailto:valentin.vinagre&#64;sygel.es">valentin.vinagre&#64;sygel.es</a>&gt;</li>
 <li>Lorenzo Battistini</li>
+<li>Eduardo de Miguel &lt;<a class="reference external" href="mailto:edu&#64;moduon.team">edu&#64;moduon.team</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/mail_show_follower/views/res_config_settings.xml
+++ b/mail_show_follower/views/res_config_settings.xml
@@ -10,12 +10,68 @@
             <div id="emails" position="inside">
                 <div class="col-12 col-lg-6 o_setting_box">
                     <div class="o_setting_left_pane">
-                        <field name="show_internal_users_cc" />
                     </div>
                     <div class="o_setting_right_pane">
-                        <label for="show_internal_users_cc" />
-                        <div class="text-muted" id="show_internal_users_cc">
-                            Add internal users in cc mails details
+                        <div class="content-group">
+                            <label
+                                for="show_internal_users_cc"
+                                string="Show Followers on mails"
+                            />
+                            <div>
+                                <div>
+                                    <label
+                                        for="show_internal_users_cc"
+                                        class="o_light_label"
+                                        string="Show Internal Users on CC"
+                                    />
+                                    <field name="show_internal_users_cc" />
+                                </div>
+                                <div>
+                                    <label
+                                        for="show_followers_message_sent_to"
+                                        class="o_light_label"
+                                        style="vertical-align: top;"
+                                    />
+                                    <field
+                                        name="show_followers_message_sent_to"
+                                        placeholder="This message has been sent to"
+                                        style="display:inline-block;"
+                                    />
+                                </div>
+                                <div>
+                                    <label
+                                        for="show_followers_partner_format"
+                                        class="o_light_label"
+                                        style="vertical-align: top;"
+                                    />
+                                    <field
+                                        name="show_followers_partner_format"
+                                        placeholder="%%(partner_name)s &lt;%%(partner_email)s&gt;"
+                                        style="display:inline-block;"
+                                    />
+                                </div>
+                                <div>
+                                    <label
+                                        for="show_followers_message_response_warning"
+                                        class="o_light_label"
+                                        style="vertical-align: top;"
+                                    />
+                                    <field
+                                        name="show_followers_message_response_warning"
+                                        placeholder="Notice: Replies to this email will be sent to all recipients."
+                                        style="display:inline-block;"
+                                    />
+                                </div>
+                            </div>
+                            <label
+                                for="show_followers_message_preview"
+                                class="text-muted"
+                            />
+                            <field
+                                name="show_followers_message_preview"
+                                style="width:100%;"
+                                widget="html"
+                            />
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Added settings to customize notification and translations to important parts of the message.

`show_followers_message_sent_to`: The first part of the message
`show_followers_partner_format`: Partner format for emails. You can chooose which fields to show
`show_followers_message_response_warning`: Additional text if you want to warn for the reply behavior

Includes a preview of the message on settings (only visible if you are in debug mode)
**The lang of the message is on the same as the recipient.** Some customization settings are translatable (enable another language to test properly)

@Yajo @rafaelbn @HaraldPanten @ValentinVinagre @pedrobaeza @flotho @cvinh @tafaRU  please review 😄 

MT-431 @moduon