### PR TITLE
[15.0][FIX] mail_quoted_reply: format of default m2m value in context (fixes tests)

### DIFF
--- a/mail_quoted_reply/models/mail_message.py
+++ b/mail_quoted_reply/models/mail_message.py
@@ -43,6 +43,6 @@ class MailMessage(models.Model):
             "is_quoted_reply": True,
             "default_notify": True,
             "force_email": True,
-            "default_partner_ids": [(6, 0, self.partner_ids.ids)],
+            "default_partner_ids": self.partner_ids.ids,
         }
         return action

--- a/mail_quoted_reply/tests/test_reply.py
+++ b/mail_quoted_reply/tests/test_reply.py
@@ -13,7 +13,11 @@ class TestMessageReply(TransactionCase):
             partner.message_ids.filtered(lambda r: r.message_type != "notification")
         )
         # pylint: disable=C8107
-        message = partner.message_post(body="demo message", message_type="email")
+        message = partner.message_post(
+            body="demo message",
+            message_type="email",
+            partner_ids=self.env.ref("base.partner_demo").ids,
+        )
         partner.refresh()
         self.assertIn(
             message,
@@ -28,6 +32,8 @@ class TestMessageReply(TransactionCase):
         wizard = (
             self.env[action["res_model"]].with_context(**action["context"]).create({})
         )
+        self.assertTrue(wizard.partner_ids)
+        self.assertEqual(message.partner_ids, wizard.partner_ids)
         # the onchange in the composer isn't triggered in tests, so we check for the
         # correct quote in the context
         email_quote = re.search("<p>.*?</p>", wizard._context["quote_body"]).group()


### PR DESCRIPTION
Fixes
```
2023-01-13 12:58:32,681 249 INFO odoo odoo.addons.mail_quoted_reply.tests.test_reply: Starting TestMessageReply.test_reply ... 
2023-01-13 12:58:32,817 249 ERROR odoo odoo.sql_db: bad query:  SELECT mail_compose_message_res_partner_rel.wizard_id, mail_compose_message_res_partner_rel.partner_id FROM mail_compose_message_res_partner_rel, "res_partner"
                    WHERE ((("res_partner"."type" != 'private') OR "res_partner"."type" IS NULL) OR ("res_partner"."id" in ((6, 0, '{}')))) AND mail_compose_message_res_partner_rel.wizard_id IN (7) AND mail_compose_message_res_partner_rel.partner_id = res_partner.id
                     ORDER BY "res_partner"."display_name"    OFFSET 0
                
ERROR: operator does not exist: integer = record
LINE 2: ...s_partner"."type" IS NULL) OR ("res_partner"."id" in ((6, 0,...
                                                             ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
```

Bug was uncovered by https://github.com/odoo/odoo/commit/e09c595da8bf6cfb5aa401d877b463e6e01a640e, but as far as I can see, default x2m values in contexts are passed as a flat list of ids in core Odoo consistently, rather than as an x2m command.