### PR TITLE
[FIX] mail_activity_board: use sudo to read ir action window

### DIFF
--- a/mail_activity_board/models/mail_activity.py
+++ b/mail_activity_board/models/mail_activity.py
@@ -52,7 +52,9 @@ class MailActivity(models.Model):
 
     @api.model
     def action_activities_board(self):
-        action = self.env.ref("mail_activity_board.open_boards_activities").read()[0]
+        action = (
+            self.env.ref("mail_activity_board.open_boards_activities").sudo().read()[0]
+        )
         return action
 
     @api.model


### PR DESCRIPTION
Self-explanatory, just in case: go to runboat, enter as demo, go to any contact, press the Activities access in the chatter. 