### PR TITLE
[14.0] [ADD] mail_layout_force

### DIFF
--- a/mail_layout_force/__init__.py
+++ b/mail_layout_force/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizards

--- a/mail_layout_force/__manifest__.py
+++ b/mail_layout_force/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Mail Layout Force",
+    "summary": "Force a mail layout on selected email templates",
+    "version": "14.0.1.0.0",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["ivantodorovich"],
+    "website": "https://github.com/OCA/social",
+    "license": "AGPL-3",
+    "category": "Marketing",
+    "depends": ["mail"],
+    "demo": ["demo/mail_layout.xml"],
+    "data": ["data/mail_layout.xml", "views/mail_template.xml"],
+}

--- a/mail_layout_force/data/mail_layout.xml
+++ b/mail_layout_force/data/mail_layout.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <template id="mail_layout_noop" name="Mail: No-Layout notification template">
+        <t t-raw="message.body" />
+    </template>
+
+</odoo>

--- a/mail_layout_force/demo/mail_layout.xml
+++ b/mail_layout_force/demo/mail_layout.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <template id="mail_layout_custom">
+        <table
+            border="0"
+            cellpadding="0"
+            cellspacing="0"
+            style="padding-top: 32px; background-color: red; width: 100%; border-collapse:separate;"
+        >
+            <tr>
+                <td align="center">
+                    <table
+                        border="0"
+                        cellpadding="0"
+                        cellspacing="0"
+                        width="590"
+                        style="padding: 24px; background-color: white; border-collapse:separate;"
+                    >
+                        <tbody>
+                            <!-- HEADER -->
+                            <tr>
+                                <td align="center" style="min-width: 590px;">
+                                    <table
+                                        border="0"
+                                        cellpadding="0"
+                                        cellspacing="0"
+                                        width="100%"
+                                        style="background-color: white; padding: 0; border-collapse:separate;"
+                                    >
+                                        <tr>
+                                            <td valign="middle">
+                                                <t
+                                                    t-esc="model_description or 'document'"
+                                                />
+                                                <t
+                                                    t-esc="message.record_name and message.record_name.replace('/','-') or ''"
+                                                />
+                                            </td>
+                                            <td valign="middle" align="right">
+                                                <img
+                                                    t-att-src="'/logo.png?company=%s' % (company.id or 0)"
+                                                    style="padding: 0px; margin: 0px; height: 48px;"
+                                                    t-att-alt="'%s' % company.name"
+                                                />
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td colspan="2" style="text-align:center;">
+                                                <hr
+                                                    width="100%"
+                                                    style="background-color: red; border: medium none; clear: both; display: block; margin:4px 0px 32px 0px;"
+                                                />
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                            <!-- CONTENT -->
+                            <tr>
+                                <td style="min-width: 590px;">
+                                    <t t-raw="message.body" />
+                                </td>
+                            </tr>
+                            <!-- FOOTER -->
+                            <tr>
+                                <td
+                                    align="center"
+                                    style="min-width: 590px; padding: 0 8px 0 8px; font-size:11px;"
+                                >
+                                    <hr
+                                        width="100%"
+                                        style="background-color: red; border: medium none; clear: both; display: block; margin:4px 0px 32px 0px;"
+                                    />
+                                    <div style="color: #FF9999;">
+                                    <b t-esc="company.name" /><br />
+                                        <t t-esc="company.name" />
+                                        <t t-if="company.phone">
+                                            ::
+                                            <t t-esc="company.phone" />
+                                        </t>
+                                        <t t-if="company.email">
+                                            ::
+                                            <a
+                                                t-att-href="'mailto:%s' % company.email"
+                                                style="text-decoration:none;color:red;"
+                                            >
+                                                <t t-esc="company.email" />
+                                            </a>
+                                        </t>
+                                        <t t-if="company.website">
+                                            ::
+                                            <a
+                                                t-att-href="'%s' % company.website"
+                                                style="text-decoration:none;color:red;"
+                                            >
+                                                <t t-esc="company.website" />
+                                            </a>
+                                        </t>
+                                    </div>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+        </table>
+    </template>
+
+</odoo>

--- a/mail_layout_force/models/__init__.py
+++ b/mail_layout_force/models/__init__.py
@@ -1,0 +1,2 @@
+from . import mail_template
+from . import mail_thread

--- a/mail_layout_force/models/mail_template.py
+++ b/mail_layout_force/models/mail_template.py
@@ -1,0 +1,44 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class MailTemplate(models.Model):
+    _inherit = "mail.template"
+
+    force_email_layout_id = fields.Many2one(
+        comodel_name="ir.ui.view",
+        string="Force Layout",
+        domain=[("type", "=", "qweb"), ("mode", "=", "primary")],
+        context={"default_type": "qweb"},
+        help="Force a mail layout for this template.",
+    )
+
+    def _ensure_force_email_layout_xml_id(self):
+        missing = self.force_email_layout_id.filtered(lambda rec: not rec.xml_id)
+        if missing:
+            vals = [
+                {
+                    "module": "__export__",
+                    "name": "force_email_layout_%s" % rec.id,
+                    "model": rec._name,
+                    "res_id": rec.id,
+                }
+                for rec in missing
+            ]
+            self.env["ir.model.data"].sudo().create(vals)
+            self.force_email_layout_id.invalidate_cache(["xml_id"])
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        records._ensure_force_email_layout_xml_id()
+        return records
+
+    def write(self, vals):
+        res = super().write(vals)
+        if "force_email_layout_id" in vals:
+            self._ensure_force_email_layout_xml_id()
+        return res

--- a/mail_layout_force/models/mail_thread.py
+++ b/mail_layout_force/models/mail_thread.py
@@ -1,0 +1,20 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class MailThread(models.AbstractModel):
+    _inherit = "mail.thread"
+
+    def message_post_with_template(
+        self, template_id, email_layout_xmlid=None, **kwargs
+    ):
+        # OVERRIDE to force the email_layout_xmlid defined on the mail.template
+        template = self.env["mail.template"].sudo().browse(template_id)
+        if template.force_email_layout_id:
+            email_layout_xmlid = template.force_email_layout_id.xml_id
+        return super().message_post_with_template(
+            template_id, email_layout_xmlid=email_layout_xmlid, **kwargs
+        )

--- a/mail_layout_force/readme/CONFIGURE.rst
+++ b/mail_layout_force/readme/CONFIGURE.rst
@@ -1,0 +1,15 @@
+# Go to Configuration > Technical > Emails > Templates
+# Open the desired ``email.template`` record.
+# In Advanced Parameters tab, find the Force Layout field.
+
+You can leave it empty to use the default email layout (chosen by Odoo).
+You can force a custom email layout of your own.
+You can use the *Mail: No-Layout notification template* to prevent Odoo
+from adding a layout.
+
+To configure a custom layout of your own, some technical knowledge is needed.
+You can see how the existing layouts are defined for details or inspiration:
+
+* ``mail.mail_notification_light``
+* ``mail.mail_notification_paynow``
+* ``mail.mail_notification_borders``

--- a/mail_layout_force/readme/CONTRIBUTORS.rst
+++ b/mail_layout_force/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+    * Iván Todorovich <ivan.todorovich@camptocamp.com>

--- a/mail_layout_force/readme/DESCRIPTION.rst
+++ b/mail_layout_force/readme/DESCRIPTION.rst
@@ -1,0 +1,17 @@
+Odoo will add a default email layout on most commercial communications.
+
+The email layout is a ``QWeb`` view that ends up wrapping the message body
+when sending an email. It usually displays the related document reference,
+the company logo, and a small footer saying "Powered by Odoo".
+
+There are notably two main layouts used in Odoo, and the user can't control when
+they're used, as it's hardcoded into the different applications.
+
+* ``mail.mail_notification_light``
+* ``mail.mail_notification_paynow``
+
+This module allows to force a specific layout for a given ``email.template``,
+effectively overwritting the one hardcoded by Odoo.
+
+This allows you to fully customize the way Odoo emails are rendered and sent
+to your customers.

--- a/mail_layout_force/tests/__init__.py
+++ b/mail_layout_force/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_mail_layout_force

--- a/mail_layout_force/tests/test_mail_layout_force.py
+++ b/mail_layout_force/tests/test_mail_layout_force.py
@@ -1,0 +1,73 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests import SavepointCase
+
+
+class TestMailLayoutForce(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.layout_noop = cls.env.ref("mail_layout_force.mail_layout_noop")
+        cls.layout_test = cls.env["ir.ui.view"].create(
+            {
+                "name": "Test Layout",
+                "type": "qweb",
+                "mode": "primary",
+                "arch": "<t t-name='test'><h1></h1><t t-raw='message.body'/></t>",
+            }
+        )
+        cls.template = cls.env["mail.template"].create(
+            {
+                "name": "Test Template",
+                "body_html": "<p>Test</p>",
+                "subject": "Test",
+                "model_id": cls.env.ref("base.model_res_partner").id,
+                "auto_delete": False,
+            }
+        )
+        cls.partner = cls.env.ref("base.res_partner_10")
+        cls.partner.message_ids.unlink()
+        cls.partner.message_subscribe([cls.partner.id])
+
+    def test_noop_layout(self):
+        self.template.force_email_layout_id = self.layout_noop
+        self.partner.message_post_with_template(
+            self.template.id,
+            # This is ignored because the template has a force_email_layout_id
+            email_layout_xmlid="mail.mail_notification_light",
+        )
+        message = self.partner.message_ids[-1]
+        self.assertEqual(message.mail_ids.body_html.strip(), "<p>Test</p>")
+
+    def test_custom_layout(self):
+        self.template.force_email_layout_id = self.layout_test
+        self.partner.message_post_with_template(
+            self.template.id,
+            # This is ignored because the template has a force_email_layout_id
+            email_layout_xmlid="mail.mail_notification_light",
+        )
+        message = self.partner.message_ids[-1]
+        self.assertEqual(message.mail_ids.body_html.strip(), "<h1></h1><p>Test</p>")
+
+    def test_custom_layout_composer(self):
+        self.template.force_email_layout_id = self.layout_test
+        composer = (
+            self.env["mail.compose.message"]
+            .with_context(
+                # This is ignored because the template has a force_email_layout_id
+                custom_layout="mail.mail_notification_light"
+            )
+            .create(
+                {
+                    "res_id": self.partner.id,
+                    "model": self.partner._name,
+                    "template_id": self.template.id,
+                }
+            )
+        )
+        composer.onchange_template_id_wrapper()
+        composer.send_mail()
+        message = self.partner.message_ids[-1]
+        self.assertEqual(message.mail_ids.body_html.strip(), "<h1></h1><p>Test</p>")

--- a/mail_layout_force/views/mail_template.xml
+++ b/mail_layout_force/views/mail_template.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="email_template_form" model="ir.ui.view">
+        <field name="model">mail.template</field>
+        <field name="inherit_id" ref="mail.email_template_form" />
+        <field name="arch" type="xml">
+            <field name="auto_delete" position="before">
+                <field name="force_email_layout_id" />
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/mail_layout_force/wizards/__init__.py
+++ b/mail_layout_force/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import mail_compose_message

--- a/mail_layout_force/wizards/mail_compose_message.py
+++ b/mail_layout_force/wizards/mail_compose_message.py
@@ -1,0 +1,20 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class MailComposer(models.TransientModel):
+    _inherit = "mail.compose.message"
+
+    def send_mail(self, auto_commit=False):
+        # OVERRIDE to force the email_layout_xmlid defined on the mail.template
+        res = []
+        for rec in self:
+            if rec.template_id.force_email_layout_id:
+                rec = rec.with_context(
+                    custom_layout=self.template_id.force_email_layout_id.xml_id
+                )
+            res.append(super(MailComposer, rec).send_mail(auto_commit=auto_commit))
+        return all(res)

--- a/setup/mail_layout_force/odoo/addons/mail_layout_force
+++ b/setup/mail_layout_force/odoo/addons/mail_layout_force
@@ -1,0 +1,1 @@
+../../../../mail_layout_force

--- a/setup/mail_layout_force/setup.py
+++ b/setup/mail_layout_force/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Odoo will add a default email layout on most commercial communications.

The email layout is a ``QWeb`` view that ends up wrapping the message body when sending an email. It usually displays the related document reference, the company logo, and a small footer saying "Powered by Odoo".

There are notably two main layouts used in Odoo, and the user can't control when they're used, as it's hardcoded into the different applications.

* ``mail.mail_notification_light``
* ``mail.mail_notification_paynow``

This module allows to force a specific layout for a given ``email.template``, effectively overwritting the one hardcoded by Odoo.

This allows you to fully customize the way Odoo emails are rendered and sent to your customers.
