### PR TITLE
[13.0][FIX] mail_tracking: failed message compute performance

### DIFF
--- a/mail_tracking/models/mail_message.py
+++ b/mail_tracking/models/mail_message.py
@@ -20,6 +20,7 @@ class MailMessage(models.Model):
     mail_tracking_ids = fields.One2many(
         comodel_name="mail.tracking.email",
         inverse_name="mail_message_id",
+        auto_join=True,
         string="Mail Trackings",
     )
     mail_tracking_needs_action = fields.Boolean(

--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -158,10 +158,16 @@ class MailTrackingEmail(models.Model):
         if not msg_linked:
             return []
         ids, msg_ids, mail_ids, partner_ids = zip(*msg_linked)
-        # Filter messages with their ACL rules
-        msg_ids = self.env["mail.message"]._search([("id", "in", msg_ids)])
-        mail_ids = self.env["mail.mail"]._search([("id", "in", mail_ids)])
-        partner_ids = self.env["res.partner"]._search([("id", "in", partner_ids)])
+        # Filter messages with their ACL rules avoiding False values fetched in the set
+        msg_ids = self.env["mail.message"]._search(
+            [("id", "in", [x for x in msg_ids if x])]
+        )
+        mail_ids = self.env["mail.mail"]._search(
+            [("id", "in", [x for x in mail_ids if x])]
+        )
+        partner_ids = self.env["res.partner"]._search(
+            [("id", "in", [x for x in partner_ids if x])]
+        )
         return [
             x[0]
             for x in msg_linked


### PR DESCRIPTION
The failed messages computation relies on a dotted notation search on the message mail_tracking_ids. This causes a really bad performance in almost any model with a mail.thread. It's a good use case for auto_join.

Customer database example of worst case scenario performance before:
![image](https://user-images.githubusercontent.com/5040182/215463327-369c9905-48b9-4eb8-9c91-483bd2d5ae72.png)

Performance after the patch:
![image](https://user-images.githubusercontent.com/5040182/215463365-b17205b7-d267-46a4-99b2-b793b0f1295d.png)

cc @Tecnativa TT41397

please review @carlosdauden @pedrobaeza 