### PR TITLE
[FIX] mail_outbound_static unittest test_ir_mail_server.py

### DIFF
--- a/mail_outbound_static/tests/test_ir_mail_server.py
+++ b/mail_outbound_static/tests/test_ir_mail_server.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+import sys
 import threading
 from email import message_from_string
 
@@ -88,8 +89,10 @@ class TestIrMailServer(TransactionCase):
                 self.Model._revert_method("connect")
         finally:
             thread.testing = True
-        send_from, send_to, message_string = connect().sendmail.call_args[0]
-        return message_from_string(message_string)
+        if sys.version_info < (3, 7, 4):
+            send_from, send_to, message_string = connect().sendmail.call_args[0]
+            return message_from_string(message_string)
+        return connect().send_message.call_args[0][0]
 
     def test_send_email_injects_from_no_canonical(self):
         """It should inject the FROM header correctly when no canonical name."""


### PR DESCRIPTION
Fixing unittest mail_outbound_static unittest test_ir_mail_server.py
For higher python versions

I am currently using, python 3.9 without my changes i will get this error message on executing the unittests for mail_outbount_static. 

```
Traceback (most recent call last):
  File "/opt/addons/mail_outbound_static/tests/test_ir_mail_server.py", line 98, in test_send_email_injects_from_no_canonical
    message = self._send_mail()
  File "/opt/addons/mail_outbound_static/tests/test_ir_mail_server.py", line 92, in _send_mail
    send_from, send_to, message_string = connect().sendmail.call_args[0]
TypeError: 'NoneType' object is not subscriptable
```

Therefor i'm fixing the unittests for python version greater than equal 3.7.4