### PR TITLE
[FIX] mail_show_follower: failure when partner has more than 1 user

### DIFF
--- a/mail_show_follower/__manifest__.py
+++ b/mail_show_follower/__manifest__.py
@@ -13,6 +13,7 @@
     "application": False,
     "installable": True,
     "depends": ["base", "mail"],
+    "maintainers": ["yajo"],
     "data": [
         "views/res_config_settings.xml",
         "views/res_users.xml",

--- a/mail_show_follower/models/mail_mail.py
+++ b/mail_show_follower/models/mail_mail.py
@@ -114,7 +114,10 @@ class MailMail(models.Model):
                         if cc_internal:
                             partners = partners_obj.filtered(
                                 lambda x: x.id not in user_partner_ids
-                                and (not x.user_ids or x.user_ids.show_in_cc)
+                                and (
+                                    not x.user_ids
+                                    or any(x.mapped("user_ids.show_in_cc"))
+                                )
                             )
                         else:
                             partners = partners_obj.filtered(


### PR DESCRIPTION
In the highly improbable but actually possible and real world case that a partner has more than one user associated, this change makes the emails able to send.

Upstream fix proposal: https://github.com/odoo/odoo/pull/107093

@moduon MT-1634