### PR TITLE
[ADD] mail_template_default Module allows to set default mail template in composer base on rules

### DIFF
--- a/mail_template_default/__init__.py
+++ b/mail_template_default/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2023 Solvti sp. z o.o. (https://solvti.pl)
+
+from . import models
+from . import wizard

--- a/mail_template_default/__manifest__.py
+++ b/mail_template_default/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2023 Solvti sp. z o.o. (https://solvti.pl)
+
+{
+    "name": "Mail Template Default",
+    "summary": "Create rules to apply default mail template in composer",
+    "version": "15.0.1.0.0",
+    "category": "Social Network",
+    "author": "Solvti, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": ["mail"],
+    "website": "https://github.com/OCA/social",
+    "data": [
+        "security/ir.model.access.csv",
+        "views/mail_template_rule_views.xml",
+    ],
+}

--- a/mail_template_default/models/__init__.py
+++ b/mail_template_default/models/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2023 Solvti sp. z o.o. (https://solvti.pl)
+
+from . import mail_template_rule

--- a/mail_template_default/models/mail_template_rule.py
+++ b/mail_template_default/models/mail_template_rule.py
@@ -30,7 +30,7 @@ class MailTemplateRule(models.Model):
         for rec in self:
             # if the domain translates to False we want to get rid of default "[]"
             # to get the right ordering of the rules
-            if not safe_eval(rec.field_domain):
+            if not safe_eval(str(rec.field_domain)):
                 rec.field_domain = False
 
     @api.constrains("template_id", "model_id")

--- a/mail_template_default/models/mail_template_rule.py
+++ b/mail_template_default/models/mail_template_rule.py
@@ -1,0 +1,47 @@
+# Copyright 2023 Solvti sp. z o.o. (https://solvti.pl)
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+from odoo.tools.safe_eval import safe_eval
+
+
+class MailTemplateRule(models.Model):
+    _name = "mail.template.rule"
+    _description = "Mail Template Rule"
+
+    name = fields.Char()
+    model_id = fields.Many2one("ir.model", required=True, ondelete="cascade")
+    model_name = fields.Char(
+        related="model_id.model",
+        string="Model Name",
+        help="Technical relation required by field_domain",
+    )
+    company_id = fields.Many2one("res.company", default=lambda self: self.env.company)
+    template_id = fields.Many2one(
+        "mail.template", required=True, domain="[('model_id', '=', model_id)]"
+    )
+    field_domain = fields.Char(string="Field Expression")
+    active = fields.Boolean(default=True)
+    sequence = fields.Integer(default=10)
+    context_flag = fields.Char()
+
+    @api.onchange("field_domain")
+    def onchange_field_domain(self):
+        for rec in self:
+            # if the domain translates to False we want to get rid of default "[]"
+            # to get the right ordering of the rules
+            if not safe_eval(rec.field_domain):
+                rec.field_domain = False
+
+    @api.constrains("template_id", "model_id")
+    def check_template_company(self):
+        for rec in self:
+            if rec.template_id.model_id != rec.model_id:
+                raise ValidationError(
+                    _("The Model of email template is differend then rule Model!")
+                )
+
+    @api.onchange("model_id")
+    def onchange_model_id(self):
+        for rec in self:
+            rec.template_id = rec.field_domain = False

--- a/mail_template_default/readme/CONFIGURE.rst
+++ b/mail_template_default/readme/CONFIGURE.rst
@@ -1,0 +1,12 @@
+To create new rule:
+
+#. Go to *Mail Template Rule*, Settings > Technical
+#. Create new rule:
+
+   - **Name** - Name of your rule
+   - **Model** - Model to which rule applies, and domain filter for *mail template*
+   - **Template** - Mail Template that will apply for that rule
+   - **Context Flag** - Context value that can be used with a specific key *force_mail_template*
+   - **Company** - If model has *company_id* field, the rule will only apply to objects from the selected company
+   - **Field Expression** - Specific domain that must be met on the object on which the composer is triggered in order for the rule to be applied
+   - **Sequence** - Specifies the order of the rules

--- a/mail_template_default/readme/CONTRIBUTORS.rst
+++ b/mail_template_default/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Solvti <https://www.solvti.pl>`_:
+
+  * Jakub Wiselka

--- a/mail_template_default/readme/DESCRIPTION.rst
+++ b/mail_template_default/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module lets you create rules that define the default mail template used in composer.

--- a/mail_template_default/readme/USAGE.rst
+++ b/mail_template_default/readme/USAGE.rst
@@ -1,0 +1,49 @@
+To use this module, you need to first create **Mail Template Rules**
+
+| Rules are executed in a specific order based on the amount of information entered into the rule.
+| The first rule to meet all the conditions is taken
+| Mail Template Rules are sorted base on 4 fields in following hierarchy:
+| Context Flag -> Company -> Filter -> Sequence
+|
+|
+
+.. list-table:: The table shows hypothetical order of rules
+   :widths: 20 20 20 20
+   :header-rows: 1
+
+   * - Context Flag
+     - Company
+     - Filter
+     - Sequence
+   * - x
+     - x
+     - x
+     - 1
+   * - x
+     - x
+     - x
+     - 2
+   * - x
+     -
+     -
+     - 2
+   * -
+     - x
+     - x
+     - 1
+   * -
+     - x
+     -
+     - 1
+   * -
+     -
+     - x
+     - 2
+   * -
+     -
+     - x
+     - 3
+   * -
+     -
+     -
+     - 1

--- a/mail_template_default/security/ir.model.access.csv
+++ b/mail_template_default/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_mail_template_rule_user,access_mail_template_rule_user,model_mail_template_rule,base.group_user,1,0,0,0
+access_mail_template_rule_admin,access_mail_template_rule_admin,model_mail_template_rule,base.group_system,1,1,1,1

--- a/mail_template_default/tests/__init__.py
+++ b/mail_template_default/tests/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2023 Solvti sp. z o.o. (https://solvti.pl)
+
+from . import test_mail_default_template

--- a/mail_template_default/tests/test_mail_default_template.py
+++ b/mail_template_default/tests/test_mail_default_template.py
@@ -1,0 +1,94 @@
+# Copyright 2023 Solvti sp. z o.o. (https://solvti.pl)
+
+from odoo.tests import TransactionCase
+
+
+class TestMailDefaultTemplateRule(TransactionCase):
+    def setUp(self):
+        super(TestMailDefaultTemplateRule, self).setUp()
+        self.context = {
+            "default_model": "res.users",
+            "default_res_id": self.env.ref("base.user_admin").id,
+        }
+        self.rule_id = self.env["mail.template.rule"].create(
+            {
+                "name": "Rule Default",
+                "model_id": self.env["ir.model"]
+                .search([("model", "=", "res.users")])
+                .id,
+                "template_id": self.env.ref("auth_signup.reset_password_email").id,
+            }
+        )
+
+    def test_context_flag_and_sequence_order(self):
+        rule2 = self.rule_id.copy(
+            {"template_id": self.env.ref("auth_signup.set_password_email").id}
+        )
+        rule2.write({"context_flag": "set_password", "sequence": 0})
+        # context force_mail_template = set_password
+        composer_id = (
+            self.env["mail.compose.message"]
+            .with_context(**{**self.context, "force_mail_template": "set_password"})
+            .create({})
+        )
+        self.assertEqual(composer_id.template_id, rule2.template_id)
+
+        # context force_mail_template = False
+        composer_id = (
+            self.env["mail.compose.message"]
+            .with_context(**{**self.context, "force_mail_template": False})
+            .create({})
+        )
+        self.assertFalse(composer_id.template_id)
+
+        # context None
+        composer_id = (
+            self.env["mail.compose.message"].with_context(**self.context).create({})
+        )
+        self.assertEqual(composer_id.template_id, self.rule_id.template_id)
+
+    def test_field_domain(self):
+        self.rule_id.write({"field_domain": "[['login','=','admin']]"})
+
+        composer_id = (
+            self.env["mail.compose.message"].with_context(**self.context).create({})
+        )
+        self.assertEqual(composer_id.template_id, self.rule_id.template_id)
+
+        composer_id = (
+            self.env["mail.compose.message"]
+            .with_context(
+                **{**self.context, "default_res_id": self.env.ref("base.user_demo").id}
+            )
+            .create({})
+        )
+        self.assertFalse(composer_id.template_id)
+
+    def test_company(self):
+        company2 = self.env["res.company"].create({"name": "company 2"})
+        user2 = (
+            self.env["res.users"]
+            .with_company(company2.id)
+            .create(
+                {
+                    "name": "user2",
+                    "login": "user2",
+                }
+            )
+        )
+        rule2 = self.rule_id.copy(
+            {"template_id": self.env.ref("auth_signup.set_password_email").id}
+        )
+        rule2.write({"company_id": company2.id})
+
+        composer_id = (
+            self.env["mail.compose.message"].with_context(**self.context).create({})
+        )
+        self.assertEqual(composer_id.template_id, self.rule_id.template_id)
+
+        composer_id = (
+            self.env["mail.compose.message"]
+            .with_context(**{**self.context, "default_res_id": user2.id})
+            .create({})
+        )
+        self.assertEqual(composer_id.template_id, rule2.template_id)

--- a/mail_template_default/tests/test_mail_default_template.py
+++ b/mail_template_default/tests/test_mail_default_template.py
@@ -22,9 +22,13 @@ class TestMailDefaultTemplateRule(TransactionCase):
 
     def test_context_flag_and_sequence_order(self):
         rule2 = self.rule_id.copy(
-            {"template_id": self.env.ref("auth_signup.set_password_email").id}
+            {
+                "template_id": self.env.ref("auth_signup.set_password_email").id,
+                "context_flag": "set_password",
+                "sequence": 0,
+            }
         )
-        rule2.write({"context_flag": "set_password", "sequence": 0})
+
         # context force_mail_template = set_password
         composer_id = (
             self.env["mail.compose.message"]
@@ -92,3 +96,116 @@ class TestMailDefaultTemplateRule(TransactionCase):
             .create({})
         )
         self.assertEqual(composer_id.template_id, rule2.template_id)
+
+    def test_sequence(self):
+        cmp = self.env.ref("base.main_company")
+        tmpl = self.env.ref("auth_signup.set_password_email")
+        company2 = self.env["res.company"].create({"name": "company 2"})
+        user2 = (
+            self.env["res.users"]
+            .with_company(company2.id)
+            .create(
+                {
+                    "name": "user2",
+                    "login": "user2",
+                }
+            )
+        )
+        user3 = user2.copy({"name": "user3", "login": "user3"})
+
+        t1, t2, t3, t4, t5, t6, t7, t8 = [
+            tmpl.copy({"body_html": f"template{x + 1}"}) for x in range(8)
+        ]
+
+        rule8 = self.rule_id.copy(
+            {"template_id": t8.id, "company_id": False, "sequence": 1}
+        )
+        rule7 = self.rule_id.copy(
+            {
+                "template_id": t7.id,
+                "company_id": False,
+                "field_domain": "[['login','=','user2']]",
+                "sequence": 3,
+            }
+        )
+        self.rule_id.copy(
+            {
+                "template_id": t6.id,
+                "company_id": False,
+                "field_domain": "[['login','=','admin']]",
+                "sequence": 2,
+            }
+        )
+        rule5 = self.rule_id.copy(
+            {"template_id": t5.id, "company_id": cmp.id, "sequence": 1}
+        )
+        rule4 = self.rule_id.copy(
+            {
+                "template_id": t4.id,
+                "company_id": cmp.id,
+                "field_domain": "[['login','=','admin']]",
+                "sequence": 1,
+            }
+        )
+        self.rule_id.copy(
+            {
+                "template_id": t3.id,
+                "context_flag": "set_password",
+                "company_id": False,
+                "sequence": 2,
+            }
+        )
+        self.rule_id.copy(
+            {
+                "template_id": t2.id,
+                "context_flag": "set_password",
+                "company_id": cmp.id,
+                "field_domain": "[['login','=','admin']]",
+                "sequence": 2,
+            }
+        )
+        rule1 = self.rule_id.copy(
+            {
+                "template_id": t1.id,
+                "context_flag": "set_password",
+                "company_id": cmp.id,
+                "field_domain": "[['login','=','admin']]",
+                "sequence": 1,
+            }
+        )
+
+        # check order of rules base on different criteria
+        composer_id = (
+            self.env["mail.compose.message"]
+            .with_context(**{**self.context, "force_mail_template": "set_password"})
+            .create({})
+        )
+        self.assertEqual(composer_id.template_id.body_html, rule1.template_id.body_html)
+
+        composer_id = (
+            self.env["mail.compose.message"].with_context(**self.context).create({})
+        )
+        self.assertEqual(composer_id.template_id.body_html, rule4.template_id.body_html)
+
+        composer_id = (
+            self.env["mail.compose.message"]
+            .with_context(
+                **{**self.context, "default_res_id": self.env.ref("base.user_demo").id}
+            )
+            .create({})
+        )
+        self.assertEqual(composer_id.template_id.body_html, rule5.template_id.body_html)
+
+        composer_id = (
+            self.env["mail.compose.message"]
+            .with_context(**{**self.context, "default_res_id": user2.id})
+            .create({})
+        )
+        self.assertEqual(composer_id.template_id.body_html, rule7.template_id.body_html)
+
+        composer_id = (
+            self.env["mail.compose.message"]
+            .with_context(**{**self.context, "default_res_id": user3.id})
+            .create({})
+        )
+        self.assertEqual(composer_id.template_id.body_html, rule8.template_id.body_html)

--- a/mail_template_default/views/mail_template_rule_views.xml
+++ b/mail_template_default/views/mail_template_rule_views.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2023 Solvti sp. z o.o. (https://solvti.pl) -->
+<odoo>
+    <record id="mail_template_rule_form" model="ir.ui.view">
+        <field name="name">Mail Template Rule Form</field>
+        <field name="model">mail.template.rule</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" />
+                        </h1>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="model_id" />
+                            <field name="model_name" invisible="1" />
+                            <field name="template_id" />
+                            <field name="context_flag" />
+                            <field name="company_id" />
+                            <field
+                                name="field_domain"
+                                widget="domain"
+                                options="{'model': 'model_name', 'in_dialog': True}"
+                                context="{'skip_search_count': 1}"
+                            />
+                            <field name="sequence" />
+                        </group>
+                        <group>
+                            <div class="text-muted">
+                                Description of the rule flow
+                                <ul>
+                                    <li
+                                    >Rules are executed in a specific order based on the amount of information entered into the rule.</li>
+                                    <li
+                                    >The first rule to meet all the conditions is taken.</li>
+                                    <li
+                                    >Mail Template Rules are sorted base on 4 fields in following hierarchy:</li>
+                                    <b>Context Flag → Company → Filter → Sequence</b>
+                                    <li><i
+                                        >The order is determined by sequence only if two or more rules have the same amount of filled fields.</i></li>
+                                </ul>
+                            </div>
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record id="mail_template_rule_tree" model="ir.ui.view">
+        <field name="name">Mail Template Rule Tree</field>
+        <field name="model">mail.template.rule</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="sequence" widget="handle" />
+                <field name="name" />
+                <field name="model_id" />
+                <field name="template_id" />
+                <field name="context_flag" />
+                <field name="company_id" />
+                <field name="field_domain" />
+            </tree>
+        </field>
+    </record>
+    <record id="mail_template_rule_search" model="ir.ui.view">
+        <field name="name">Mail Template Rule search</field>
+        <field name="model">mail.template.rule</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name" />
+                <field name="model_id" />
+                <field name="template_id" />
+                <field name="context_flag" />
+                <separator />
+                <filter
+                    string="Archived"
+                    name="inactive"
+                    domain="[('active', '=', False)]"
+                />
+                <group>
+                    <filter
+                        string="Model"
+                        name="group_by_model"
+                        domain="[]"
+                        context="{'group_by':'model_id'}"
+                    />
+                    <filter
+                        string="Company"
+                        name="group_by_company"
+                        domain="[]"
+                        context="{'group_by': 'company_id'}"
+                    />
+                    <filter
+                        string="Template"
+                        name="group_by_context"
+                        domain="[]"
+                        context="{'group_by': 'template_id'}"
+                    />
+                    <filter
+                        string="Context"
+                        name="group_by_context"
+                        domain="[]"
+                        context="{'group_by': 'context_flag'}"
+                    />
+                </group>
+            </search>
+        </field>
+    </record>
+    <record id="action_mail_template_rule" model="ir.actions.act_window">
+        <field name="name">Mail Template Rule</field>
+        <field name="res_model">mail.template.rule</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+    <menuitem
+        id="menu_mail_template_rule"
+        name="Mail Template Rule"
+        parent="base.menu_email"
+        action="action_mail_template_rule"
+    />
+</odoo>

--- a/mail_template_default/wizard/__init__.py
+++ b/mail_template_default/wizard/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2023 Solvti sp. z o.o. (https://solvti.pl)
+
+from . import mail_compose_message

--- a/mail_template_default/wizard/mail_compose_message.py
+++ b/mail_template_default/wizard/mail_compose_message.py
@@ -1,0 +1,80 @@
+# Copyright 2023 Solvti sp. z o.o. (https://solvti.pl)
+
+from odoo import api, models
+from odoo.tools.safe_eval import safe_eval
+
+
+class MailComposer(models.TransientModel):
+    _inherit = "mail.compose.message"
+
+    @api.model
+    def default_get(self, fields):
+        """Mail Template Rules are sorted base on 4 fields in following hierarchy:
+        bool(context_flag) -> bool(company_id) -> bool(field_domain) -> sequence
+        The table show hypothetically order:
+
+        +---------+---------+--------+-----+
+        | context | company | domain | seq |
+        +---------+---------+--------+-----+
+        |    x    |    x    |   x    |  1  |
+        |    x    |    x    |   x    |  2  |
+        |    x    |         |        |  2  |
+        |         |    x    |   x    |  1  |
+        |         |    x    |        |  1  |
+        |         |         |   x    |  2  |
+        |         |         |   x    |  3  |
+        |         |         |        |  1  |
+        """
+
+        res = super(MailComposer, self).default_get(fields)
+
+        res_model = self._context.get("active_model") or self._context.get(
+            "default_model"
+        )
+        res_id = self._context.get("active_id") or self._context.get("default_res_id")
+        force_mt = self._context.get("force_mail_template")
+        domain = []
+        if not res_model or not res_id or force_mt is False:
+            return res
+        elif force_mt:
+            domain += [
+                "|",
+                ("context_flag", "=", False),
+                ("context_flag", "=", force_mt),
+            ]
+        else:
+            # if force_mail_template is None we want to get rid of all rules with context_flag
+            domain += [("context_flag", "=", False)]
+
+        rec = self.env[res_model].sudo().browse(res_id)
+
+        if hasattr(rec, "company_id"):
+            domain += [
+                "|",
+                ("company_id", "=", False),
+                ("company_id", "=", rec.company_id.id),
+            ]
+
+        rule_ids = self.env["mail.template.rule"].search(
+            [("model_id.model", "=", rec._name)] + domain
+        )
+        rule_ids = rule_ids.sorted(
+            lambda x: (
+                not bool(x.context_flag),
+                not bool(x.company_id),
+                not bool(x.field_domain),
+                x.sequence,
+            )
+        )
+
+        for rule in rule_ids:
+            if rule.field_domain:
+                if rec.search_count(
+                    [("id", "=", rec.id)] + safe_eval(rule.field_domain)
+                ):
+                    res["template_id"] = rule.template_id.id
+                    break
+            else:
+                res["template_id"] = rule.template_id.id
+                break
+        return res

--- a/setup/mail_template_default/odoo/addons/mail_template_default
+++ b/setup/mail_template_default/odoo/addons/mail_template_default
@@ -1,0 +1,1 @@
+../../../../mail_template_default

--- a/setup/mail_template_default/setup.py
+++ b/setup/mail_template_default/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Module that allows you to create rules base on which the specific template will be applied to mail composer.

Rules are executed in a specific order based on the amount of information entered into the rule.
The first rule to meet all the conditions is taken
Mail Template Rules are sorted base on 4 fields in the following hierarchy:
Context Flag -> Company -> Filter -> Sequence