### PR TITLE
[16.0][FIX] mail_outbound_static: Move smtp info update logic to _prepare_email_message()

### DIFF
--- a/mail_outbound_static/README.rst
+++ b/mail_outbound_static/README.rst
@@ -91,6 +91,9 @@ Contributors
 * Pierre Pizzetta <pierre@devreaction.com>
 * Katherine Zaoral <kz@adhoc.com.ar>
 * Juan José Scarafía <jjs@adhoc.com.ar>
+* `Quartile <https://www.quartile.co>`__:
+
+  * Yoshi Tashiro
 
 Maintainers
 ~~~~~~~~~~~

--- a/mail_outbound_static/models/ir_mail_server.py
+++ b/mail_outbound_static/models/ir_mail_server.py
@@ -67,6 +67,34 @@ class IrMailServer(models.Model):
         res = [item.strip() for item in res]
         return res
 
+    def _prepare_email_message(self, message, smtp_session):
+        smtp_from, smtp_to_list, message = super()._prepare_email_message(
+            message, smtp_session
+        )
+        name_from = self._context.get("name_from")
+        email_from = self._context.get("email_from")
+        email_domain = self._context.get("email_domain")
+        mail_server = self.browse(self._context.get("mail_server_id"))
+        domain_whitelist = mail_server.domain_whitelist or tools.config.get(
+            "smtp_domain_whitelist"
+        )
+        domain_whitelist = self._get_domain_whitelist(domain_whitelist)
+        # Replace the From only if needed
+        if mail_server.smtp_from and (
+            not domain_whitelist or email_domain not in domain_whitelist
+        ):
+            email_from = formataddr((name_from, mail_server.smtp_from))
+            message.replace_header("From", email_from)
+            smtp_from = email_from
+            if not self._get_default_bounce_address():
+                # then, bounce handling is disabled and we want
+                # Return-Path = From
+                if "Return-Path" in message:
+                    message.replace_header("Return-Path", email_from)
+                else:
+                    message.add_header("Return-Path", email_from)
+        return smtp_from, smtp_to_list, message
+
     @api.model
     def send_email(
         self, message, mail_server_id=None, smtp_server=None, *args, **kwargs
@@ -78,40 +106,17 @@ class IrMailServer(models.Model):
             email_from = split_from[-1].replace(">", "")
         else:
             name_from, email_from = parseaddr(message["From"])
-
         email_domain = email_from.split("@")[1]
-
         # Replicate logic from core to get mail server
         # Get proper mail server to use
         if not smtp_server and not mail_server_id:
             mail_server_id = self._get_mail_sever(email_domain)
-
-        # If not mail sever defined use smtp_from defined in odoo config
-        if mail_server_id:
-            mail_server = self.sudo().browse(mail_server_id)
-            domain_whitelist = mail_server.domain_whitelist
-            smtp_from = mail_server.smtp_from
-        else:
-            domain_whitelist = tools.config.get("smtp_domain_whitelist")
-            smtp_from = tools.config.get("smtp_from")
-
-        domain_whitelist = self._get_domain_whitelist(domain_whitelist)
-
-        # Replace the From only if needed
-        if smtp_from and (not domain_whitelist or email_domain not in domain_whitelist):
-            email_from = formataddr((name_from, smtp_from))
-            message.replace_header("From", email_from)
-            bounce_alias = (
-                self.env["ir.config_parameter"].sudo().get_param("mail.bounce.alias")
-            )
-            if not bounce_alias:
-                # then, bounce handling is disabled and we want
-                # Return-Path = From
-                if "Return-Path" in message:
-                    message.replace_header("Return-Path", email_from)
-                else:
-                    message.add_header("Return-Path", email_from)
-
+        self = self.with_context(
+            name_from=name_from,
+            email_from=email_from,
+            email_domain=email_domain,
+            mail_server_id=mail_server_id,
+        )
         return super(IrMailServer, self).send_email(
             message, mail_server_id, smtp_server, *args, **kwargs
         )

--- a/mail_outbound_static/readme/CONTRIBUTORS.rst
+++ b/mail_outbound_static/readme/CONTRIBUTORS.rst
@@ -4,3 +4,6 @@
 * Pierre Pizzetta <pierre@devreaction.com>
 * Katherine Zaoral <kz@adhoc.com.ar>
 * Juan José Scarafía <jjs@adhoc.com.ar>
+* `Quartile <https://www.quartile.co>`__:
+
+  * Yoshi Tashiro

--- a/mail_outbound_static/static/description/index.html
+++ b/mail_outbound_static/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Mail Outbound Static</title>
 <style type="text/css">
 
@@ -439,6 +439,10 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Pierre Pizzetta &lt;<a class="reference external" href="mailto:pierre&#64;devreaction.com">pierre&#64;devreaction.com</a>&gt;</li>
 <li>Katherine Zaoral &lt;<a class="reference external" href="mailto:kz&#64;adhoc.com.ar">kz&#64;adhoc.com.ar</a>&gt;</li>
 <li>Juan José Scarafía &lt;<a class="reference external" href="mailto:jjs&#64;adhoc.com.ar">jjs&#64;adhoc.com.ar</a>&gt;</li>
+<li><a class="reference external" href="https://www.quartile.co">Quartile</a>:<ul>
+<li>Yoshi Tashiro</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Since 15.0, smtp info is prepared in _prepare_email_message() which is called from send_email(), and the smtp info manipulation should be done in this method instead of in send_email().

Forward port of https://github.com/OCA/social/pull/1051
@qrtl