### PR TITLE
[13.0][IMP] mail_outbound_static: Reply-to the same address as From

### DIFF
--- a/mail_outbound_static/__manifest__.py
+++ b/mail_outbound_static/__manifest__.py
@@ -4,10 +4,13 @@
 {
     "name": "Mail Outbound Static",
     "summary": "Allows you to configure the from header for a mail server.",
-    "version": "13.0.2.0.0",
+    "version": "13.0.2.1.0",
     "category": "Discuss",
     "website": "https://github.com/OCA/social",
-    "author": "brain-tec AG, LasLabs, Adhoc SA, Odoo Community Association (OCA)",
+    "author": "Solvti sp. z o.o., "
+    "brain-tec AG, "
+    "LasLabs, Adhoc SA, "
+    "Odoo Community Association (OCA)",
     "license": "LGPL-3",
     "application": False,
     "installable": True,

--- a/mail_outbound_static/i18n/mail_outbound_static.pot
+++ b/mail_outbound_static/i18n/mail_outbound_static.pot
@@ -52,6 +52,18 @@ msgid "Not a valid Email From"
 msgstr ""
 
 #. module: mail_outbound_static
+#: model:ir.model.fields,field_description:mail_outbound_static.field_ir_mail_server__reply_to_the_same_address
+msgid "Reply To The Same Address"
+msgstr ""
+
+#. module: mail_outbound_static
+#: model:ir.model.fields,help:mail_outbound_static.field_ir_mail_server__reply_to_the_same_address
+msgid ""
+"If you have no catchall support for  this server and will activate "
+"this option, Reply-To address will be the same as From address."
+msgstr ""
+
+#. module: mail_outbound_static
 #: model:ir.model.fields,help:mail_outbound_static.field_ir_mail_server__smtp_from
 msgid ""
 "Set this in order to email from a specific address. If the original "

--- a/mail_outbound_static/models/ir_mail_server.py
+++ b/mail_outbound_static/models/ir_mail_server.py
@@ -26,6 +26,11 @@ class IrMailServer(models.Model):
         " match with the domain whitelist."
     )
 
+    reply_to_the_same_address = fields.Boolean(
+        help="If you have no catchall support for  this server and will activate "
+        "this option, Reply-To address will be the same as From address."
+    )
+
     @api.constrains("domain_whitelist")
     def check_valid_domain_whitelist(self):
         if self.domain_whitelist:
@@ -111,6 +116,13 @@ class IrMailServer(models.Model):
                     message.replace_header("Return-Path", email_from)
                 else:
                     message.add_header("Return-Path", email_from)
+
+            # If reply to the same address is True,
+            # Reply-To header field should have the same as sender address
+            if mail_server.reply_to_the_same_address:
+                message.replace_header("Reply-To", email_from) if message.get(
+                    "Reply-To"
+                ) else message.add_header("Reply-To", email_from)
 
         return super(IrMailServer, self).send_email(
             message, mail_server_id, smtp_server, *args, **kwargs

--- a/mail_outbound_static/readme/CONTRIBUTORS.rst
+++ b/mail_outbound_static/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
 * Lorenzo Battistini <https://github.com/eLBati>
 * Katherine Zaoral <kz@adhoc.com.ar>
 * Juan José Scarafía <jjs@adhoc.com.ar>
+* Sergei Ruzki <sergei.ruzki@gmail.com>

--- a/mail_outbound_static/readme/DESCRIPTION.rst
+++ b/mail_outbound_static/readme/DESCRIPTION.rst
@@ -22,3 +22,6 @@ being appended into the proper Sender header instead. To accomplish this we:
 * Add compatibility to define the smtp information in Odoo config file. Both
   smtp_from and smtp_whitelist_domain values will be used if there is not mail
   server configured in the system.
+
+* If your server doesn't support catchall too, you can activate `Reply To The Same Address`
+  flag, so 'Reply-To' in your message will be the same as 'From'.

--- a/mail_outbound_static/readme/USAGE.rst
+++ b/mail_outbound_static/readme/USAGE.rst
@@ -1,3 +1,4 @@
 * Navigate to an Outbound Email Server
 * Set the `Email From` option to an email address
 * Set the `Domain Whitelist` option with the domain whitelist
+* Set the `Reply to the same address` option to modify 'Reply-To' message field

--- a/mail_outbound_static/tests/test_ir_mail_server.py
+++ b/mail_outbound_static/tests/test_ir_mail_server.py
@@ -327,3 +327,24 @@ class TestIrMailServer(TransactionCase):
             mail_server.smtp_from = "."
 
         mail_server.smtp_from = "notifications@test.com"
+
+    def test_11_from_outgoing_server_with_catchall(self):
+        self._init_mail_server_domain_whilelist_based()
+        domain = "example.com"
+        email_from = "test@%s" % domain
+
+        self.message.replace_header("From", email_from)
+        reply_to_address = self.message["Reply-To"]
+        message = self._send_mail()
+        self.assertEqual(message["Reply-To"], reply_to_address)
+
+    def test_12_from_outgoing_server_no_catchall(self):
+        self._init_mail_server_domain_whilelist_based()
+        domain = "example.com"
+        email_from = "test@%s" % domain
+        expected_mail_server = self.mail_server_domainone
+
+        self.message.replace_header("From", email_from)
+        expected_mail_server.reply_to_the_same_address = True
+        message = self._send_mail()
+        self.assertEqual(message["Reply-To"], expected_mail_server.smtp_from)

--- a/mail_outbound_static/views/ir_mail_server_view.xml
+++ b/mail_outbound_static/views/ir_mail_server_view.xml
@@ -13,6 +13,10 @@
             <xpath expr="//field[@name='smtp_pass']" position="after">
                 <field name="domain_whitelist" />
                 <field name="smtp_from" widget="email" />
+                <field
+                    name="reply_to_the_same_address"
+                    attrs="{'invisible': [('smtp_from', '=', False)]}"
+                />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
if server has no catchall support, there should be Reply-To message field modified, so the replies returns to the same address, we used for 'From' field So there is special flag added, user can easily turn this option on