### PR TITLE
[IMP] We should always have aliases in tracking

### DIFF
--- a/mail_tracking/models/mail_thread.py
+++ b/mail_tracking/models/mail_thread.py
@@ -75,9 +75,10 @@ class MailThread(models.AbstractModel):
                     )
             else:
                 partner = ResPartnerObj.browse(partner_id)
-                self._message_add_suggested_recipient(
-                    suggestions, partner=partner, reason=reason
-                )
+                if partner.email not in aliases:
+                    self._message_add_suggested_recipient(
+                        suggestions, partner=partner, reason=reason
+                    )
 
     @api.model
     def _fields_view_get(


### PR DESCRIPTION
When receiving an email the user should know if the alias is the mail recipient or is a Cc

Use case :

setup an alias (ie [info@domain.com](mailto:info@domain.com)) to an object
1- send an email to [info@domain.com](mailto:info@domain.com) and cc someone else
2- send an email to someone else and cc [info@domain.com](mailto:info@domain.com)
In the chatter, we want to include the alias to know if the alias was was email_to or email_cc because the user has not the same priority to answer (if the alias is email_to --> the user must reply, if the alias is email_cc --> the user has no action)

Here are screenshots after this PR (alias is setup with crm.team)
![Test_email_to_alias](https://user-images.githubusercontent.com/7600872/217375144-6531e6fb-67b3-4280-8fb2-6045c3e30f4c.png)
![Test_email_cc_alias](https://user-images.githubusercontent.com/7600872/217405790-6fb75e17-ee0d-442d-a431-0059849d1af0.png)
