### PR TITLE
[15.0][FIX] mail_activity_team: warning Two fields have same label

### DIFF
--- a/mail_activity_team/models/mail_activity.py
+++ b/mail_activity_team/models/mail_activity.py
@@ -20,8 +20,10 @@ class MailActivity(models.Model):
             )
         return self.env["mail.activity.team"].search(domain, limit=1)
 
-    user_id = fields.Many2one(required=False)
-    team_user_id = fields.Many2one(related="user_id", readonly=False)
+    user_id = fields.Many2one(string="User", required=False)
+    team_user_id = fields.Many2one(
+        string="Team user", related="user_id", readonly=False
+    )
 
     team_id = fields.Many2one(
         comodel_name="mail.activity.team", default=lambda s: s._get_default_team_id()


### PR DESCRIPTION
Test case failed from **microsoft_outlook_single_tenant** module