### PR TITLE
[FIX] mail_debrand: default engine as odoo while rendering

### DIFF
--- a/mail_debrand/models/mail_render_mixin.py
+++ b/mail_debrand/models/mail_render_mixin.py
@@ -56,7 +56,7 @@ class MailRenderMixin(models.AbstractModel):
         template_src,
         model,
         res_ids,
-        engine="qweb_view",
+        engine="inline_template",
         add_context=None,
         options=None,
         post_process=False,


### PR DESCRIPTION
On mail_render_mixin._render_template method as we call the
[parent method defined in odoo](https://github.com/OCA/OCB/blob/15.0/addons/mail/models/mail_render_mixin.py#L478) we should use the same
default engine value as mail module. Because `template_src`
can be the content of the template or a reference to a to
a qweb template.

To reproduce this:

* install sms and mail_debrand modules
* go to the partner list and select multiple parteners
* In Action click on *Send SMS Text Message*

Without this fix return content is an empty
string. With the `inline_template` engine
collect body is properly rendered.