### PR TITLE
[ADD] mass_mailing_list_sql: Integrate SQL queries for partner selection in mailing lists

### DIFF
--- a/mass_mailing_list_sql/__init__.py
+++ b/mass_mailing_list_sql/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import tests

--- a/mass_mailing_list_sql/__manifest__.py
+++ b/mass_mailing_list_sql/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2023 ForgeFlow, S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "Mass Mailing List SQL",
+    "category": "Marketing",
+    "summary": "Mass mailing lists that get autopopulated, rules defined in SQL",
+    "version": "14.0.1.0.0",
+    "author": "ForgeFlow S.L., Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/social",
+    "depends": ["mass_mailing_list_dynamic", "sql_request_abstract"],
+    "data": ["views/mailing_list_views.xml"],
+    "installable": True,
+    "auto_install": False,
+    "license": "AGPL-3",
+}

--- a/mass_mailing_list_sql/models/__init__.py
+++ b/mass_mailing_list_sql/models/__init__.py
@@ -1,0 +1,1 @@
+from . import mailing_list

--- a/mass_mailing_list_sql/models/mailing_list.py
+++ b/mass_mailing_list_sql/models/mailing_list.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2023 ForgeFlow, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class MassMailingList(models.Model):
+    _name = "mailing.list"
+    _inherit = ["mailing.list", "sql.request.mixin"]
+
+    sql_search = fields.Boolean(
+        string="Use SQL Search",
+        help="Enable this option to define an SQL query for "
+        "selecting partners in the mailing list.",
+    )
+
+    def action_sync(self):
+        if self.dynamic:
+            super().action_sync()
+        if self.sql_search and self.query:
+            # Synchronize mailing list contacts based on the SQL query
+            mailing_lists = self.filtered("sql_search").with_context(syncing=True)
+            for mailing_list in mailing_lists:
+                mailing_list.button_validate_sql_expression()
+                if mailing_lists.state == "sql_valid":
+                    sync_query = mailing_lists.query
+                    self.env.cr.execute(sync_query)
+                    desired_partners = self.env["res.partner"].browse(
+                        [r[0] for r in self.env.cr.fetchall()]
+                    )
+                    if mailing_list.sync_method == "full":
+                        contact_to_detach = mailing_list.contact_ids.filtered(
+                            lambda r: r.partner_id not in desired_partners
+                        )
+                        mailing_list.contact_ids -= contact_to_detach
+                        contact_to_detach.filtered(lambda r: not r.list_ids).unlink()
+                    current_partners = mailing_list.contact_ids.mapped("partner_id")
+                    contact_to_list = self.env["mailing.contact"]
+                    vals_list = []
+                    for partner in desired_partners - current_partners:
+                        contacts_in_partner = partner.mass_mailing_contact_ids
+                        if contacts_in_partner:
+                            contact_to_list |= contacts_in_partner[0]
+                        else:
+                            vals_list.append(
+                                {
+                                    "list_ids": [(4, mailing_list.id)],
+                                    "partner_id": partner.id,
+                                }
+                            )
+                    mailing_list.contact_ids |= contact_to_list
+                    self.env["mailing.contact"].with_context(syncing=True).create(
+                        vals_list
+                    )
+                    mailing_list.is_synced = True
+                self.invalidate_cache(["contact_nbr"], mailing_lists.ids)
+
+    @api.onchange("sql_search", "sync_method", "query")
+    def _onchange_dynamic(self):
+        if self.sql_search:
+            self.is_synced = False
+
+    @api.onchange("query")
+    def _onchange_query(self):
+        if self.sql_search:
+            self.button_validate_sql_expression()

--- a/mass_mailing_list_sql/readme/CONTRIBUTORS.rst
+++ b/mass_mailing_list_sql/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Joan Sisquella <joan.sisquella@forgeflow.com>

--- a/mass_mailing_list_sql/readme/DESCRIPTION.rst
+++ b/mass_mailing_list_sql/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+The `mass_mailing_sql` module enhances Odoo's mass mailing functionality by allowing users to define an SQL query for selecting partners to be included in the mailing list.

--- a/mass_mailing_list_sql/readme/USAGE.rst
+++ b/mass_mailing_list_sql/readme/USAGE.rst
@@ -1,0 +1,5 @@
+1. Install the `mass_mailing_sql` module.
+2. Navigate to the mailing list form view.
+3. Enable the "Use SQL Search" option to define an SQL query for selecting partners in the mailing list.
+4. Write the SQL query in the "Query" field.
+5. Save the form, and the contacts will be synchronized based on the SQL query.

--- a/mass_mailing_list_sql/tests/__init__.py
+++ b/mass_mailing_list_sql/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sql_list

--- a/mass_mailing_list_sql/tests/test_sql_list.py
+++ b/mass_mailing_list_sql/tests/test_sql_list.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2023 ForgeFlow, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo.tests import common
+
+
+class TestMassMailingSql(common.SavepointCase):
+    post_install = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.tag = cls.env["res.partner.category"].create({"name": "testing tag"})
+        cls.partners = cls.env["res.partner"]
+        for number in range(5):
+            cls.partners |= cls.partners.create(
+                {
+                    "name": "partner %d" % number,
+                    "email": "%d@example.com" % number,
+                    "country_id": 1,
+                }
+            )
+        for number in range(6, 9):
+            cls.partners |= cls.partners.create(
+                {
+                    "name": "partner %d" % number,
+                    "email": "%d@example.com" % number,
+                    "country_id": 2,
+                }
+            )
+
+        cls.Partner = cls.env["res.partner"]
+        cls.partner_in = cls.Partner.create(
+            {
+                "name": "Partner in",
+                "email": "partner.in@example.com",
+            }
+        )
+        cls.partner_out = cls.Partner.create(
+            {
+                "name": "Partner out",
+                "email": "partner.out@example.com",
+            }
+        )
+
+        cls.list = cls.env["mailing.list"].create(
+            {
+                "name": "test list",
+                "sql_search": True,
+                "query": "SELECT * FROM res_partner WHERE country_id = 1",
+                "sync_method": "full",
+            }
+        )
+
+    def test_mass_mailing_sql_1(self):
+        """sql_search method returns correct partners."""
+        self.list.flush()
+        self.list.action_sync()
+        self.list.flush()
+        self.assertEqual(self.list.contact_nbr, 5)
+        self.list.query = "SELECT * FROM res_partner WHERE country_id = 2"
+        self.list.action_sync()
+        self.list.flush()
+        self.assertEqual(self.list.contact_nbr, 3)
+        self.list.query = "SELECT * FROM res_partner WHERE country_id in (1,2)"
+        self.list.action_sync()
+        self.list.flush()
+        self.assertEqual(self.list.contact_nbr, 8)
+
+    def test_mass_mailing_sql_2(self):
+        # Test sync_method and onchange methods
+        self.list.write(
+            {
+                "sync_method": "full",
+                "query": "SELECT id FROM res_partner WHERE email = 'partner.in@example.com'",
+            }
+        )
+
+        self.list._onchange_dynamic()
+        self.assertFalse(self.list.is_synced)
+
+        self.list._onchange_query()
+        self.list.button_validate_sql_expression()
+
+        self.list.action_sync()
+        self.assertIn(self.partner_in, self.list.contact_ids.mapped("partner_id"))
+        self.assertNotIn(self.partner_out, self.list.contact_ids.mapped("partner_id"))

--- a/mass_mailing_list_sql/views/mailing_list_views.xml
+++ b/mass_mailing_list_sql/views/mailing_list_views.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright (C) 2023 ForgeFlow, S.L.
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="mailing_list_view_form_sql" model="ir.ui.view">
+        <field name="name">Add sql query</field>
+        <field name="model">mailing.list</field>
+        <field name="inherit_id" ref="mass_mailing.mailing_list_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='dynamic']" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible':[('sql_search', '=', True)]}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='dynamic']" position="after">
+                <field
+                    name="sql_search"
+                    attrs="{'invisible': [('dynamic', '=', True)]}"
+                />
+                <field
+                    name="query"
+                    widget="ace"
+                    attrs="{'invisible': [('sql_search', '=', False)]}"
+                />
+            </xpath>
+            <xpath expr="//label[@for='sync_method']/.." position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible':[('dynamic', '=', False),('sql_search', '=', False)]}</attribute>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/mass_mailing_list_sql/odoo/addons/mass_mailing_list_sql
+++ b/setup/mass_mailing_list_sql/odoo/addons/mass_mailing_list_sql
@@ -1,0 +1,1 @@
+../../../../mass_mailing_list_sql

--- a/setup/mass_mailing_list_sql/setup.py
+++ b/setup/mass_mailing_list_sql/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
The module allows users to define an SQL query for selecting partners to be included in the mailing list, providing greater flexibility in targeting recipients with complex criteria. 

By integrating this module, users can create more refined and targeted mailing lists, ultimately improving their email marketing strategies.

@JordiBForgeFlow @ForgeFlow