### PR TITLE
[14.0] Add module mail_notification_with_history

### DIFF
--- a/mail_notification_with_history/__init__.py
+++ b/mail_notification_with_history/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/mail_notification_with_history/__manifest__.py
+++ b/mail_notification_with_history/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+{
+    "name": "Mail Notification With History",
+    "summary": """Add the previous chatter discussion into new email notifications.""",
+    "version": "14.0.1.0.0",
+    "category": "Social",
+    "website": "https://github.com/OCA/social",
+    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "installable": True,
+    "depends": ["mail"],
+    "data": ["data/mail_data.xml"],
+    "development_status": "Beta",
+    "maintainers": ["TDu"],
+}

--- a/mail_notification_with_history/data/mail_data.xml
+++ b/mail_notification_with_history/data/mail_data.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+  <template
+        id="message_notification_email"
+        inherit_id="mail.message_notification_email"
+    >
+    <xpath expr="//div[@t-if='signature']" position="after">
+
+      <t
+                t-set="message_history"
+                t-value="message._get_notification_message_history()"
+            />
+      <t t-if="message_history">
+        <p class="message_history_title">Discussion history in Odoo:</p>
+        <ul>
+          <t t-foreach="message_history" t-as="msg">
+            <li class="message_history_item">
+            <p><t t-esc="msg.author_id.name or 'unknown'" /> commented on <span
+                                    t-field="msg.date"
+                                /></p>
+            <div t-raw="msg.body" />
+            </li>
+          </t>
+        </ul>
+      </t>
+
+    </xpath>
+  </template>
+
+</odoo>

--- a/mail_notification_with_history/models/__init__.py
+++ b/mail_notification_with_history/models/__init__.py
@@ -1,0 +1,2 @@
+from . import mail_message
+from . import mail_thread

--- a/mail_notification_with_history/models/mail_message.py
+++ b/mail_notification_with_history/models/mail_message.py
@@ -1,0 +1,28 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import models
+
+
+class Message(models.Model):
+    _inherit = "mail.message"
+
+    def _get_notification_message_history(self):
+        """Get the list of messages to include into an email notification history."""
+        if not self.env[self.model]._mail_notification_include_history:
+            return self.browse()
+        domain = self._get_notification_message_history_domain()
+        messages = self.env["mail.message"].search(domain, order="date desc")
+        return messages - self
+
+    def _get_notification_message_history_domain(self):
+        """Return the domain for email and send message comments."""
+        return [
+            ("model", "=", self.model),
+            ("res_id", "=", self.res_id),
+            "|",
+            "&",
+            ("message_type", "=", "comment"),
+            ("subtype_id", "=", self.env.ref("mail.mt_comment").id),
+            ("message_type", "=", "email"),
+        ]

--- a/mail_notification_with_history/models/mail_thread.py
+++ b/mail_notification_with_history/models/mail_thread.py
@@ -1,0 +1,10 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import models
+
+
+class MailThread(models.AbstractModel):
+    _inherit = "mail.thread"
+
+    _mail_notification_include_history = False

--- a/mail_notification_with_history/readme/CONTRIBUTORS.rst
+++ b/mail_notification_with_history/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+   * Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/mail_notification_with_history/readme/DESCRIPTION.rst
+++ b/mail_notification_with_history/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+Followers of a discussion in the chatter of Odoo can be informed by email
+of a new message being created.
+This module adds in that email the history of the chatter discussion to help
+the recipient with more context.

--- a/mail_notification_with_history/readme/INSTALL.rst
+++ b/mail_notification_with_history/readme/INSTALL.rst
@@ -1,0 +1,4 @@
+After installing the module its behaviour needs to be activated.
+This is done by setting the following class variable
+`_mail_notification_include_history` to True, on the model that
+we would like to activate it.

--- a/mail_notification_with_history/tests/__init__.py
+++ b/mail_notification_with_history/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_mail_notification_with_history

--- a/mail_notification_with_history/tests/test_mail_notification_with_history.py
+++ b/mail_notification_with_history/tests/test_mail_notification_with_history.py
@@ -1,0 +1,85 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from unittest.mock import Mock, patch
+
+from odoo.tests import common
+
+
+class TestMailNotificationWithHistory(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.base_template = cls.env.ref("mail.message_notification_email")
+        cls.mail_message = cls.env.ref("mail.mail_message_channel_1_2_1")
+        cls.message_subtype = cls.env.ref("mail.mt_comment")
+        cls.render_values = {
+            "button_access": {"title": "View Record", "url": "http://127.0.0.1"},
+            "actions": [],
+            "company": cls.env.company,
+            "has_button_access": True,
+            "is_discussion": True,
+            "lang": "en_US",
+            "message": cls.mail_message,
+            "subtype": cls.message_subtype,
+        }
+
+    def test_thread_history_is_included(self):
+        with patch(
+            (
+                "odoo.addons.mail_notification_with_history.models.mail_thread."
+                "MailThread._mail_notification_include_history"
+            ),
+            new=Mock(return_value=True),
+        ):
+            body = self.base_template._render(
+                self.render_values, engine="ir.qweb", minimal_qcontext=True
+            )
+        self.assertTrue(body.find(b"Discussion") >= 0)
+
+    def test_thread_history_is_not_included(self):
+        body = self.base_template._render(
+            self.render_values, engine="ir.qweb", minimal_qcontext=True
+        )
+        self.assertTrue(body.find(b"Discussion") == -1)
+
+    def test_domain_message_in_history(self):
+        """Check the good number of message is returned for the history."""
+        # There is already two messages from demo data and we create...
+        # One email message that should be included
+        self.env["mail.message"].create(
+            {
+                "message_type": "email",
+                "model": self.mail_message.model,
+                "res_id": self.mail_message.res_id,
+            }
+        )
+        # One comment (message) should be included
+        self.env["mail.message"].create(
+            {
+                "message_type": "comment",
+                "model": self.mail_message.model,
+                "res_id": self.mail_message.res_id,
+                "subtype_id": self.env.ref("mail.mt_comment").id,
+            }
+        )
+        # One comment (internal note) should NOT be included
+        self.env["mail.message"].create(
+            {
+                "message_type": "comment",
+                "model": self.mail_message.model,
+                "res_id": self.mail_message.res_id,
+                "subtype_id": self.env.ref("mail.mt_note").id,
+            }
+        )
+        with patch(
+            (
+                "odoo.addons.mail_notification_with_history.models.mail_thread."
+                "MailThread._mail_notification_include_history"
+            ),
+            new=Mock(return_value=True),
+        ):
+            history = self.mail_message._get_notification_message_history()
+        # So that is four message to include in history
+        self.assertEqual(len(history), 4)

--- a/setup/mail_notification_with_history/odoo/addons/mail_notification_with_history
+++ b/setup/mail_notification_with_history/odoo/addons/mail_notification_with_history
@@ -1,0 +1,1 @@
+../../../../mail_notification_with_history

--- a/setup/mail_notification_with_history/setup.py
+++ b/setup/mail_notification_with_history/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Followers of a discussion in the chatter of Odoo can be informed by email
of a new message being created.
This module adds in that email the history of the chatter discussion to help
the recipient with more context.