### PR TITLE
[FIX][12.0] mail_drop_target: Pin msgextract version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # mail_inline_css
 premailer
-extract-msg<=0.27.4
+extract_msg<0.30

--- a/setup/mail_drop_target/setup.py
+++ b/setup/mail_drop_target/setup.py
@@ -4,6 +4,6 @@ setuptools.setup(
     setup_requires=['setuptools-odoo'],
     odoo_addon=True,
     install_requires=[
-        'extract-msg<=0.27.4'
-    ]
+        'extract_msg<0.30'
+    ],
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 # freezegun > 0.3.11 has issue: module 'dateutil.tz' has no attribute 'UTC'
 freezegun<=0.3.11
+extract_msg<0.30


### PR DESCRIPTION
we need to pin the same name as in the [python dependencies](https://github.com/OCA/social/blob/12.0/mail_drop_target/__manifest__.py#L16), otherwise our CI tries to install the latest version for the [unpinned name](https://app.travis-ci.com/github/OCA/social/jobs/566634249#L563).