### PR TITLE
[15.0][FIX] mail_activity_board: read access to ir.model for non admin

### DIFF
--- a/mail_activity_board/models/mail_activity.py
+++ b/mail_activity_board/models/mail_activity.py
@@ -33,7 +33,7 @@ class MailActivity(models.Model):
 
     @api.model
     def _selection_related_model_instance(self):
-        models = self.env["ir.model"].search([("is_mail_activity", "=", True)])
+        models = self.env["ir.model"].sudo().search([("is_mail_activity", "=", True)])
         return [(model.model, model.name) for model in models]
 
     def open_origin(self):


### PR DESCRIPTION
Give read access to ir.model for non admin users when accessing records that inherit mail.activity mixing. Otherwise those users will get access error.

Steps to reproduce: Just access a manufacturing order with a non admin user. An access error to ir.model model will be thrown.

@ForgeFlow