### PR TITLE
[FIX] [15.0] base_search_mail_content: Avoid CacheMiss errors

### DIFF
--- a/base_search_mail_content/models/mail_thread.py
+++ b/base_search_mail_content/models/mail_thread.py
@@ -29,9 +29,13 @@ class MailThread(models.AbstractModel):
 
     message_content = fields.Text(
         help="Message content, to be used only in searches",
-        compute=lambda self: False,
+        compute="_compute_message_content",
         search="_search_message_content",
     )
+
+    def _compute_message_content(self):
+        # Always assign a value to avoid CacheMiss errors
+        self.message_content = False
 
     @api.model
     def fields_view_get(


### PR DESCRIPTION
Avoid **CacheMiss** errors setting a value on `message_content` field.

Odoo needs to have a value on this `message_content` field because **Cache** doesn't found a previous valid value.

MT-441 @moduon