### PR TITLE
[14.0][FIX] mass_mailing_partner: Use width inheritance and prevents buttons from wrapping to fit the page

### DIFF
--- a/mass_mailing_partner/views/res_partner_view.xml
+++ b/mass_mailing_partner/views/res_partner_view.xml
@@ -22,7 +22,7 @@
                     context="{'search_default_partner_id': active_id,
                                   'default_partner_id': active_id}"
                     type="action"
-                    class="oe_stat_button oe_inline"
+                    class="oe_stat_button"
                     icon="fa-envelope-o"
                 >
                     <field
@@ -36,7 +36,7 @@
                     context="{'search_default_partner_id': active_id,
                                   'default_partner_id': active_id}"
                     type="action"
-                    class="oe_stat_button oe_inline"
+                    class="oe_stat_button"
                     icon="fa-envelope-o"
                 >
                     <field


### PR DESCRIPTION
[REF] mass_mailing_partner: Use width inheritance and prevents buttons from wrapping to fit the page

`oe_inline` makes the `button.width = auto !important;`
    - https://github.com/OCA/social/blob/f5d73f90527367e5036a95d10cb911ab076748b9/mass_mailing_partner/views/res_partner_view.xml#L25

Causing the `button.oe_inline` to have a different size than the others (depending on your text):
    - https://github.com/odoo/odoo/blob/a9395e2460f8cd22a6b6c59b0ad3d5ae67e2847f/addons/web/static/src/scss/form_view.scss#L41

Since the `auto !important;` breaks the width inheritance and prevents buttons from wrapping to fit the page width

Before of this PR:
 - ![Screen Shot 2022-03-28 at 13 14 55](https://user-images.githubusercontent.com/6644187/160470215-e6e238a2-d54d-49ac-a6c1-fe6f97891ff0.png)

After of this PR:
 - ![Screen Shot 2022-03-28 at 13 14 27](https://user-images.githubusercontent.com/6644187/160470217-899af909-9770-4874-96bf-4561afeb5ae9.png)

Co-authored-by: Manuel Gómez <manuel@vauxoo.com> @imanie383


