### PR TITLE
15.0-mail_autosubscrite-dependencies

### DIFF
--- a/mail_autosubscribe/__manifest__.py
+++ b/mail_autosubscribe/__manifest__.py
@@ -10,6 +10,9 @@
     "license": "AGPL-3",
     "category": "Marketing",
     "depends": ["mail"],
+    "external_dependencies": {
+        "python": ["odoo_test_helper"],
+    },
     "website": "https://github.com/OCA/social",
     "data": [
         "security/ir.model.access.csv",

--- a/mail_autosubscribe/readme/CONTRIBUTORS.rst
+++ b/mail_autosubscribe/readme/CONTRIBUTORS.rst
@@ -1,3 +1,7 @@
 * `Camptocamp <https://www.camptocamp.com>`_
 
      * Iván Todorovich <ivan.todorovich@gmail.com>
+
+* `Moduon <https://www.moduon.team/>`__
+
+     * Jairo Llopis

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# generated from manifests external_dependencies
+odoo_test_helper


### PR DESCRIPTION
This should fix the tests, that are currently failing on CI with:

```
2022-07-05 16:19:13,250 259 INFO odoo odoo.service.server: Starting post tests
2022-07-05 16:19:13,253 259 ERROR odoo odoo.tests.loader: Can not `import mail_autosubscribe`.
Traceback (most recent call last):
  File "/opt/odoo/odoo/tests/loader.py", line 33, in _get_tests_modules
    mod = importlib.import_module('.tests', modpath)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 848, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/__w/social/social/mail_autosubscribe/tests/__init__.py", line 1, in <module>
    from . import test_mail_autosubscribe
  File "/__w/social/social/mail_autosubscribe/tests/test_mail_autosubscribe.py", line 5, in <module>
    from odoo_test_helper import FakeModelLoader
ModuleNotFoundError: No module named 'odoo_test_helper'
```