### PR TITLE
[14.0] [BKP] mail_show_follower: v15 improvements

### DIFF
--- a/mail_show_follower/README.rst
+++ b/mail_show_follower/README.rst
@@ -23,7 +23,7 @@ Mail Show Follower
     :target: https://runbot.odoo-community.org/runbot/205/14.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| |badge5| 
+|badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module extends the functionality of mailing to show the document followers in head of the mails.
 In the cc, only appear when:
@@ -41,8 +41,11 @@ Configuration
 
 To configure this module, you need to:
 
-#. Go General settings/Discuss/Show Internal Users CC and set if want to show or not internal users in cc details.
+#. Go General settings/Discuss/Show Followers on mails/Show Internal Users CC and set if want to show or not internal users in cc details.
 #. Go Settings/Users & Company salect any user in 'Preferences' check or not the 'Show in CC' field if this user need to appear in the cc note.
+#. Go General settings/Discuss/Show Followers on mails/Text 'Sent to' and set the initial part of the message.
+#. Go General settings/Discuss/Show Followers on mails/Partner format and choose desired fields to show on CC recipients.
+#. Go General settings/Discuss/Show Followers on mails/Text 'Replies' and choose desired warn message
 
 Usage
 =====
@@ -68,6 +71,7 @@ Authors
 ~~~~~~~
 
 * Sygel
+* Moduon
 
 Contributors
 ~~~~~~~~~~~~
@@ -75,6 +79,7 @@ Contributors
 * Valentin Vinagre <valentin.vinagre@sygel.es>
 * Lorenzo Battistini
 * Alex Comba <alex.comba@agilebg.com>
+* Eduardo de Miguel <edu@moduon.team>
 
 Maintainers
 ~~~~~~~~~~~

--- a/mail_show_follower/__manifest__.py
+++ b/mail_show_follower/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Valentin Vinagre <valentin.vinagre@sygel.es>
+# Copyright 2022 Eduardo de Miguel <edu@moduon.team>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {
@@ -7,7 +8,7 @@
     "version": "14.0.1.0.0",
     "category": "Mail",
     "website": "https://github.com/OCA/social",
-    "author": "Sygel, Odoo Community Association (OCA)",
+    "author": "Sygel, Moduon, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,
     "installable": True,

--- a/mail_show_follower/models/mail_mail.py
+++ b/mail_show_follower/models/mail_mail.py
@@ -57,6 +57,11 @@ class MailMail(models.Model):
         group_portal = self.env.ref("base.group_portal")
         for mail_id in self.ids:
             mail = self.browse(mail_id)
+            message_recipients = self.search(
+                [
+                    ("message_id", "=", mail.message_id),
+                ]
+            ).mapped("recipient_ids")
             # if the email has a model, id and it belongs to the portal group
             if mail.model and mail.res_id and group_portal:
                 obj = self.env[mail.model].browse(mail.res_id)
@@ -64,7 +69,10 @@ class MailMail(models.Model):
                 # if they do it must be a portal, we exclude internal
                 # users of the system.
                 if hasattr(obj, "message_follower_ids"):
-                    partners_obj = obj.message_follower_ids.mapped("partner_id")
+                    partners_obj = (
+                        obj.message_follower_ids.mapped("partner_id")
+                        | message_recipients
+                    )
                     # internal partners
                     user_partner_ids = (
                         self.env["res.users"]

--- a/mail_show_follower/models/mail_mail.py
+++ b/mail_show_follower/models/mail_mail.py
@@ -1,16 +1,64 @@
-from odoo import models
+from markupsafe import Markup
+
+from odoo import api, models, tools
 
 
 class MailMail(models.Model):
     _inherit = "mail.mail"
 
-    def _send(self, auto_commit=False, raise_exception=False, smtp_session=None):
-        plain_text = (
-            '<div summary="o_mail_notification" style="padding: 0px; '
-            'font-size: 10px;"><b>CC</b>: %s<hr style="background-color:'
-            "rgb(204,204,204);border:medium none;clear:both;display:block;"
-            'font-size:0px;min-height:1px;line-height:0; margin:4px 0 12px 0;"></div>'
+    @api.model
+    def _build_cc_text(self, partners):
+        if not partners:
+            return ""
+
+        def get_ctx_param(ctx_key, default_parm):
+            if ctx_key in self.env.context:
+                return self.env.context[ctx_key]
+            return default_parm
+
+        def remove_p(markup_txt):
+            if markup_txt.startswith("<p>") and markup_txt.endswith("</p>"):
+                return markup_txt[3:-4]
+            return markup_txt
+
+        company = self.env.company
+        partner_format = get_ctx_param(
+            "partner_format", company.show_followers_partner_format
         )
+        msg_sent_to = get_ctx_param(
+            "msg_sent_to", company.show_followers_message_sent_to
+        )
+        msg_warn = get_ctx_param(
+            "msg_warn", company.show_followers_message_response_warning
+        )
+        partner_message = ", ".join(
+            [
+                partner_format
+                % {
+                    # Supported parameters
+                    "partner_name": p.name,
+                    "partner_email": p.email,
+                    "partner_email_domain": tools.email_domain_extract(p.email),
+                }
+                for p in partners
+            ]
+        )
+        full_text = """
+            <div summary='o_mail_notification' style='padding:5px;
+            margin:10px 0px 10px 0px;font-size:13px;border-radius:5px;
+            font-family:Arial;border:1px solid #E0E2E6;background-color:#EBEBEB;'>
+            {msg_sent_to} {partner_message}
+            {rc}{msg_warn}
+            </div>
+        """.format(
+            msg_sent_to=remove_p(msg_sent_to),
+            partner_message=Markup.escape(partner_message),
+            rc=msg_warn.striptags() and "<br/>" or "",
+            msg_warn=msg_warn.striptags() and remove_p(msg_warn) or "",
+        )
+        return full_text
+
+    def _send(self, auto_commit=False, raise_exception=False, smtp_session=None):
         group_portal = self.env.ref("base.group_portal")
         for mail_id in self.ids:
             mail = self.browse(mail_id)
@@ -73,12 +121,21 @@ class MailMail(models.Model):
                             or x.user_ids  # otherwise, email is not sent
                             and "email" in x.user_ids.mapped("notification_type")
                         )
-                        # get names and emails and join texts
-                        final_cc = plain_text % (
-                            ", ".join(
-                                "%s &lt;%s&gt;" % (p.name, p.email) for p in partners
+                        # set proper lang for recipients
+                        langs = list(
+                            filter(
+                                bool,
+                                mail.mapped("recipient_ids.lang")
+                                + [
+                                    mail.author_id.lang,
+                                    self.env.company.partner_id.lang,
+                                ],
                             )
                         )
+                        # get show follower text
+                        final_cc = mail.with_context(
+                            lang=langs and langs[0]
+                        )._build_cc_text(partners)
                         # it is saved in the body_html field so that it does
                         # not appear in the odoo log
                         mail.body_html = final_cc + mail.body_html

--- a/mail_show_follower/models/mail_mail.py
+++ b/mail_show_follower/models/mail_mail.py
@@ -16,11 +16,6 @@ class MailMail(models.Model):
                 return self.env.context[ctx_key]
             return default_parm
 
-        def remove_p(markup_txt):
-            if markup_txt.startswith("<p>") and markup_txt.endswith("</p>"):
-                return markup_txt[3:-4]
-            return markup_txt
-
         company = self.env.company
         partner_format = get_ctx_param(
             "partner_format", company.show_followers_partner_format
@@ -51,10 +46,10 @@ class MailMail(models.Model):
             {rc}{msg_warn}
             </div>
         """.format(
-            msg_sent_to=remove_p(msg_sent_to),
+            msg_sent_to=msg_sent_to,
             partner_message=Markup.escape(partner_message),
-            rc=msg_warn.striptags() and "<br/>" or "",
-            msg_warn=msg_warn.striptags() and remove_p(msg_warn) or "",
+            rc=msg_warn and "<br/>" or "",
+            msg_warn=msg_warn or "",
         )
         return full_text
 

--- a/mail_show_follower/models/res_company.py
+++ b/mail_show_follower/models/res_company.py
@@ -5,5 +5,24 @@ class ResCompany(models.Model):
     _inherit = "res.company"
 
     show_internal_users_cc = fields.Boolean(
-        string="Show Internal Users CC", default=True
+        string="Show Internal Users CC",
+        default=True,
+    )
+    show_followers_message_sent_to = fields.Html(
+        string="Text 'Sent to'",
+        translate=True,
+        default="This message has been sent to",
+    )
+    show_followers_partner_format = fields.Char(
+        string="Partner format",
+        default="%(partner_name)s",
+        help="Supported parameters:\n"
+        "%(partner_name)s = Partner Name\n"
+        "%(partner_email)s = Partner Email\n"
+        "%(partner_email_domain)s = Partner Email Domain",
+    )
+    show_followers_message_response_warning = fields.Html(
+        string="Text 'Replies'",
+        translate=True,
+        default="Notice: Replies to this email will be sent to all recipients",
     )

--- a/mail_show_follower/models/res_company.py
+++ b/mail_show_follower/models/res_company.py
@@ -8,7 +8,7 @@ class ResCompany(models.Model):
         string="Show Internal Users CC",
         default=True,
     )
-    show_followers_message_sent_to = fields.Html(
+    show_followers_message_sent_to = fields.Text(
         string="Text 'Sent to'",
         translate=True,
         default="This message has been sent to",
@@ -21,7 +21,7 @@ class ResCompany(models.Model):
         "%(partner_email)s = Partner Email\n"
         "%(partner_email_domain)s = Partner Email Domain",
     )
-    show_followers_message_response_warning = fields.Html(
+    show_followers_message_response_warning = fields.Text(
         string="Text 'Replies'",
         translate=True,
         default="Notice: Replies to this email will be sent to all recipients",

--- a/mail_show_follower/models/res_config_settings.py
+++ b/mail_show_follower/models/res_config_settings.py
@@ -1,11 +1,51 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
     show_internal_users_cc = fields.Boolean(
-        string="Show Internal Users CC",
         related="company_id.show_internal_users_cc",
         readonly=False,
     )
+    show_followers_message_sent_to = fields.Html(
+        related="company_id.show_followers_message_sent_to",
+        readonly=False,
+    )
+    show_followers_partner_format = fields.Char(
+        related="company_id.show_followers_partner_format",
+        readonly=False,
+        help="Supported parameters:\n"
+        "%(partner_name)s = Partner Name\n"
+        "%(partner_email)s = Partner Email\n"
+        "%(partner_email_domain)s = Partner Email Domain",
+    )
+    show_followers_message_response_warning = fields.Html(
+        related="company_id.show_followers_message_response_warning",
+        readonly=False,
+    )
+    show_followers_message_preview = fields.Html(
+        string="Message preview",
+        readonly=True,
+        store=False,
+    )
+
+    @api.onchange(
+        "show_followers_message_sent_to",
+        "show_followers_partner_format",
+        "show_followers_message_response_warning",
+    )
+    def onchange_show_followers_message_preview(self):
+        self.show_followers_message_preview = (
+            self.env["mail.mail"]
+            .with_context(
+                # Use current data before
+                partner_format=self.show_followers_partner_format or "",
+                msg_sent_to=self.show_followers_message_sent_to or "",
+                msg_warn=self.show_followers_message_response_warning or "",
+            )
+            ._build_cc_text(
+                # Sample partners
+                self.env["res.partner"].search([("email", "!=", False)], limit=3),
+            )
+        )

--- a/mail_show_follower/models/res_config_settings.py
+++ b/mail_show_follower/models/res_config_settings.py
@@ -8,7 +8,7 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.show_internal_users_cc",
         readonly=False,
     )
-    show_followers_message_sent_to = fields.Html(
+    show_followers_message_sent_to = fields.Text(
         related="company_id.show_followers_message_sent_to",
         readonly=False,
     )
@@ -20,7 +20,7 @@ class ResConfigSettings(models.TransientModel):
         "%(partner_email)s = Partner Email\n"
         "%(partner_email_domain)s = Partner Email Domain",
     )
-    show_followers_message_response_warning = fields.Html(
+    show_followers_message_response_warning = fields.Text(
         related="company_id.show_followers_message_response_warning",
         readonly=False,
     )

--- a/mail_show_follower/models/res_config_settings.py
+++ b/mail_show_follower/models/res_config_settings.py
@@ -35,7 +35,7 @@ class ResConfigSettings(models.TransientModel):
         "show_followers_partner_format",
         "show_followers_message_response_warning",
     )
-    def onchange_show_followers_message_preview(self):
+    def _onchange_show_followers_message_preview(self):
         self.show_followers_message_preview = (
             self.env["mail.mail"]
             .with_context(

--- a/mail_show_follower/readme/CONFIGURE.rst
+++ b/mail_show_follower/readme/CONFIGURE.rst
@@ -1,4 +1,7 @@
 To configure this module, you need to:
 
-#. Go General settings/Discuss/Show Internal Users CC and set if want to show or not internal users in cc details.
+#. Go General settings/Discuss/Show Followers on mails/Show Internal Users CC and set if want to show or not internal users in cc details.
 #. Go Settings/Users & Company salect any user in 'Preferences' check or not the 'Show in CC' field if this user need to appear in the cc note.
+#. Go General settings/Discuss/Show Followers on mails/Text 'Sent to' and set the initial part of the message.
+#. Go General settings/Discuss/Show Followers on mails/Partner format and choose desired fields to show on CC recipients.
+#. Go General settings/Discuss/Show Followers on mails/Text 'Replies' and choose desired warn message

--- a/mail_show_follower/readme/CONTRIBUTORS.rst
+++ b/mail_show_follower/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Valentin Vinagre <valentin.vinagre@sygel.es>
 * Lorenzo Battistini
 * Alex Comba <alex.comba@agilebg.com>
+* Eduardo de Miguel <edu@moduon.team>

--- a/mail_show_follower/static/description/index.html
+++ b/mail_show_follower/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Mail Show Follower</title>
 <style type="text/css">
 
@@ -392,8 +392,11 @@ In the cc, only appear when:</p>
 <h1><a class="toc-backref" href="#id1">Configuration</a></h1>
 <p>To configure this module, you need to:</p>
 <ol class="arabic simple">
-<li>Go General settings/Discuss/Show Internal Users CC and set if want to show or not internal users in cc details.</li>
+<li>Go General settings/Discuss/Show Followers on mails/Show Internal Users CC and set if want to show or not internal users in cc details.</li>
 <li>Go Settings/Users &amp; Company salect any user in ‘Preferences’ check or not the ‘Show in CC’ field if this user need to appear in the cc note.</li>
+<li>Go General settings/Discuss/Show Followers on mails/Text ‘Sent to’ and set the initial part of the message.</li>
+<li>Go General settings/Discuss/Show Followers on mails/Partner format and choose desired fields to show on CC recipients.</li>
+<li>Go General settings/Discuss/Show Followers on mails/Text ‘Replies‘ and choose desired warn message</li>
 </ol>
 </div>
 <div class="section" id="usage">
@@ -417,6 +420,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#id5">Authors</a></h2>
 <ul class="simple">
 <li>Sygel</li>
+<li>Moduon</li>
 </ul>
 </div>
 <div class="section" id="contributors">
@@ -425,6 +429,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Valentin Vinagre &lt;<a class="reference external" href="mailto:valentin.vinagre&#64;sygel.es">valentin.vinagre&#64;sygel.es</a>&gt;</li>
 <li>Lorenzo Battistini</li>
 <li>Alex Comba &lt;<a class="reference external" href="mailto:alex.comba&#64;agilebg.com">alex.comba&#64;agilebg.com</a>&gt;</li>
+<li>Eduardo de Miguel &lt;<a class="reference external" href="mailto:edu&#64;moduon.team">edu&#64;moduon.team</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/mail_show_follower/views/res_config_settings.xml
+++ b/mail_show_follower/views/res_config_settings.xml
@@ -10,12 +10,68 @@
             <div id="emails" position="inside">
                 <div class="col-12 col-lg-6 o_setting_box">
                     <div class="o_setting_left_pane">
-                        <field name="show_internal_users_cc" />
                     </div>
                     <div class="o_setting_right_pane">
-                        <label for="show_internal_users_cc" />
-                        <div class="text-muted" id="show_internal_users_cc">
-                            Add internal users in cc mails details
+                        <div class="content-group">
+                            <label
+                                for="show_internal_users_cc"
+                                string="Show Followers on mails"
+                            />
+                            <div>
+                                <div>
+                                    <label
+                                        for="show_internal_users_cc"
+                                        class="o_light_label"
+                                        string="Show Internal Users on CC"
+                                    />
+                                    <field name="show_internal_users_cc" />
+                                </div>
+                                <div>
+                                    <label
+                                        for="show_followers_message_sent_to"
+                                        class="o_light_label"
+                                        style="vertical-align: top;"
+                                    />
+                                    <field
+                                        name="show_followers_message_sent_to"
+                                        placeholder="This message has been sent to"
+                                        style="display:inline-block;"
+                                    />
+                                </div>
+                                <div>
+                                    <label
+                                        for="show_followers_partner_format"
+                                        class="o_light_label"
+                                        style="vertical-align: top;"
+                                    />
+                                    <field
+                                        name="show_followers_partner_format"
+                                        placeholder="%%(partner_name)s &lt;%%(partner_email)s&gt;"
+                                        style="display:inline-block;"
+                                    />
+                                </div>
+                                <div>
+                                    <label
+                                        for="show_followers_message_response_warning"
+                                        class="o_light_label"
+                                        style="vertical-align: top;"
+                                    />
+                                    <field
+                                        name="show_followers_message_response_warning"
+                                        placeholder="Notice: Replies to this email will be sent to all recipients."
+                                        style="display:inline-block;"
+                                    />
+                                </div>
+                            </div>
+                            <label
+                                for="show_followers_message_preview"
+                                class="text-muted"
+                            />
+                            <field
+                                name="show_followers_message_preview"
+                                style="width:100%;"
+                                widget="html"
+                            />
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Backport of improvements on mail_show_follower:
- https://github.com/OCA/social/pull/866
- https://github.com/OCA/social/pull/889

Dropped compatibility with HTML fields due to HTML fields on v14 using too much space.
`show_followers_message_sent_to` and `show_followers_message_response_warning` are now **Text** fields.

@rafaelbn @ValentinVinagre @Yajo please review if you want 😄 