### PR TITLE
[14.0][FIX] mail_quoted_reply: avoid access right errors when reading action.

### DIFF
--- a/mail_quoted_reply/models/mail_message.py
+++ b/mail_quoted_reply/models/mail_message.py
@@ -9,7 +9,9 @@ class MailMessage(models.Model):
     _inherit = "mail.message"
 
     def reply_message(self):
-        action = self.env.ref("mail.action_email_compose_message_wizard").read()[0]
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "mail.action_email_compose_message_wizard"
+        )
         action["context"] = {
             "default_model": self._name,
             "default_res_id": self.id,


### PR DESCRIPTION
Otherwise non-admin users cannot user the feature.

@ForgeFlow