### PR TITLE
[13.0] add mass_mailing_contact_active and mass_mailing_partner_contact_active

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,18 +36,18 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.6-odoo13.0:latest
-            include: "mail_restrict_follower_selection"
+            include: "mail_restrict_follower_selection,mass_mailing_contact_active,mass_mailing_partner_contact_active"
             makepot: "true"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.6-ocb13.0:latest
-            include: "mail_restrict_follower_selection"
+            include: "mail_restrict_follower_selection,mass_mailing_contact_active,mass_mailing_partner_contact_active"
             name: test with OCB
           - container: ghcr.io/oca/oca-ci/py3.6-odoo13.0:latest
-            exclude: "mail_restrict_follower_selection"
+            exclude: "mail_restrict_follower_selection,mass_mailing_contact_active,mass_mailing_partner_contact_active"
             makepot: "true"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.6-ocb13.0:latest
-            exclude: "mail_restrict_follower_selection"
+            exclude: "mail_restrict_follower_selection,mass_mailing_contact_active,mass_mailing_partner_contact_active"
             name: test with OCB
     services:
       postgres:

--- a/mass_mailing_contact_active/__init__.py
+++ b/mass_mailing_contact_active/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/mass_mailing_contact_active/__manifest__.py
+++ b/mass_mailing_contact_active/__manifest__.py
@@ -1,0 +1,14 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Mass Mailing Contact Active",
+    "summary": "Adds active feature on mailing list contact and subscriptions",
+    "version": "13.0.1.0.0",
+    "category": "Marketing/Email Marketing",
+    "website": "https://github.com/OCA/social",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": ["mass_mailing"],
+}

--- a/mass_mailing_contact_active/models/__init__.py
+++ b/mass_mailing_contact_active/models/__init__.py
@@ -1,0 +1,2 @@
+from . import mailing_contact
+from . import mailing_contact_subscription

--- a/mass_mailing_contact_active/models/mailing_contact.py
+++ b/mass_mailing_contact_active/models/mailing_contact.py
@@ -1,0 +1,16 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class MailingContact(models.Model):
+
+    _inherit = "mailing.contact"
+
+    active = fields.Boolean(default=True)
+
+    def write(self, values):
+        res = super().write(values)
+        if "active" in values:
+            self.mapped("subscription_list_ids").write({"active": values["active"]})
+        return res

--- a/mass_mailing_contact_active/models/mailing_contact_subscription.py
+++ b/mass_mailing_contact_active/models/mailing_contact_subscription.py
@@ -1,0 +1,10 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class MailingContactSubscription(models.Model):
+
+    _inherit = "mailing.contact.subscription"
+
+    active = fields.Boolean(default=True)

--- a/mass_mailing_contact_active/readme/CONTRIBUTORS.rst
+++ b/mass_mailing_contact_active/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/mass_mailing_contact_active/readme/DESCRIPTION.rst
+++ b/mass_mailing_contact_active/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module adds an active field on mailing contact and subscription.

--- a/mass_mailing_contact_active/tests/__init__.py
+++ b/mass_mailing_contact_active/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_mailing_contact_active

--- a/mass_mailing_contact_active/tests/test_mailing_contact_active.py
+++ b/mass_mailing_contact_active/tests/test_mailing_contact_active.py
@@ -1,0 +1,19 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.tests.common import SavepointCase
+
+
+class TestMailingContactActive(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.mailing_contact = cls.env.ref("mass_mailing.mass_mail_contact_1")
+
+    def test_archive_unarchive_mailing_contact(self):
+        self.assertTrue(self.mailing_contact.active)
+        subscription = self.mailing_contact.subscription_list_ids
+        self.assertTrue(subscription)
+        self.assertTrue(subscription.active)
+        self.mailing_contact.write({"active": False})
+        self.assertFalse(self.mailing_contact.active)
+        self.assertFalse(subscription.active)

--- a/mass_mailing_partner_contact_active/__init__.py
+++ b/mass_mailing_partner_contact_active/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/mass_mailing_partner_contact_active/__manifest__.py
+++ b/mass_mailing_partner_contact_active/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Mass Mailing Partner Contact Active",
+    "summary": "Archive/unarchvice mailing list contact through partner",
+    "version": "13.0.1.0.0",
+    "category": "Marketing/Email Marketing",
+    "website": "https://github.com/OCA/social",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "auto_install": True,
+    "depends": ["mass_mailing_partner", "mass_mailing_contact_active"],
+}

--- a/mass_mailing_partner_contact_active/models/__init__.py
+++ b/mass_mailing_partner_contact_active/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_partner

--- a/mass_mailing_partner_contact_active/models/res_partner.py
+++ b/mass_mailing_partner_contact_active/models/res_partner.py
@@ -1,0 +1,16 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models
+
+
+class ResPartner(models.Model):
+
+    _inherit = "res.partner"
+
+    def write(self, values):
+        res = super().write(values)
+        if "active" in values:
+            self.env["mailing.contact"].with_context(active_test=False).sudo().search(
+                [("partner_id", "in", self.ids)]
+            ).write({"active": values["active"]})
+        return res

--- a/mass_mailing_partner_contact_active/readme/CONTRIBUTORS.rst
+++ b/mass_mailing_partner_contact_active/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/mass_mailing_partner_contact_active/readme/DESCRIPTION.rst
+++ b/mass_mailing_partner_contact_active/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module automatically triggers archive/unarchive operations on partner
+to the mailing list contact and its subscriptions.

--- a/mass_mailing_partner_contact_active/readme/ROADMAP.rst
+++ b/mass_mailing_partner_contact_active/readme/ROADMAP.rst
@@ -1,0 +1,1 @@
+Merge this module in mass_mailing_partner?

--- a/mass_mailing_partner_contact_active/tests/__init__.py
+++ b/mass_mailing_partner_contact_active/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_mailing_partner_contact_active

--- a/mass_mailing_partner_contact_active/tests/test_mailing_partner_contact_active.py
+++ b/mass_mailing_partner_contact_active/tests/test_mailing_partner_contact_active.py
@@ -1,0 +1,21 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.tests.common import SavepointCase
+
+
+class TestMailingPartnerContactActive(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.mailing_contact = cls.env.ref("mass_mailing.mass_mail_contact_1")
+        cls.partner = cls.env["res.partner"].create(
+            cls.mailing_contact._prepare_partner()
+        )
+        cls.mailing_contact.write({"partner_id": cls.partner.id})
+
+    def test_archive_unarchive_partner(self):
+        self.assertTrue(self.partner.active)
+        self.assertTrue(self.mailing_contact.active)
+        self.partner.write({"active": False})
+        self.assertFalse(self.partner.active)
+        self.assertFalse(self.mailing_contact.active)

--- a/setup/mass_mailing_contact_active/odoo/addons/mass_mailing_contact_active
+++ b/setup/mass_mailing_contact_active/odoo/addons/mass_mailing_contact_active
@@ -1,0 +1,1 @@
+../../../../mass_mailing_contact_active

--- a/setup/mass_mailing_contact_active/setup.py
+++ b/setup/mass_mailing_contact_active/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/mass_mailing_partner_contact_active/odoo/addons/mass_mailing_partner_contact_active
+++ b/setup/mass_mailing_partner_contact_active/odoo/addons/mass_mailing_partner_contact_active
@@ -1,0 +1,1 @@
+../../../../mass_mailing_partner_contact_active

--- a/setup/mass_mailing_partner_contact_active/setup.py
+++ b/setup/mass_mailing_partner_contact_active/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This PR includes two modules:

 - mass_mailing_contact_active: This module adds an active field on mailing contact and subscription.
 - mass_mailing_partner_contact_active: This module automatically triggers archive/unarchive operations on partner
to the mailing list contact and its subscriptions.

Closes: #520 