### PR TITLE
[14.0][mail_tracking] [IMP] Add option to keep aliases in mail tracking

### DIFF
--- a/mail_tracking/__manifest__.py
+++ b/mail_tracking/__manifest__.py
@@ -24,6 +24,7 @@
         "views/mail_tracking_event_view.xml",
         "views/mail_message_view.xml",
         "views/res_partner_view.xml",
+        "views/res_config_settings.xml",
     ],
     "qweb": [
         "static/src/xml/mail_tracking.xml",

--- a/mail_tracking/models/__init__.py
+++ b/mail_tracking/models/__init__.py
@@ -1,5 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from . import res_company
+from . import res_config_settings
 from . import ir_mail_server
 from . import mail_bounced_mixin
 from . import mail_mail

--- a/mail_tracking/models/mail_message.py
+++ b/mail_tracking/models/mail_message.py
@@ -217,6 +217,12 @@ class MailMessage(models.Model):
     @api.model
     def _drop_aliases(self, mail_list):
         aliases = self.env["mail.alias"].get_aliases()
+        if self.env.company.mail_tracking_show_aliases:
+            IrConfigParamObj = self.env["ir.config_parameter"].sudo()
+            aliases = "{}@{}".format(
+                IrConfigParamObj.get_param("mail.catchall.alias"),
+                IrConfigParamObj.get_param("mail.catchall.domain"),
+            )
 
         def _filter_alias(email):
             email_wn = getaddresses([email])[0][1]

--- a/mail_tracking/models/mail_thread.py
+++ b/mail_tracking/models/mail_thread.py
@@ -75,9 +75,10 @@ class MailThread(models.AbstractModel):
                     )
             else:
                 partner = ResPartnerObj.browse(partner_id)
-                self._message_add_suggested_recipient(
-                    suggestions, partner=partner, reason=reason
-                )
+                if partner.email not in aliases:
+                    self._message_add_suggested_recipient(
+                        suggestions, partner=partner, reason=reason
+                    )
 
     @api.model
     def _fields_view_get(

--- a/mail_tracking/models/res_company.py
+++ b/mail_tracking/models/res_company.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    mail_tracking_show_aliases = fields.Boolean(
+        string="Show Aliases in Mail Tracking",
+        default=False,
+    )

--- a/mail_tracking/models/res_config_settings.py
+++ b/mail_tracking/models/res_config_settings.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    mail_tracking_show_aliases = fields.Boolean(
+        related="company_id.mail_tracking_show_aliases",
+        readonly=False,
+    )

--- a/mail_tracking/tests/test_mail_tracking.py
+++ b/mail_tracking/tests/test_mail_tracking.py
@@ -157,6 +157,37 @@ class TestMailTracking(TransactionCase):
         self.assertEqual(tracking_email.error_type, "no_recipient")
         self.assertFalse(self.recipient.email_bounced)
 
+    def test_message_post_show_aliases(self):
+        # Create message with show aliases setup
+        self.env.company.mail_tracking_show_aliases = True
+        # Setup catchall domain
+        IrConfigParamObj = self.env["ir.config_parameter"].sudo()
+        IrConfigParamObj.set_param("mail.catchall.domain", "test.com")
+        # pylint: disable=C8107
+        message = self.env["mail.message"].create(
+            {
+                "subject": "Message test",
+                "author_id": self.sender.id,
+                "email_from": self.sender.email,
+                "message_type": "comment",
+                "model": "res.partner",
+                "res_id": self.recipient.id,
+                "partner_ids": [(4, self.recipient.id)],
+                "email_cc": "Dominique Pinon <unnamed@test.com>, customer-invoices@test.com",
+                "body": "<p>This is another test message</p>",
+            }
+        )
+        message._moderate_accept()
+        message_dict, *_ = message.message_format()
+        self.assertTrue(
+            any(
+                [
+                    tracking["recipient"] == "customer-invoices@test.com"
+                    for tracking in message_dict["partner_trackings"]
+                ]
+            )
+        )
+
     def _check_partner_trackings_cc(self, message):
         message_dict = message.message_format()[0]
         self.assertEqual(len(message_dict["partner_trackings"]), 3)

--- a/mail_tracking/views/res_config_settings.xml
+++ b/mail_tracking/views/res_config_settings.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.mail.tracking</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="mail.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <div id="emails" position="inside">
+                <div class="col-12 col-lg-6 o_setting_box" id="mail_tracking_settings">
+                    <div class="o_setting_left_pane">
+                        <field name="mail_tracking_show_aliases" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <div class="content-group">
+                            <label for="mail_tracking_show_aliases" />
+                            <div class="text-muted" id="mail_tracking_show_aliases">
+                                Show Aliases in Mail Tracking
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Use case :
- setup an alias (ie info@domain.com) to an object
1- send an email to info@domain.com and cc someone else
2- send an email to someone else and cc info@domain.com

In the chatter, we want to include the alias to know if the alias was was email_to or email_cc because the user has not the same priority to answer (if the alias is email_to --> the user must reply, if the alias is email_cc --> the user has no action)

Here are screenshots after this PR (alias is setup with crm.team)

![Test_email_to_alias](https://user-images.githubusercontent.com/7600872/217374827-4e74eacd-a8b3-4452-920a-555aaf60b506.png)
![Test_email_cc_alias](https://user-images.githubusercontent.com/7600872/217405925-5fa9805f-1cc6-4bdc-a7ea-0798f441557c.png)
