### PR TITLE
[FIX][15.0] mail_debrand: test_mail_digest update for 15.0

### DIFF
--- a/mail_debrand/tests/test_mail_debrand_digest.py
+++ b/mail_debrand/tests/test_mail_debrand_digest.py
@@ -38,7 +38,7 @@ class TestMailDebrandDigest(common.TransactionCase):
             "digest.digest_mail_main",
             "digest.digest",
             self.mail_digest_id.ids,
-            engine="qweb",
+            engine="qweb_view",
             add_context={
                 "title": self.mail_digest_id.name,
                 "top_button_label": _("Connect"),
@@ -48,13 +48,13 @@ class TestMailDebrandDigest(common.TransactionCase):
                 "tips_count": 1,
                 "formatted_date": datetime.today().strftime("%B %d, %Y"),
                 "display_mobile_banner": True,
-                "kpi_data": self.mail_digest_id.compute_kpis(
+                "kpi_data": self.mail_digest_id._compute_kpis(
                     self.env.user.company_id, self.env.user
                 ),
-                "tips": self.mail_digest_id.compute_tips(
+                "tips": self.mail_digest_id._compute_tips(
                     self.env.user.company_id, self.env.user, tips_count=1, consumed=True
                 ),
-                "preferences": self.mail_digest_id.compute_preferences(
+                "preferences": self.mail_digest_id._compute_preferences(
                     self.env.user.company_id, self.env.user
                 ),
             },


### PR DESCRIPTION
With 15.0 test_mail_digest seems to be broken:

```
ERROR: TestMailDebrandDigest.test_mail_digest
Traceback (most recent call last):
  File "/data/build/addons-oca/addons/mail_debrand/tests/test_mail_debrand_digest.py", line 51, in test_mail_digest
    "kpi_data": self.mail_digest_id.compute_kpis(
AttributeError: 'digest.digest' object has no attribute 'compute_kpis'
```

This PR solves the issue for us by:
- updating function calls to use new internal names
- using qweb_view engine to be able to specify the template via xmlid (the qweb engine doesn't seem to accept xmlids anymore since  https://github.com/odoo/odoo/commit/69dfaf4ca5a17f880264b2d95f782c7136613e95 )
