### PR TITLE
[15.0] [IMP] `mail_activity_team`: Allow to set a team on server actions

### DIFF
--- a/mail_activity_team/__manifest__.py
+++ b/mail_activity_team/__manifest__.py
@@ -15,6 +15,7 @@
     "data": [
         "security/ir.model.access.csv",
         "security/mail_activity_team_security.xml",
+        "views/ir_actions_server_views.xml",
         "views/mail_activity_type.xml",
         "views/mail_activity_team_views.xml",
         "views/mail_activity_views.xml",

--- a/mail_activity_team/models/__init__.py
+++ b/mail_activity_team/models/__init__.py
@@ -1,3 +1,4 @@
+from . import ir_actions_server
 from . import mail_activity_team
 from . import mail_activity
 from . import mail_activity_mixin

--- a/mail_activity_team/models/ir_actions_server.py
+++ b/mail_activity_team/models/ir_actions_server.py
@@ -1,0 +1,20 @@
+# Copyright 2023 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class IrActionsServer(models.Model):
+    _inherit = "ir.actions.server"
+
+    activity_team_id = fields.Many2one(
+        "mail.activity.team",
+        string="Activity Team",
+    )
+
+    def _run_action_next_activity(self, eval_context=None):
+        # OVERRIDE to force the activity team on scheduled actions
+        if self.activity_user_type == "specific" and self.activity_team_id:
+            self = self.with_context(force_activity_team=self.activity_team_id)
+        return super()._run_action_next_activity(eval_context=eval_context)

--- a/mail_activity_team/models/mail_activity_mixin.py
+++ b/mail_activity_team/models/mail_activity_mixin.py
@@ -46,6 +46,8 @@ class MailActivityMixin(models.AbstractModel):
         user-team missmatch. We can hook onto `act_values` dict as it's passed
         to the create activity method.
         """
+        if self.env.context.get("force_activity_team"):
+            act_values["team_id"] = self.env.context["force_activity_team"].id
         if "team_id" not in act_values:
             if act_type_xmlid:
                 activity_type = self.sudo().env.ref(act_type_xmlid)

--- a/mail_activity_team/views/ir_actions_server_views.xml
+++ b/mail_activity_team/views/ir_actions_server_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2023 Camptocamp SA (https://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="view_server_action_form_template" model="ir.ui.view">
+        <field name="model">ir.actions.server</field>
+        <field name="inherit_id" ref="mail.view_server_action_form_template" />
+        <field name="arch" type="xml">
+            <field name="activity_user_id" position="after">
+                <field
+                    name="activity_team_id"
+                    attrs="{'invisible': [('activity_user_type', '!=', 'specific')]}"
+                />
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1914185/215575201-bae1e4e9-668c-40b6-a94e-37ddbea9a346.png)

This PR let you force a team (different than the user's default one) when configuring activities through server actions

----
+bonus: Use `setUpClass` instead of `setUp` during tests


