### PR TITLE
[UPD] Python to 3.6 to support latest pylint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
     - $HOME/.cache/pre-commit
 
 python:
-  - "3.5"
+  - "3.6"
 
 addons:
   postgresql: "9.6"


### PR DESCRIPTION
Try to fix Travis builds for 12.0 OCA/social