### PR TITLE
[FIX] mail_notification_custom_subject: do not require being admin to send messages

### DIFF
--- a/mail_notification_custom_subject/__manifest__.py
+++ b/mail_notification_custom_subject/__manifest__.py
@@ -17,5 +17,5 @@
         "views/mail_notification_custom_subject_views.xml",
     ],
     "development_status": "Production/Stable",
-    "maintainers": ["joao-p-marques"],
+    "maintainers": ["yajo"],
 }

--- a/mail_notification_custom_subject/models/mail_thread.py
+++ b/mail_notification_custom_subject/models/mail_thread.py
@@ -33,8 +33,16 @@ class MailThread(models.AbstractModel):
                 raise_if_not_found=False,
             )
         if subtype_id:
-            custom_subjects = self.env["mail.message.custom.subject"].search(
-                [("model_id.model", "=", self._name), ("subtype_ids", "=", subtype_id)]
+            custom_subjects = (
+                self.env["mail.message.custom.subject"]
+                .sudo()
+                .search(
+                    [
+                        ("model_id.model", "=", self._name),
+                        ("subtype_ids", "=", subtype_id),
+                    ]
+                )
+                .sudo(False)
             )
             if not subject:
                 subject = "Re: %s" % self.env["mail.message"].with_context(

--- a/mail_notification_custom_subject/tests/test_mail_notification_custom_subject.py
+++ b/mail_notification_custom_subject/tests/test_mail_notification_custom_subject.py
@@ -20,16 +20,22 @@ class TestMailNotificationCustomSubject(common.TransactionCase):
                 ]
             )
         )
+        cls.admin = common.new_test_user(cls.env, "boss", "base.group_system")
+
+    def setUp(self):
+        super().setUp()
+        self.uid = common.new_test_user(self.env, "worker")
 
     def test_email_subject_template_overrides(self):
-        self.env["mail.message.custom.subject"].create(
-            {
-                "name": "Test template 1",
-                "model_id": self.env.ref("base.model_res_partner").id,
-                "subtype_ids": [(6, 0, [self.env.ref("mail.mt_comment").id])],
-                "subject_template": "{{object.name or 'n/a'}} and something more",
-            }
-        )
+        with self.with_user("boss"):
+            self.env["mail.message.custom.subject"].create(
+                {
+                    "name": "Test template 1",
+                    "model_id": self.env.ref("base.model_res_partner").id,
+                    "subtype_ids": [(6, 0, [self.env.ref("mail.mt_comment").id])],
+                    "subject_template": "{{object.name or 'n/a'}} and something more",
+                }
+            )
         # Send message in partner
         mail_message_1 = self.partner_1.message_post(
             body="Test", subtype_xmlid="mail.mt_comment"
@@ -52,14 +58,15 @@ class TestMailNotificationCustomSubject(common.TransactionCase):
         self.assertEqual(mail_message_3.subject, "Test partner 2 and something more")
 
     def test_email_subject_template_normal(self):
-        self.env["mail.message.custom.subject"].create(
-            {
-                "name": "Test template 1",
-                "model_id": self.env.ref("base.model_res_partner").id,
-                "subtype_ids": [(6, 0, [self.env.ref("mail.mt_comment").id])],
-                "subject_template": "{{object.name or 'n/a'}} and something more",
-            }
-        )
+        with self.with_user("boss"):
+            self.env["mail.message.custom.subject"].create(
+                {
+                    "name": "Test template 1",
+                    "model_id": self.env.ref("base.model_res_partner").id,
+                    "subtype_ids": [(6, 0, [self.env.ref("mail.mt_comment").id])],
+                    "subject_template": "{{object.name or 'n/a'}} and something more",
+                }
+            )
         # Send note in partner
         mail_message_1 = self.partner_1.message_post(
             body="Test", subtype_xmlid="mail.mt_note", subject="Test"
@@ -68,22 +75,24 @@ class TestMailNotificationCustomSubject(common.TransactionCase):
         self.assertEqual(mail_message_1.subject, "Test")
 
     def test_email_subject_template_multi(self):
-        self.env["mail.message.custom.subject"].create(
-            {
-                "name": "Test template 1",
-                "model_id": self.env.ref("base.model_res_partner").id,
-                "subtype_ids": [(6, 0, [self.env.ref("mail.mt_comment").id])],
-                "subject_template": "{{object.name or 'n/a'}} and something more",
-            }
-        )
-        self.env["mail.message.custom.subject"].create(
-            {
-                "name": "Test template 2",
-                "model_id": self.env.ref("base.model_res_partner").id,
-                "subtype_ids": [(6, 0, [self.env.ref("mail.mt_comment").id])],
-                "subject_template": "{{object.name or 'n/a'}} and something different",
-            }
-        )
+        with self.with_user("boss"):
+            self.env["mail.message.custom.subject"].create(
+                {
+                    "name": "Test template 1",
+                    "model_id": self.env.ref("base.model_res_partner").id,
+                    "subtype_ids": [(6, 0, [self.env.ref("mail.mt_comment").id])],
+                    "subject_template": "{{object.name or 'n/a'}} and something more",
+                }
+            )
+        with self.with_user("boss"):
+            self.env["mail.message.custom.subject"].create(
+                {
+                    "name": "Test template 2",
+                    "model_id": self.env.ref("base.model_res_partner").id,
+                    "subtype_ids": [(6, 0, [self.env.ref("mail.mt_comment").id])],
+                    "subject_template": "{{object.name or 'n/a'}} and something different",
+                }
+            )
         # Send message in partner
         mail_message_1 = self.partner_1.message_post(
             body="Test", subtype_xmlid="mail.mt_comment"
@@ -92,15 +101,16 @@ class TestMailNotificationCustomSubject(common.TransactionCase):
         self.assertEqual(
             mail_message_1.subject, "Test partner 1 and something different"
         )
-        self.env["mail.message.custom.subject"].create(
-            {
-                "name": "Test template 3",
-                "model_id": self.env.ref("base.model_res_partner").id,
-                "subtype_ids": [(6, 0, [self.env.ref("mail.mt_comment").id])],
-                "subject_template": "{{' and yet something else'}}",
-                "position": "append_after",
-            }
-        )
+        with self.with_user("boss"):
+            self.env["mail.message.custom.subject"].create(
+                {
+                    "name": "Test template 3",
+                    "model_id": self.env.ref("base.model_res_partner").id,
+                    "subtype_ids": [(6, 0, [self.env.ref("mail.mt_comment").id])],
+                    "subject_template": "{{' and yet something else'}}",
+                    "position": "append_after",
+                }
+            )
         # Send message in partner
         mail_message_2 = self.partner_1.message_post(
             body="Test", subtype_xmlid="mail.mt_comment"
@@ -110,15 +120,16 @@ class TestMailNotificationCustomSubject(common.TransactionCase):
             mail_message_2.subject,
             "Test partner 1 and something different and yet something else",
         )
-        self.env["mail.message.custom.subject"].create(
-            {
-                "name": "Test template 4",
-                "model_id": self.env.ref("base.model_res_partner").id,
-                "subtype_ids": [(6, 0, [self.env.ref("mail.mt_comment").id])],
-                "subject_template": "{{'Re: '}}",
-                "position": "append_before",
-            }
-        )
+        with self.with_user("boss"):
+            self.env["mail.message.custom.subject"].create(
+                {
+                    "name": "Test template 4",
+                    "model_id": self.env.ref("base.model_res_partner").id,
+                    "subtype_ids": [(6, 0, [self.env.ref("mail.mt_comment").id])],
+                    "subject_template": "{{'Re: '}}",
+                    "position": "append_before",
+                }
+            )
         # Send message in partner
         mail_message_3 = self.partner_1.message_post(
             body="Test", subtype_xmlid="mail.mt_comment"
@@ -130,15 +141,16 @@ class TestMailNotificationCustomSubject(common.TransactionCase):
         )
 
     def test_email_subject_template_w_original(self):
-        self.env["mail.message.custom.subject"].create(
-            {
-                "name": "Test template 1",
-                "model_id": self.env.ref("base.model_res_partner").id,
-                "subtype_ids": [(6, 0, [self.env.ref("mail.mt_comment").id])],
-                "subject_template": "{{' and something more'}}",
-                "position": "append_after",
-            }
-        )
+        with self.with_user("boss"):
+            self.env["mail.message.custom.subject"].create(
+                {
+                    "name": "Test template 1",
+                    "model_id": self.env.ref("base.model_res_partner").id,
+                    "subtype_ids": [(6, 0, [self.env.ref("mail.mt_comment").id])],
+                    "subject_template": "{{' and something more'}}",
+                    "position": "append_after",
+                }
+            )
         # Send message in partner
         mail_message_1 = self.partner_1.message_post(
             body="Test",
@@ -150,15 +162,16 @@ class TestMailNotificationCustomSubject(common.TransactionCase):
 
     def test_bad_template_does_not_break(self):
         """Create template with error (obaject) to test error."""
-        self.env["mail.message.custom.subject"].create(
-            {
-                "name": "Test bad template 1",
-                "model_id": self.env.ref("base.model_res_partner").id,
-                "subtype_ids": [(6, 0, [self.env.ref("mail.mt_comment").id])],
-                "subject_template": "{{obaject.number_a}} and something",
-                "position": "append_after",
-            }
-        )
+        with self.with_user("boss"):
+            self.env["mail.message.custom.subject"].create(
+                {
+                    "name": "Test bad template 1",
+                    "model_id": self.env.ref("base.model_res_partner").id,
+                    "subtype_ids": [(6, 0, [self.env.ref("mail.mt_comment").id])],
+                    "subject_template": "{{obaject.number_a}} and something",
+                    "position": "append_after",
+                }
+            )
         # Send message in partner
         with mute_logger("odoo.addons.mail.models.mail_render_mixin"):
             mail_message_1 = self.partner_1.message_post(


### PR DESCRIPTION
After installing the module, any user was required to have admin rights to be able to search across models.

This fix does just that search with sudo and returns back to non-sudo mode immediately after. This way, we don't need to increase permissions for everybody.

Tests now run unprivileged, to assert this problem never happens again.

@moduon MT-1644 MT-1645