### PR TITLE
[14.0] Deprecate microsoft_outlook_single_tenant

### DIFF
--- a/microsoft_outlook_single_tenant/__init__.py
+++ b/microsoft_outlook_single_tenant/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import hooks

--- a/microsoft_outlook_single_tenant/__manifest__.py
+++ b/microsoft_outlook_single_tenant/__manifest__.py
@@ -1,7 +1,7 @@
 # Copyright 2022 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 {
-    "name": "Microsoft Outlook Single Tenant",
+    "name": "Microsoft Outlook Single Tenant (DEPRECATED)",
     "version": "14.0.1.0.0",
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/microsoft_outlook_single_tenant/hooks.py
+++ b/microsoft_outlook_single_tenant/hooks.py
@@ -1,0 +1,19 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def deprecate():
+    _logger.warning(
+        """
+        `microsoft_outlook_single_tenant` is deprecated.
+        Configure microsoft_outlook.endpoint ir.config_parameter
+        """
+    )
+
+
+def post_load_hook():
+    deprecate()

--- a/microsoft_outlook_single_tenant/tests/test_fetchmail_outlook.py
+++ b/microsoft_outlook_single_tenant/tests/test_fetchmail_outlook.py
@@ -30,6 +30,10 @@ class TestFetchMailServerMicrosoftOutlook(SavepointCase):
         self.assertIn(common_endpoint, mail_server.microsoft_outlook_uri)
 
     def test_single_tenant_app_endpoint(self):
+        self.env["ir.config_parameter"].sudo().set_param(
+            "microsoft_outlook.endpoint",
+            "https://login.microsoftonline.com/test_directory_tenant_id/oauth2/v2.0/",
+        )
         self.env["res.config.settings"].create(
             {
                 "microsoft_outlook_client_identifier": "test_client_id",


### PR DESCRIPTION
Odoo added the possibility to customize Microsoft authentication endpoint. Therefore this module is not needed anymore.

Related with https://github.com/OCA/social/issues/1061

