### PR TITLE
[14.0][FIX] mail_debrand: remove_href_odoo function

### DIFF
--- a/mail_debrand/models/mail_render_mixin.py
+++ b/mail_debrand/models/mail_render_mixin.py
@@ -26,37 +26,28 @@ class MailRenderMixin(models.AbstractModel):
             # We don't want to change what was explicitly added in the message body,
             # so we will only change what is before and after it.
             if to_keep:
-                to_change = value.split(to_keep)
-            else:
-                to_change = [value]
-                to_keep = ""
-            new_parts = []
-            for part in to_change:
-                tree = html.fromstring(part)
-                if tree is None:
-                    new_parts.append(part)
-                    continue
-                odoo_anchors = tree.xpath('//a[contains(@href,"odoo.com")]')
-                for elem in odoo_anchors:
-                    parent = elem.getparent()
-                    previous = elem.getprevious()
-
-                    if remove_before and not remove_parent and previous is not None:
-                        # remove 'using' that is before <a and after </span>
-                        previous.tail = ""
-                    if remove_parent and len(parent.getparent()):
-                        # anchor <a href odoo has a parent powered by that must be removed
+                value = value.replace(to_keep, "<body_msg></body_msg>")
+            tree = html.fromstring(value)
+            odoo_anchors = tree.xpath('//a[contains(@href,"odoo.com")]')
+            for elem in odoo_anchors:
+                parent = elem.getparent()
+                previous = elem.getprevious()
+                if remove_before and not remove_parent and previous is not None:
+                    # remove 'using' that is before <a and after </span>
+                    previous.tail = ""
+                if remove_parent and len(parent.getparent()):
+                    # anchor <a href odoo has a parent powered by that must be removed
+                    parent.getparent().remove(parent)
+                else:
+                    if parent.tag == "td":  # also here can be powered by
                         parent.getparent().remove(parent)
                     else:
-                        if parent.tag == "td":  # also here can be powered by
-                            parent.getparent().remove(parent)
-                        else:
-                            parent.remove(elem)
-                part = etree.tostring(
-                    tree, pretty_print=True, method="html", encoding="unicode"
-                )
-                new_parts.append(part)
-            value = to_keep.join(new_parts)
+                        parent.remove(elem)
+            value = etree.tostring(
+                tree, pretty_print=True, method="html", encoding="unicode"
+            )
+            if to_keep:
+                value = value.replace("<body_msg></body_msg>", to_keep)
         return value
 
     @api.model


### PR DESCRIPTION
Fixing this issue https://github.com/OCA/social/issues/839

- FIX bug when split email message by `to_keep` parameter. When the html code is split, it is broken. As a result of this, when it use `fromstring`, it try to fix this by closing tags.
Example about fixed functionality:
message: `<table><tr><td>{to_keep}</td></tr></table>`
Split messsage inside `remove_href_odoo` function:
part[0]: `<table><tr><td>`
part[1]: `</td></tr></table>`
Result when join by `to_keep`: `<table><tr><td><td></tr></table>{to_keep}<table><tr><td></td></tr></table>`