### PR TITLE
[15.0] [IMP] mail_activity_team: settings menu position

### DIFF
--- a/mail_activity_team/views/mail_activity_team_views.xml
+++ b/mail_activity_team/views/mail_activity_team_views.xml
@@ -99,7 +99,8 @@ Menus
     <menuitem
         id="menu_mail_activity_team"
         name="Activity Teams"
-        parent="base.menu_email"
+        parent="mail.mail_menu_technical"
+        sequence="10"
         action="mail_activity_team_action"
     />
 


### PR DESCRIPTION
So that it's next to the other "Activity" menues.


|**Before:** | **After:** |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/1914185/199010127-bbb97768-a290-4327-840d-4b5cc5404185.png) | ![after](https://user-images.githubusercontent.com/1914185/199010147-8f79e772-91c9-464a-98ae-4790e8635def.png) |



ping @JordiBForgeFlow @MiquelRForgeFlow 





