### PR TITLE
[IMP] mail_activity_team: Force team on schedule

### DIFF
--- a/mail_activity_team/models/mail_activity_mixin.py
+++ b/mail_activity_team/models/mail_activity_mixin.py
@@ -56,9 +56,7 @@ class MailActivityMixin(models.AbstractModel):
                         .with_context(default_res_model=self._name,)
                         ._get_default_team_id(user_id=user_id)
                     )
-                    # Even if it comes empty, we don't want to mismatch the user's team
-                    if team:
-                        act_values.update({"team_id": team.id})
+                    act_values.update({"team_id": team.id})
         return super().activity_schedule(
             act_type_xmlid=act_type_xmlid,
             date_deadline=date_deadline,


### PR DESCRIPTION
If you schedule an activity and you don't force the team as False, errors might araise.
For example, on holidays.

Is an error raised by #912