### PR TITLE
[FIX] Fix for a AccessError for normal users

### DIFF
--- a/mail_activity_board/models/mail_activity.py
+++ b/mail_activity_board/models/mail_activity.py
@@ -33,7 +33,7 @@ class MailActivity(models.Model):
 
     @api.model
     def _selection_related_model_instance(self):
-        models = self.env["ir.model"].search([("is_mail_activity", "=", True)])
+        models = self.env["ir.model"].sudo().search([("is_mail_activity", "=", True)])
         return [(model.model, model.name) for model in models]
 
     def open_origin(self):


### PR DESCRIPTION
Normal users don't have read access to ir.model - but the function to get selection values does try to read ir.model without sudo - this does not work. Adding sudo here is safe.