### PR TITLE
[13.0][FIX] mail_activity_team: activity count

### DIFF
--- a/mail_activity_team/models/res_users.py
+++ b/mail_activity_team/models/res_users.py
@@ -14,7 +14,7 @@ class ResUsers(models.Model):
 
     @api.model
     def systray_get_activities(self):
-        if not self._context.get("team_activities", False):
+        if not self.env.context.get("team_activities"):
             return super().systray_get_activities()
         query = """SELECT m.id, count(*), act.res_model as model,
                                 CASE


### PR DESCRIPTION
The user couldn't see the proper count of his own activities. It was
allways showing the team activities counter.

cc @Tecnativa TT35885

please review @Tardo @victoralmau  @MiquelRForgeFlow @LoisRForgeFlow 

Also please forward port features across versions so you don't miss them later, like this one https://github.com/OCA/social/pull/877