### PR TITLE
[15.0] [FIX] mail_notification_custom_subject: Use same approach as Odoo when selecting subtype_id

### DIFF
--- a/mail_notification_custom_subject/models/mail_thread.py
+++ b/mail_notification_custom_subject/models/mail_thread.py
@@ -1,5 +1,6 @@
 # Copyright 2020-2021 Tecnativa - João Marques
 # Copyright 2021 Tecnativa - Pedro M. Baeza
+# Copyright 2022 Moduon - Eduardo de Miguel
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, models
@@ -27,11 +28,13 @@ class MailThread(models.AbstractModel):
         record_name=False,
         **kwargs
     ):
-        if not subtype_id and subtype_xmlid:
+        if subtype_xmlid:
             subtype_id = self.env["ir.model.data"]._xmlid_to_res_id(
                 subtype_xmlid,
                 raise_if_not_found=False,
             )
+        if not subtype_id:
+            subtype_id = self.env["ir.model.data"]._xmlid_to_res_id("mail.mt_note")
         if subtype_id:
             custom_subjects = (
                 self.env["mail.message.custom.subject"]

--- a/mail_notification_custom_subject/readme/CONTRIBUTORS.rst
+++ b/mail_notification_custom_subject/readme/CONTRIBUTORS.rst
@@ -7,3 +7,6 @@
 
 * Versada <https://versada.eu>
     * Naglis Jonaitis
+
+* Moduon <https://www.moduon.team>
+    * Eduardo de Miguel


### PR DESCRIPTION
If an user sends a internal message expanding the editor, the message sent doesn't have any `subtype_xml_id` nor `subtype_id`.

Using the [same approach as Odoo](https://github.com/odoo/odoo/blob/15.0/addons/mail/models/mail_thread.py#L1830-L1833) does selecting the `subtype_id`, fallbacks on `mail.mt_note` type, so the module will try to use a `mail.message.custom.subject` record.

MT-134 @moduon @rafaelbn @yajo