### PR TITLE
[16.0][FIX] mail_outbound_static: align maximum length of TLD to DNS limit (63 chars)

### DIFF
--- a/mail_outbound_static/models/ir_mail_server.py
+++ b/mail_outbound_static/models/ir_mail_server.py
@@ -45,7 +45,7 @@ class IrMailServer(models.Model):
         if self.smtp_from:
             match = re.match(
                 r"^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\."
-                r"[a-z]{2,4})$",
+                r"[a-z]{2,63})$",
                 self.smtp_from,
             )
             if match is None:


### PR DESCRIPTION
The module consider valid emails only addresses ending with a top level domain with a size between 2 and 4 characters.

There are plenty of TLDs longer, see https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains, but just as an example:

.digital
.energy
...

Technically, there is no reason a TLD cannot be long as 63 characters - the limit imposed by DNS specifics - even if, in practice, IANA will approve only domains with a reasonable size.