### PR TITLE
[14.0][ADD] mail_activity_reply_creator

### DIFF
--- a/mail_activity_reply_creator/__init__.py
+++ b/mail_activity_reply_creator/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/mail_activity_reply_creator/__manifest__.py
+++ b/mail_activity_reply_creator/__manifest__.py
@@ -1,3 +1,5 @@
+# Copyright 2023 Ooops404
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Mail Activity Reply Creator",
     "summary": "Assign new to its creator",

--- a/mail_activity_reply_creator/__manifest__.py
+++ b/mail_activity_reply_creator/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    "name": "Mail Activity Reply Creator",
+    "summary": "Assign new to its creator",
+    "version": "14.0.1.0.0",
+    "category": "Social",
+    "website": "https://github.com/OCA/social",
+    "author": "Ilyas, Ooops, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "installable": True,
+    "depends": ["mail"],
+}

--- a/mail_activity_reply_creator/models/__init__.py
+++ b/mail_activity_reply_creator/models/__init__.py
@@ -1,0 +1,1 @@
+from . import mail_activity

--- a/mail_activity_reply_creator/models/mail_activity.py
+++ b/mail_activity_reply_creator/models/mail_activity.py
@@ -1,4 +1,4 @@
-# Copyright 2018 ForgeFlow S.L.
+# Copyright 2023 Ooops404
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import api, models
 

--- a/mail_activity_reply_creator/models/mail_activity.py
+++ b/mail_activity_reply_creator/models/mail_activity.py
@@ -1,3 +1,5 @@
+# Copyright 2018 ForgeFlow S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import api, models
 
 
@@ -7,7 +9,7 @@ class MailActivity(models.Model):
     @api.onchange("activity_type_id")
     def _onchange_activity_type_id(self):
         original_user_id = self.user_id
-        super(MailActivity, self)._onchange_activity_type_id()
+        super()._onchange_activity_type_id()
         if (
             original_user_id != self.env.user
             and not self.activity_type_id.default_user_id
@@ -17,14 +19,14 @@ class MailActivity(models.Model):
 
     def action_feedback_schedule_next(self, feedback=False):
         create_uid = self.create_uid.id
-        action = super().action_feedback_schedule_next()
+        action = super().action_feedback_schedule_next(feedback)
         action["context"]["source_activity_create_uid"] = create_uid
         return action
 
     @api.model
     def default_get(self, fields):
         res = super().default_get(fields)
-        if self._context.get("source_activity_create_uid") and not self._context.get(
+        if self._context.get("source_activity_create_uid") and not self.env.context.get(
             "no_recursion"
         ):
             default_activity_type_id = self.with_context(
@@ -35,5 +37,5 @@ class MailActivity(models.Model):
                 or not default_activity_type_id.default_user_id
             ):
                 # assign to prev. activity creator
-                res["user_id"] = self._context["source_activity_create_uid"]
+                res["user_id"] = self.env.context["source_activity_create_uid"]
         return res

--- a/mail_activity_reply_creator/models/mail_activity.py
+++ b/mail_activity_reply_creator/models/mail_activity.py
@@ -1,0 +1,39 @@
+from odoo import api, models
+
+
+class MailActivity(models.Model):
+    _inherit = "mail.activity"
+
+    @api.onchange("activity_type_id")
+    def _onchange_activity_type_id(self):
+        original_user_id = self.user_id
+        super(MailActivity, self)._onchange_activity_type_id()
+        if (
+            original_user_id != self.env.user
+            and not self.activity_type_id.default_user_id
+        ):
+            # keep already set user
+            self.user_id = original_user_id
+
+    def action_feedback_schedule_next(self, feedback=False):
+        create_uid = self.create_uid.id
+        action = super().action_feedback_schedule_next()
+        action["context"]["source_activity_create_uid"] = create_uid
+        return action
+
+    @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        if self._context.get("source_activity_create_uid") and not self._context.get(
+            "no_recursion"
+        ):
+            default_activity_type_id = self.with_context(
+                no_recursion=True
+            )._default_activity_type_id()
+            if (
+                not default_activity_type_id
+                or not default_activity_type_id.default_user_id
+            ):
+                # assign to prev. activity creator
+                res["user_id"] = self._context["source_activity_create_uid"]
+        return res

--- a/mail_activity_reply_creator/readme/CONTRIBUTORS.rst
+++ b/mail_activity_reply_creator/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* Ooops404 <https://ooops404.com>
+
+  * Ilyas <irazor147@gmail.com>

--- a/mail_activity_reply_creator/readme/DESCRIPTION.rst
+++ b/mail_activity_reply_creator/readme/DESCRIPTION.rst
@@ -1,0 +1,18 @@
+This module aims to facilitate back-and-forth activity assignment between users by
+automatically selecting activity creator as the assignee of the followup activity when
+using button "Done & schedule next". Use case:
+
+Mitchell Admin assigns activity "to do" to Marc Demo >
+Marc Demo clicks "done and schedule next" on the activity >
+in new activity form, "assigned to" is set to Mitchell Admin (unless a different default
+user is set for the selected activity type).
+
+Furthermore, the module corrects a behavior that can induce user to assigning a new
+activity to themselves instead of the previously selected user. Use case:
+
+Mitchell Admin creates a new activity, selects "Marc Demo" as "assigned to", but then
+changes activity type.
+
+In standard behavior "assigned to" is reset to "Mitchell Admin";
+with this module, the user selection is maintained when changing activity type (unless
+a different default user is set for the selected activity type).

--- a/mail_activity_reply_creator/tests/__init__.py
+++ b/mail_activity_reply_creator/tests/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_mail_activity_reply_creator

--- a/mail_activity_reply_creator/tests/test_mail_activity_reply_creator.py
+++ b/mail_activity_reply_creator/tests/test_mail_activity_reply_creator.py
@@ -1,4 +1,4 @@
-# Copyright 2018 ForgeFlow S.L.
+# Copyright 2023 Ooops404
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo.tests.common import SavepointCase
 

--- a/mail_activity_reply_creator/tests/test_mail_activity_reply_creator.py
+++ b/mail_activity_reply_creator/tests/test_mail_activity_reply_creator.py
@@ -1,0 +1,51 @@
+# Copyright 2018 ForgeFlow S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.tests.common import SavepointCase
+
+
+class TestMailActivityReplyCreator(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # disable tracking test suite wise
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.user_model = cls.env["res.users"].with_context(no_reset_password=True)
+        cls.user_admin = cls.env.ref("base.user_root")
+        cls.user_2 = cls.env["res.users"].search([])[-1]
+        cls.partner_ir_model = cls.env["ir.model"]._get("res.partner")
+        cls.partner_01 = cls.env.ref("base.res_partner_1")
+        activity_type_model = cls.env["mail.activity.type"]
+        cls.activity_type_1 = activity_type_model.create(
+            {
+                "name": "Act Type Without Default Responsible",
+                "res_model_id": cls.partner_ir_model.id,
+                "default_user_id": False,
+            }
+        )
+        cls.act1 = (
+            cls.env["mail.activity"]
+            .with_user(cls.user_2)
+            .create(
+                {
+                    "activity_type_id": cls.activity_type_1.id,
+                    "note": "Partner activity 1.",
+                    "res_id": cls.partner_01.id,
+                    "res_model_id": cls.partner_ir_model.id,
+                    "user_id": cls.user_2.id,
+                }
+            )
+        )
+
+    def test_activity_default_user(self):
+        self.act1._onchange_activity_type_id()
+        # by default user is set to current user.
+        # module keeps original activity user, if activity type has no default_user_id.
+        self.assertEqual(self.act1.user_id, self.user_2)
+
+    def test_schedule_new_activity_user(self):
+        prev_act_uid = self.act1.create_uid
+        action = self.act1.action_feedback_schedule_next()
+        new_act = self.env["mail.activity"].with_context(action["context"]).create({})
+        # by default current user will be responsible.
+        # module set responsible as prev. activity creator.
+        self.assertEqual(new_act.user_id, prev_act_uid)

--- a/setup/mail_activity_reply_creator/odoo/addons/mail_activity_reply_creator
+++ b/setup/mail_activity_reply_creator/odoo/addons/mail_activity_reply_creator
@@ -1,0 +1,1 @@
+../../../../mail_activity_reply_creator

--- a/setup/mail_activity_reply_creator/setup.py
+++ b/setup/mail_activity_reply_creator/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module aims to facilitate back-and-forth activity assignment between users by
automatically selecting activity creator as the assignee of the followup activity when
using button "Done & schedule next". Use case:

Mitchell Admin assigns activity "to do" to Marc Demo >
Marc Demo clicks "done and schedule next" on the activity >
in new activity form, "assigned to" is set to Mitchell Admin (unless a different default
user is set for the selected activity type).

Furthermore, the module corrects a behavior that can induce user to assigning a new
activity to themselves instead of the previously selected user. Use case:

Mitchell Admin creates a new activity, selects "Marc Demo" as "assigned to", but then
changes activity type.

In standard behavior "assigned to" is reset to "Mitchell Admin";
with this module, the user selection is maintained when changing activity type (unless
a different default user is set for the selected activity type).
