### PR TITLE
[12.0][FIX] mail_attach_existing_attachment: fix view

### DIFF
--- a/mail_attach_existing_attachment/wizard/mail_compose_message_view.xml
+++ b/mail_attach_existing_attachment/wizard/mail_compose_message_view.xml
@@ -6,11 +6,8 @@
         <field name="inherit_id" ref="mail.email_compose_message_wizard_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='attachment_ids']" position="after">
+                <field name="object_attachment_ids" widget="many2many_checkboxes" domain="[('res_model', '=', model), ('res_id', '=', res_id)]" attrs="{'invisible': [('can_attach_attachment', '=', False)]}"/>
                 <field name="can_attach_attachment" invisible="1"/>
-                <div attrs="{'invisible': [('can_attach_attachment', '=', False)]}">
-                    <br />
-                    <field name="object_attachment_ids" widget="many2many_checkboxes" domain="[('res_model', '=', model), ('res_id', '=', res_id)]" />
-                </div>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
mail.compose wizard shows empty space because of can_attach_attachment and colspan on attachment_ids This patch fixes the view by putting can_attach_attachment after object_attachment_ids and removes unnecessary div and br