### PR TITLE
[13.0] mass_mailing_partner: Fix assignation of company name

### DIFF
--- a/mass_mailing_partner/models/res_partner.py
+++ b/mass_mailing_partner/models/res_partner.py
@@ -79,9 +79,9 @@ class ResPartner(models.Model):
             mm_vals["email"] = vals["email"]
         if vals.get("title"):
             mm_vals["title_id"] = vals["title"]
-        if vals.get("company_id"):
-            company = self.env["res.company"].browse(vals.get("company_id"))
-            mm_vals["company_name"] = company.name
+        if vals.get("parent_id"):
+            parent = self.browse(vals.get("parent_id"))
+            mm_vals["company_name"] = parent.commercial_company_name
         if vals.get("country_id"):
             mm_vals["country_id"] = vals["country_id"]
         if vals.get("category_id"):


### PR DESCRIPTION
Defining a res.company on a partner should not set the company_name
on a mailing contact as the mailing contact is not linked to a
res.company.
The company_name should instead be set according to the commercial
partner of the partner being modified if it's parent_id is changed.

Related to the handling of company issues of the module (cf https://github.com/OCA/social/pull/778)
