### PR TITLE
[14.0][IMP][mail_filter_adressee_by_contact] differenciate users and partners in mail filter

### DIFF
--- a/mail_filter_adressee_by_contact/__manifest__.py
+++ b/mail_filter_adressee_by_contact/__manifest__.py
@@ -9,12 +9,14 @@
     "category": "Social Network",
     "website": "https://github.com/OCA/social",
     "author": "Akretion, Odoo Community Association (OCA)",
+    "maintainers": ["Kev-Roche"],
     "license": "AGPL-3",
     "application": False,
     "installable": True,
     "depends": [
         "mail",
         "account",
+        "sale",
     ],
     "data": [
         "views/mail_compose_message_view.xml",

--- a/mail_filter_adressee_by_contact/models/__init__.py
+++ b/mail_filter_adressee_by_contact/models/__init__.py
@@ -1,1 +1,2 @@
 from . import mail_compose_message
+from . import account_invoice_send

--- a/mail_filter_adressee_by_contact/models/account_invoice_send.py
+++ b/mail_filter_adressee_by_contact/models/account_invoice_send.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2022 Akretion (<http://www.akretion.com>).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class AccountInvoiceSend(models.TransientModel):
+    _inherit = "account.invoice.send"
+
+    @api.onchange("apply_filter")
+    def _onchange_apply_filter(self):
+        return self.composer_id.get_partner_ids_domain()

--- a/mail_filter_adressee_by_contact/models/mail_compose_message.py
+++ b/mail_filter_adressee_by_contact/models/mail_compose_message.py
@@ -3,13 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
-
-FILTERED_MODEL = [
-    "account.move",
-    "sale.order",
-    "purchase.order",
-    "stock.picking",
-]
+from odoo.osv import expression
 
 
 class MailComposer(models.TransientModel):
@@ -23,21 +17,43 @@ class MailComposer(models.TransientModel):
         "Additional Contacts",
     )
 
-    apply_filter = fields.Boolean(default=True, string="Filtering relevant adressees")
+    apply_filter = fields.Selection(
+        (
+            [
+                ("contacts", "Contacts"),
+                ("users", "Users"),
+                ("all", "All"),
+            ]
+        ),
+        string="Filtering relevant adressees",
+        default="contacts",
+        required=True,
+    )
 
     @api.onchange("apply_filter")
-    def _get_partner_ids_domain(self):
+    def get_partner_ids_domain(self):
         domain = [("type", "!=", "private")]
         model = self._context.get("active_model")
-        if model in FILTERED_MODEL and self.apply_filter:
-            domain.insert(0, "&")
-            records = self.env[self._context["active_model"]].browse(
-                self._context.get("active_ids")
+        if model and self.apply_filter == "contacts":
+            method_name = f"_get_domain_for_{model.replace('.', '_')}"
+            if hasattr(self, method_name):
+                records = self.env[self._context["active_model"]].browse(
+                    self._context.get("active_ids")
+                )
+                partners = getattr(self, method_name)(records)
+                domain = expression.AND(
+                    [
+                        domain,
+                        partners,
+                    ]
+                )
+        if self.apply_filter == "users":
+            domain = expression.AND(
+                [
+                    domain,
+                    [("user_ids", "!=", False)],
+                ]
             )
-            partners = getattr(self, f"_get_domain_for_{model.replace('.', '_')}")(
-                records
-            )
-            domain += partners
         return {"domain": {"partner_ids": domain}}
 
     def _get_domain_for_sale_order(self, records):
@@ -45,8 +61,6 @@ class MailComposer(models.TransientModel):
             "|",
             "|",
             "|",
-            "|",
-            ("user_ids", "!=", False),
             ("id", "child_of", records.partner_id.ids),
             ("id", "child_of", records.partner_invoice_id.ids),
             ("id", "child_of", records.partner_shipping_id.ids),
@@ -57,8 +71,6 @@ class MailComposer(models.TransientModel):
         return [
             "|",
             "|",
-            "|",
-            ("user_ids", "!=", False),
             ("id", "child_of", records.partner_id.ids),
             ("id", "child_of", records.partner_shipping_id.ids),
             ("id", "in", records.message_partner_ids.ids),
@@ -67,8 +79,6 @@ class MailComposer(models.TransientModel):
     def _get_domain_for_purchase_order(self, records):
         return [
             "|",
-            "|",
-            ("user_ids", "!=", False),
             ("id", "child_of", records.partner_id.ids),
             ("id", "in", records.message_partner_ids.ids),
         ]
@@ -76,8 +86,6 @@ class MailComposer(models.TransientModel):
     def _get_domain_for_stock_picking(self, records):
         return [
             "|",
-            "|",
-            ("user_ids", "!=", False),
             ("id", "child_of", records.partner_id.ids),
             ("id", "in", records.message_partner_ids.ids),
         ]

--- a/mail_filter_adressee_by_contact/views/mail_compose_message_view.xml
+++ b/mail_filter_adressee_by_contact/views/mail_compose_message_view.xml
@@ -7,8 +7,11 @@
         <field name="arch" type="xml">
             <field name="partner_ids" position="before">
                 <div>
-                    <field name="apply_filter" widget="boolean_toggle" />
-                    <span name="apply_filter">Filter Email</span>
+                    <field
+                        name="apply_filter"
+                        widget="radio"
+                        options="{'horizontal': True}"
+                    />
                 </div>
             </field>
         </field>

--- a/mail_filter_adressee_by_contact/views/mail_invoice_send_view.xml
+++ b/mail_filter_adressee_by_contact/views/mail_invoice_send_view.xml
@@ -5,9 +5,15 @@
         <field name="model">account.invoice.send</field>
         <field name="inherit_id" ref="account.account_invoice_send_wizard_form" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='template_id']" position="after">
-                <field name="apply_filter" />
-            </xpath>
+            <field name="partner_ids" position="before">
+                <div>
+                    <field
+                        name="apply_filter"
+                        widget="radio"
+                        options="{'horizontal': True}"
+                    />
+                </div>
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Today, the email filter on adresses doesn't differentiate users and partners. 
But some companies have a large amount of users. In this case, the adresses's filter do not fully fulfill its role.
We propose here to replace the apply_filter boolean (filter/no filter) by a selection field with : 
- Users : only users
- Partners : only partners (by default)
- All : no filter

Also add me as maintainer of this module. 

cc @rafaelbn, @sebastienbeau 
