### PR TITLE
[FIX] mail_private: Manage records without `allow_private`

### DIFF
--- a/mail_private/wizards/mail_compose_message.py
+++ b/mail_private/wizards/mail_compose_message.py
@@ -16,9 +16,16 @@ class MailComposeMessage(models.TransientModel):
     @api.depends('model', 'res_id')
     def _compute_allow_private(self):
         for record in self:
-            record.allow_private = record.model and record.res_id and self.env[
-                record.model
-            ].browse(record.res_id).allow_private
+            allow_private = False
+
+            related_res_id = record.res_id
+            related_model = record.model
+            if related_model and related_res_id:
+                related_record = self.env[related_model].browse(related_res_id)
+                if hasattr(related_record, 'allow_private'):
+                    allow_private = related_record.allow_private
+
+            record.allow_private = allow_private
 
     def get_mail_values(self, res_ids):
         res = super().get_mail_values(res_ids)

--- a/test_mail_private/tests/test_mail_private.py
+++ b/test_mail_private/tests/test_mail_private.py
@@ -247,6 +247,25 @@ class TestMailPrivate(Moderation):
             'partner_ids': []})
         self.assertFalse(compose.allow_private)
 
+    def test_compose_message_compute_no_field(self):
+        """
+        Compose Wizard does not allow private
+        if related record has no field `allow_private`.
+        """
+        mail_message = self.env['mail.message'].search([], limit=1)
+        self.assertTrue(mail_message)
+        self.assertFalse(hasattr(mail_message, 'allow_private'))
+
+        compose = self.env['mail.compose.message'].with_context({
+            'default_composition_mode': 'comment',
+            'default_model': mail_message._name,
+            'default_res_id': mail_message.id
+        }).sudo(self.user_01.id).create({
+            'subject': 'Subject',
+            'body': 'Body text',
+            'partner_ids': []})
+        self.assertFalse(compose.allow_private)
+
     def test_security_groups(self):
         groups = self.partner.sudo(
             self.user_01.id).get_message_security_groups()


### PR DESCRIPTION
Otherwise, the following occurs:
AttributeError: 'mail.message' object has no attribute 'allow_private'