### PR TITLE
[IMP] mail_activity_team: Forwarding commits from 13.0 to 15.0

### DIFF
--- a/mail_activity_team/__manifest__.py
+++ b/mail_activity_team/__manifest__.py
@@ -15,6 +15,7 @@
     "data": [
         "security/ir.model.access.csv",
         "security/mail_activity_team_security.xml",
+        "views/mail_activity_type.xml",
         "views/mail_activity_team_views.xml",
         "views/mail_activity_views.xml",
         "views/res_users_views.xml",

--- a/mail_activity_team/models/__init__.py
+++ b/mail_activity_team/models/__init__.py
@@ -2,3 +2,4 @@ from . import mail_activity_team
 from . import mail_activity
 from . import mail_activity_mixin
 from . import res_users
+from . import mail_activity_type

--- a/mail_activity_team/models/mail_activity.py
+++ b/mail_activity_team/models/mail_activity.py
@@ -19,6 +19,8 @@ class MailActivity(models.Model):
             )
         return self.env["mail.activity.team"].search(domain, limit=1)
 
+    user_id = fields.Many2one(required=False)
+
     team_id = fields.Many2one(
         comodel_name="mail.activity.team", default=lambda s: s._get_default_team_id()
     )
@@ -81,3 +83,12 @@ class MailActivity(models.Model):
                         team_name=activity.team_id.name,
                     )
                 )
+
+    @api.onchange("activity_type_id")
+    def _onchange_activity_type_id(self):
+        super(MailActivity, self)._onchange_activity_type_id()
+        if self.activity_type_id.default_team_id:
+            self.team_id = self.activity_type_id.default_team_id
+            members = self.activity_type_id.default_team_id.member_ids
+            if self.user_id not in members and members:
+                self.user_id = members[:1]

--- a/mail_activity_team/models/mail_activity.py
+++ b/mail_activity_team/models/mail_activity.py
@@ -38,7 +38,7 @@ class MailActivity(models.Model):
         if self.team_id and self.user_id in self.team_id.member_ids:
             return res
         self.team_id = self.with_context(
-            default_res_model=self.res_model_id.id
+            default_res_model=self.res_model_id.model
         )._get_default_team_id(user_id=self.user_id.id)
         return res
 

--- a/mail_activity_team/models/mail_activity.py
+++ b/mail_activity_team/models/mail_activity.py
@@ -1,6 +1,5 @@
 # Copyright 2018-22 ForgeFlow S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-import json
 
 from odoo import SUPERUSER_ID, _, api, fields, models
 from odoo.exceptions import ValidationError
@@ -27,15 +26,6 @@ class MailActivity(models.Model):
     team_id = fields.Many2one(
         comodel_name="mail.activity.team", default=lambda s: s._get_default_team_id()
     )
-    user_id_domain = fields.Char(compute="_compute_user_id_domain")
-
-    @api.depends("team_id")
-    def _compute_user_id_domain(self):
-        for record in self:
-            domain = []
-            if record.team_id:
-                domain.append(("id", "in", record.team_id.member_ids.ids))
-            record.user_id_domain = json.dumps(domain)
 
     @api.onchange("user_id")
     def _onchange_user_id(self):

--- a/mail_activity_team/models/mail_activity.py
+++ b/mail_activity_team/models/mail_activity.py
@@ -1,5 +1,7 @@
 # Copyright 2018-22 ForgeFlow S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import json
+
 from odoo import SUPERUSER_ID, _, api, fields, models
 from odoo.exceptions import ValidationError
 
@@ -20,42 +22,40 @@ class MailActivity(models.Model):
         return self.env["mail.activity.team"].search(domain, limit=1)
 
     user_id = fields.Many2one(required=False)
+    team_user_id = fields.Many2one(related="user_id", readonly=False)
 
     team_id = fields.Many2one(
         comodel_name="mail.activity.team", default=lambda s: s._get_default_team_id()
     )
+    user_id_domain = fields.Char(compute="_compute_user_id_domain")
+
+    @api.depends("team_id")
+    def _compute_user_id_domain(self):
+        for record in self:
+            domain = []
+            if record.team_id:
+                domain.append(("id", "in", record.team_id.member_ids.ids))
+            record.user_id_domain = json.dumps(domain)
 
     @api.onchange("user_id")
     def _onchange_user_id(self):
-        res = {"domain": {"team_id": []}}
-        if not self.user_id:
-            return res
-        res["domain"]["team_id"] = [
-            "|",
-            ("res_model_ids", "=", False),
-            ("res_model_ids", "in", self.res_model_id.ids),
-        ]
-        if self.team_id and self.user_id in self.team_id.member_ids:
-            return res
+        if not self.user_id or (
+            self.team_id and self.user_id in self.team_id.member_ids
+        ):
+            return
         self.team_id = self.with_context(
             default_res_model=self.sudo().res_model_id.model
         )._get_default_team_id(user_id=self.user_id.id)
-        return res
 
     @api.onchange("team_id")
     def _onchange_team_id(self):
-        res = {"domain": {"user_id": []}}
-        if not self.team_id:
-            return res
-        res["domain"]["user_id"] = [("id", "in", self.team_id.member_ids.ids)]
-        if self.user_id not in self.team_id.member_ids:
+        if self.team_id and self.user_id not in self.team_id.member_ids:
             if self.team_id.user_id:
                 self.user_id = self.team_id.user_id
             elif len(self.team_id.member_ids) == 1:
                 self.user_id = self.team_id.member_ids
             else:
                 self.user_id = self.env["res.users"]
-        return res
 
     @api.constrains("team_id", "user_id")
     def _check_team_and_user(self):

--- a/mail_activity_team/models/mail_activity.py
+++ b/mail_activity_team/models/mail_activity.py
@@ -38,7 +38,7 @@ class MailActivity(models.Model):
         if self.team_id and self.user_id in self.team_id.member_ids:
             return res
         self.team_id = self.with_context(
-            default_res_model=self.res_model_id.model
+            default_res_model=self.sudo().res_model_id.model
         )._get_default_team_id(user_id=self.user_id.id)
         return res
 
@@ -86,9 +86,10 @@ class MailActivity(models.Model):
 
     @api.onchange("activity_type_id")
     def _onchange_activity_type_id(self):
-        super(MailActivity, self)._onchange_activity_type_id()
+        res = super(MailActivity, self)._onchange_activity_type_id()
         if self.activity_type_id.default_team_id:
             self.team_id = self.activity_type_id.default_team_id
             members = self.activity_type_id.default_team_id.member_ids
             if self.user_id not in members and members:
                 self.user_id = members[:1]
+        return res

--- a/mail_activity_team/models/mail_activity_mixin.py
+++ b/mail_activity_team/models/mail_activity_mixin.py
@@ -72,9 +72,7 @@ class MailActivityMixin(models.AbstractModel):
                         .with_context(default_res_model=self._name,)
                         ._get_default_team_id(user_id=user_id)
                     )
-                    # Even if it comes empty, we don't want to mismatch the user's team
-                    if team:
-                        act_values.update({"team_id": team.id})
+                    act_values.update({"team_id": team.id})
         return super().activity_schedule(
             act_type_xmlid=act_type_xmlid,
             date_deadline=date_deadline,

--- a/mail_activity_team/models/mail_activity_mixin.py
+++ b/mail_activity_team/models/mail_activity_mixin.py
@@ -69,7 +69,9 @@ class MailActivityMixin(models.AbstractModel):
                 if user_id:
                     team = (
                         self.env["mail.activity"]
-                        .with_context(default_res_model=self._name,)
+                        .with_context(
+                            default_res_model=self._name,
+                        )
                         ._get_default_team_id(user_id=user_id)
                     )
                     act_values.update({"team_id": team.id})

--- a/mail_activity_team/models/mail_activity_type.py
+++ b/mail_activity_team/models/mail_activity_type.py
@@ -1,0 +1,11 @@
+# Copyright 2022 CreuBlanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class MailActivityType(models.Model):
+
+    _inherit = "mail.activity.type"
+
+    default_team_id = fields.Many2one(comodel_name="mail.activity.team")

--- a/mail_activity_team/models/res_users.py
+++ b/mail_activity_team/models/res_users.py
@@ -64,6 +64,9 @@ class ResUsers(models.Model):
             user_activities[activity["model"]][
                 "%s_count" % activity["states"]
             ] += activity["count"]
-            if activity["states"] in ("today", "overdue"):
+            if (
+                activity["states"] in ("today", "overdue")
+                and activity["user_id"] != user
+            ):
                 user_activities[activity["model"]]["total_count"] += activity["count"]
         return list(user_activities.values())

--- a/mail_activity_team/models/res_users.py
+++ b/mail_activity_team/models/res_users.py
@@ -14,7 +14,7 @@ class ResUsers(models.Model):
 
     @api.model
     def systray_get_activities(self):
-        if not self._context.get("team_activities", False):
+        if not self.env.context.get("team_activities"):
             return super().systray_get_activities()
         query = """SELECT m.id, count(*), act.res_model as model,
                     CASE

--- a/mail_activity_team/static/src/js/systray.esm.js
+++ b/mail_activity_team/static/src/js/systray.esm.js
@@ -98,4 +98,13 @@ ActivityMenu.include({
                 session.user_context.team_activities = false;
             });
     },
+    _onActivityMenuHide: function () {
+        this.filter = "my";
+        this._update_team_activities_context();
+        this._getActivityData();
+        this.$filter_buttons.removeClass("active");
+        var $target = $(".my_activities");
+        $target.addClass("active");
+        return this._super.apply(this, arguments);
+    },
 });

--- a/mail_activity_team/static/src/js/systray.esm.js
+++ b/mail_activity_team/static/src/js/systray.esm.js
@@ -81,7 +81,7 @@ ActivityMenu.include({
                 model: "res.users",
                 method: "systray_get_activities",
                 args: [],
-                kwargs: {context: self.user_context},
+                kwargs: {context: session.user_context},
             })
             .then(function (data) {
                 self._activities = data;

--- a/mail_activity_team/static/src/xml/systray.xml
+++ b/mail_activity_team/static/src/xml/systray.xml
@@ -7,13 +7,13 @@
                 <div>
                     <button
                         type="button"
-                        class="btn btn-link o_filter_button active"
+                        class="my_activities btn btn-link o_filter_button active"
                         data-filter='my'
                         role="tab"
                     > My Activities </button>
                     <button
                         type="button"
-                        class="btn btn-link o_filter_button"
+                        class="team_activities btn btn-link o_filter_button"
                         data-filter='team'
                         role="tab"
                     > Team Activities </button>

--- a/mail_activity_team/tests/test_mail_activity_team.py
+++ b/mail_activity_team/tests/test_mail_activity_team.py
@@ -1,13 +1,14 @@
 # Copyright 2018-22 ForgeFlow S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo.exceptions import ValidationError
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import Form, SavepointCase
 
 
-class TestMailActivityTeam(TransactionCase):
-    def setUp(self):
-        super(TestMailActivityTeam, self).setUp()
-
+class TestMailActivityTeam(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        self = cls
         self.env["mail.activity.team"].search([]).unlink()
 
         self.employee = self.env["res.users"].create(
@@ -125,6 +126,18 @@ class TestMailActivityTeam(TransactionCase):
             }
         )
 
+    def test_activity_members(self):
+        self.team1.member_ids |= self.employee2
+        self.partner_client.refresh()
+        self.assertIn(self.employee2, self.partner_client.activity_team_user_ids)
+        self.assertIn(self.employee, self.partner_client.activity_team_user_ids)
+        self.assertEqual(
+            self.partner_client,
+            self.env["res.partner"].search(
+                [("activity_team_user_ids", "=", self.employee.id)]
+            ),
+        )
+
     def test_team_and_user_onchange(self):
         with self.assertRaises(ValidationError):
             self.team1.member_ids = [(3, self.employee.id)]
@@ -144,32 +157,83 @@ class TestMailActivityTeam(TransactionCase):
         self.team2._onchange_user_id()
         self.assertTrue(self.employee3 in self.team2.member_ids)
 
-    def test_activity_onchanges(self):
+    def test_activity_onchanges_keep_user(self):
         self.assertEqual(
             self.act2.team_id, self.team1, "Error: Activity 2 should have Team 1."
         )
-        self.act2.team_id = False
-        self.act2._onchange_team_id()
-        self.assertEqual(self.act2.user_id, self.employee)
-        self.act2.team_id = self.team2
-        self.act2._onchange_team_id()
-        self.assertEqual(self.act2.user_id, self.employee)
-        self.act2.user_id = self.employee2
-        self.act2._onchange_user_id()
-        self.assertEqual(self.act2.team_id, self.team2)
+        with Form(self.act2) as form:
+            form.team_id = self.env["mail.activity.team"]
+            self.assertEqual(form.user_id, self.employee)
+
+    def test_activity_onchanges_user_no_member_team(self):
+        self.assertEqual(
+            self.act2.team_id, self.team1, "Error: Activity 2 should have Team 1."
+        )
+        with Form(self.act2) as form:
+            form.user_id = self.employee2
+            self.assertEqual(form.team_id, self.team2)
+
+    def test_activity_onchanges_user_no_team(self):
+        self.assertEqual(
+            self.act2.team_id, self.team1, "Error: Activity 2 should have Team 1."
+        )
+        with Form(self.act2) as form:
+            form.team_id = self.env["mail.activity.team"]
+            form.user_id = self.employee2
+            self.assertEqual(form.team_id, self.team2)
+
+    def test_activity_onchanges_team_no_member(self):
+        self.assertEqual(
+            self.act2.team_id, self.team1, "Error: Activity 2 should have Team 1."
+        )
+        self.team2.user_id = False
+        self.team2.member_ids = False
+        with Form(self.act2) as form:
+            form.team_id = self.team2
+            self.assertFalse(form.user_id)
+
+    def test_activity_onchanges_team_different_member(self):
+        self.assertEqual(
+            self.act2.team_id, self.team1, "Error: Activity 2 should have Team 1."
+        )
+        self.team2.user_id = self.employee2
+        self.team2.member_ids = self.employee2
+        with Form(self.act2) as form:
+            form.team_id = self.team2
+            self.assertEqual(form.user_id, self.employee2)
+
+    def test_activity_onchanges_team_different_member_no_leader(self):
+        self.assertEqual(
+            self.act2.team_id, self.team1, "Error: Activity 2 should have Team 1."
+        )
+        self.team2.user_id = False
+        self.team2.member_ids = self.employee2
+        with Form(self.act2) as form:
+            form.team_id = self.team2
+            self.assertEqual(form.user_id, self.employee2)
+
+    def test_activity_onchanges_activity_type_set_team(self):
+        self.assertEqual(
+            self.act2.team_id, self.team1, "Error: Activity 2 should have Team 1."
+        )
+        self.activity1.default_team_id = self.team2
+        self.assertEqual(self.act2.activity_type_id, self.activity2)
+        with Form(self.act2) as form:
+            form.activity_type_id = self.activity1
+            self.assertEqual(form.team_id, self.team2)
+
+    def test_activity_onchanges_activity_type_no_team(self):
+        self.assertEqual(
+            self.act2.team_id, self.team1, "Error: Activity 2 should have Team 1."
+        )
+        self.assertEqual(self.act2.activity_type_id, self.activity2)
+        with Form(self.act2) as form:
+            form.activity_type_id = self.activity1
+            self.assertEqual(form.team_id, self.team1)
+
+    def test_activity_constrain(self):
         with self.assertRaises(ValidationError):
             self.act2.write({"user_id": self.employee2.id, "team_id": self.team1.id})
-        self.team1.user_id = False
-        self.act2.user_id = False
-        self.act2._onchange_user_id()
-        self.team2.member_ids = [(4, self.employee3.id)]
-        self.act2.team_id = self.team1
-        self.act2.team_id = False
-        self.act2.user_id = self.employee3
-        self.act2._onchange_user_id()
-        self.act2.team_id = self.team2
-        self.team2.member_ids = [(3, self.act2.user_id.id)]
-        self.act2._onchange_team_id()
 
     def test_schedule_activity(self):
         """Correctly assign teams to auto scheduled activities. Those won't
@@ -210,6 +274,23 @@ class TestMailActivityTeam(TransactionCase):
             .systray_get_activities()
         )
         self.assertEqual(res[0]["total_count"], 0)
+        self.assertEqual(res[0]["today_count"], 1)
+        partner_record = self.employee.partner_id.with_user(self.employee.id)
+        self.activity2.default_team_id = self.team2
+        activity = partner_record.activity_schedule(
+            activity_type_id=self.activity2.id, user_id=self.employee2.id
+        )
+        activity.flush()
+        res = (
+            self.env["res.users"]
+            .with_user(self.employee.id)
+            .with_context({"team_activities": True})
+            .systray_get_activities()
+        )
+        self.assertEqual(res[0]["total_count"], 1)
+        self.assertEqual(res[0]["today_count"], 2)
+        res = self.env["res.users"].with_user(self.employee.id).systray_get_activities()
+        self.assertEqual(res[0]["total_count"], 2)
 
     def test_activity_schedule_next(self):
         self.activity1.write(

--- a/mail_activity_team/tests/test_mail_activity_team.py
+++ b/mail_activity_team/tests/test_mail_activity_team.py
@@ -1,5 +1,7 @@
 # Copyright 2018-22 ForgeFlow S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import json
+
 from odoo.exceptions import ValidationError
 from odoo.tests.common import Form, TransactionCase
 
@@ -200,6 +202,10 @@ class TestMailActivityTeam(TransactionCase):
         self.team2.member_ids = self.employee2
         with Form(self.act2) as form:
             form.team_id = self.team2
+            self.assertIn(
+                form.user_id,
+                self.env["res.users"].search(json.loads(form.user_id_domain)),
+            )
             self.assertEqual(form.user_id, self.employee2)
 
     def test_activity_onchanges_team_different_member_no_leader(self):

--- a/mail_activity_team/tests/test_mail_activity_team.py
+++ b/mail_activity_team/tests/test_mail_activity_team.py
@@ -1,10 +1,10 @@
 # Copyright 2018-22 ForgeFlow S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo.exceptions import ValidationError
-from odoo.tests.common import Form, SavepointCase
+from odoo.tests.common import Form, TransactionCase
 
 
-class TestMailActivityTeam(SavepointCase):
+class TestMailActivityTeam(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -251,7 +251,8 @@ class TestMailActivityTeam(SavepointCase):
         partner_record = self.employee.partner_id.with_user(self.employee.id)
         self.env.ref("mail.mail_activity_data_call").default_team_id = self.team2
         activity = partner_record.activity_schedule(
-            act_type_xmlid="mail.mail_activity_data_call", user_id=self.employee2.id,
+            act_type_xmlid="mail.mail_activity_data_call",
+            user_id=self.employee2.id,
         )
         self.assertEqual(activity.team_id, self.team2)
         self.assertEqual(activity.user_id, self.employee2)
@@ -262,7 +263,9 @@ class TestMailActivityTeam(SavepointCase):
         partner_record = self.employee.partner_id.with_user(self.employee.id)
         self.activity2.default_team_id = self.team2
         self.team2.member_ids = self.employee2
-        activity = partner_record.activity_schedule(activity_type_id=self.activity2.id,)
+        activity = partner_record.activity_schedule(
+            activity_type_id=self.activity2.id,
+        )
         self.assertEqual(activity.team_id, self.team2)
         self.assertEqual(activity.user_id, self.employee2)
 
@@ -270,7 +273,7 @@ class TestMailActivityTeam(SavepointCase):
         res = (
             self.env["res.users"]
             .with_user(self.employee.id)
-            .with_context({"team_activities": True})
+            .with_context(**{"team_activities": True})
             .systray_get_activities()
         )
         self.assertEqual(res[0]["total_count"], 0)
@@ -284,7 +287,7 @@ class TestMailActivityTeam(SavepointCase):
         res = (
             self.env["res.users"]
             .with_user(self.employee.id)
-            .with_context({"team_activities": True})
+            .with_context(**{"team_activities": True})
             .systray_get_activities()
         )
         self.assertEqual(res[0]["total_count"], 1)
@@ -296,8 +299,7 @@ class TestMailActivityTeam(SavepointCase):
         self.activity1.write(
             {
                 "default_team_id": self.team1.id,
-                "default_next_type_id": self.activity2.id,
-                "force_next": True,
+                "triggered_next_type_id": self.activity2.id,
             }
         )
         self.activity2.default_team_id = self.team2

--- a/mail_activity_team/tests/test_mail_activity_team.py
+++ b/mail_activity_team/tests/test_mail_activity_team.py
@@ -1,6 +1,5 @@
 # Copyright 2018-22 ForgeFlow S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-import json
 
 from odoo.exceptions import ValidationError
 from odoo.tests.common import Form, TransactionCase
@@ -202,10 +201,6 @@ class TestMailActivityTeam(TransactionCase):
         self.team2.member_ids = self.employee2
         with Form(self.act2) as form:
             form.team_id = self.team2
-            self.assertIn(
-                form.user_id,
-                self.env["res.users"].search(json.loads(form.user_id_domain)),
-            )
             self.assertEqual(form.user_id, self.employee2)
 
     def test_activity_onchanges_team_different_member_no_leader(self):

--- a/mail_activity_team/tests/test_mail_activity_team.py
+++ b/mail_activity_team/tests/test_mail_activity_team.py
@@ -148,6 +148,7 @@ class TestMailActivityTeam(TransactionCase):
         self.assertEqual(
             self.act2.team_id, self.team1, "Error: Activity 2 should have Team 1."
         )
+        self.act2.team_id = False
         self.act2._onchange_team_id()
         self.assertEqual(self.act2.user_id, self.employee)
         self.act2.team_id = self.team2
@@ -179,3 +180,51 @@ class TestMailActivityTeam(TransactionCase):
             activity_type_id=self.env.ref("mail.mail_activity_data_call").id,
         )
         self.assertEqual(activity.team_id, self.team2)
+
+    def test_schedule_activity_default_team(self):
+        """Correctly assign teams to auto scheduled activities. Those won't
+        trigger onchanges and could raise constraints and team missmatches"""
+        partner_record = self.employee.partner_id.with_user(self.employee.id)
+        self.env.ref("mail.mail_activity_data_call").default_team_id = self.team2
+        activity = partner_record.activity_schedule(
+            act_type_xmlid="mail.mail_activity_data_call", user_id=self.employee2.id,
+        )
+        self.assertEqual(activity.team_id, self.team2)
+        self.assertEqual(activity.user_id, self.employee2)
+
+    def test_schedule_activity_default_team_no_user(self):
+        """Correctly assign teams to auto scheduled activities. Those won't
+        trigger onchanges and could raise constraints and team missmatches"""
+        partner_record = self.employee.partner_id.with_user(self.employee.id)
+        self.activity2.default_team_id = self.team2
+        self.team2.member_ids = self.employee2
+        activity = partner_record.activity_schedule(activity_type_id=self.activity2.id,)
+        self.assertEqual(activity.team_id, self.team2)
+        self.assertEqual(activity.user_id, self.employee2)
+
+    def test_activity_count(self):
+        res = (
+            self.env["res.users"]
+            .with_user(self.employee.id)
+            .with_context({"team_activities": True})
+            .systray_get_activities()
+        )
+        self.assertEqual(res[0]["total_count"], 0)
+
+    def test_activity_schedule_next(self):
+        self.activity1.write(
+            {
+                "default_team_id": self.team1.id,
+                "default_next_type_id": self.activity2.id,
+                "force_next": True,
+            }
+        )
+        self.activity2.default_team_id = self.team2
+        self.team2.member_ids = self.employee2
+        partner_record = self.employee.partner_id.with_user(self.employee.id)
+        activity = partner_record.activity_schedule(activity_type_id=self.activity1.id)
+        activity.flush()
+        _messages, next_activities = activity._action_done()
+        self.assertTrue(next_activities)
+        self.assertEqual(next_activities.team_id, self.team2)
+        self.assertEqual(next_activities.user_id, self.employee2)

--- a/mail_activity_team/views/mail_activity_type.xml
+++ b/mail_activity_team/views/mail_activity_type.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2022 CreuBlanca
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="mail_activity_type_form_view">
+        <field name="name">mail.activity.type.form (in mail_activity_team)</field>
+        <field name="model">mail.activity.type</field>
+        <field name="inherit_id" ref="mail.mail_activity_type_view_form" />
+        <field name="arch" type="xml">
+            <field name="default_user_id" position="after">
+                <field
+                    name="default_team_id"
+                    options="{'no_create': True, 'no_edit': True}"
+                />
+            </field>
+        </field>
+    </record>
+
+
+
+</odoo>

--- a/mail_activity_team/views/mail_activity_views.xml
+++ b/mail_activity_team/views/mail_activity_views.xml
@@ -6,8 +6,22 @@
         <field name="model">mail.activity</field>
         <field name="inherit_id" ref="mail.mail_activity_view_form_popup" />
         <field name="arch" type="xml">
+            <field name="user_id" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': [('team_id', '!=', False)]}</attribute>
+            </field>
             <field name="user_id" position="after">
-                <field name="team_id" options="{'no_create': True, 'no_open': True}" />
+                <field
+                    name="team_user_id"
+                    attrs="{'invisible': [('team_id', '=', False)]}"
+                    domain="[('activity_team_ids', '=', team_id)]"
+                />
+                <field
+                    name="team_id"
+                    options="{'no_create': True, 'no_open': True}"
+                    domain="['|', ('res_model_ids', '=', False), ('res_model_ids', '=', res_model_id)]"
+                />
             </field>
         </field>
     </record>
@@ -31,8 +45,21 @@
             ref="mail_activity_board.mail_activity_view_form_board"
         />
         <field name="arch" type="xml">
+            <field name="user_id" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': [('team_id', '=', False)]}</attribute>
+            </field>
             <field name="user_id" position="after">
-                <field name="team_id" />
+                <field
+                    name="user_id"
+                    attrs="{'invisible': [('team_id', '!=', False)]}"
+                    domain="[('activity_team_ids', '=', team_id)]"
+                />
+                <field
+                    name="team_id"
+                    domain="['|', ('res_model_ids', '=', False), ('res_model_ids', '=', res_model_id)]"
+                />
             </field>
         </field>
     </record>

--- a/mail_activity_team/views/mail_activity_views.xml
+++ b/mail_activity_team/views/mail_activity_views.xml
@@ -52,7 +52,7 @@
             </field>
             <field name="user_id" position="after">
                 <field
-                    name="user_id"
+                    name="team_user_id"
                     attrs="{'invisible': [('team_id', '!=', False)]}"
                     domain="[('activity_team_ids', '=', team_id)]"
                 />


### PR DESCRIPTION
Includes (besides small changes):

- #912 
- #919 



@etobella 

There are warnings associated with MailActivity._onchange_team_id and MailActivity._onchange_user_id, we think about using https://github.com/odoo/odoo/pull/41918 but it would be a problem if a BBDD with many users is used. What do you think?