### PR TITLE
[14.0][IMP] mail_tracking_mailgun: mass mailing manual tracking

### DIFF
--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -45,6 +45,7 @@ class MailTrackingEmail(models.Model):
     mail_message_id = fields.Many2one(
         string="Message", comodel_name="mail.message", readonly=True, index=True
     )
+    message_id = fields.Char(compute="_compute_message_id")
     mail_id = fields.Many2one(string="Email", comodel_name="mail.mail", readonly=True)
     partner_id = fields.Many2one(
         string="Partner", comodel_name="res.partner", readonly=True
@@ -115,6 +116,15 @@ class MailTrackingEmail(models.Model):
         default=lambda s: uuid.uuid4().hex,
         groups="base.group_system",
     )
+
+    @api.depends("mail_message_id")
+    def _compute_message_id(self):
+        """This helper field will allow us to map the message_id from either the linked
+        mail.message or a mass.mailing mail.trace.
+        """
+        self.message_id = False
+        for tracking in self.filtered("mail_message_id"):
+            tracking.message_id = tracking.mail_message_id.message_id
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/mail_tracking_mailgun/models/mail_tracking_email.py
+++ b/mail_tracking_mailgun/models/mail_tracking_email.py
@@ -202,12 +202,8 @@ class MailTrackingEmail(models.Model):
         https://documentation.mailgun.com/en/latest/api-events.html
         """
         api_key, api_url, domain, *__ = self._mailgun_values()
-        for tracking in self:
-            if not tracking.mail_message_id:
-                raise UserError(_("There is no tracked message!"))
-            message_id = tracking.mail_message_id.message_id.replace("<", "").replace(
-                ">", ""
-            )
+        for tracking in self.filtered("message_id"):
+            message_id = tracking.message_id.replace("<", "").replace(">", "")
             events = []
             url = urljoin(api_url, "/v3/%s/events" % domain)
             params = {

--- a/mail_tracking_mailgun/views/mail_tracking_email.xml
+++ b/mail_tracking_mailgun/views/mail_tracking_email.xml
@@ -7,10 +7,12 @@
         <field name="inherit_id" ref="mail_tracking.view_mail_tracking_email_form" />
         <field name="arch" type="xml">
             <field name="state" position="before">
+                    <field name="message_id" invisible="1" />
                     <button
                     name="action_manual_check_mailgun"
                     type="object"
                     string="Re-sync Mailgun"
+                    attrs="{'invisible': [('message_id', '=', False)]}"
                 />
             </field>
         </field>

--- a/mail_tracking_mass_mailing/models/mail_tracking_email.py
+++ b/mail_tracking_mass_mailing/models/mail_tracking_email.py
@@ -21,6 +21,14 @@ class MailTrackingEmail(models.Model):
         """Inherit this method to link other object to mailing.trace"""
         return {"mail_tracking_id": tracking.id}
 
+    @api.depends("mail_stats_id")
+    def _compute_message_id(self):
+        """For the mass mailings, the message id is stored in the mailing.trace record."""
+        res = super()._compute_message_id()
+        for tracking in self.filtered("mail_stats_id"):
+            tracking.message_id = tracking.mail_stats_id.message_id
+        return res
+
     @api.model
     def create(self, vals):
         tracking = super().create(vals)


### PR DESCRIPTION
- FW of #1038 

Mass mailing are tracked from mail.trace as the don't store a message in the db. In order to gather the message_id and be able to do manual checks to mailgun, that's the table where we should get the message id.

cc @Tecnativa TT40816

please review @victoralmau @pedrobaeza 
