### PR TITLE
[16.0][FIX] mail_attach_existing_attachment: view display of existing attachments

### DIFF
--- a/mail_attach_existing_attachment/wizard/mail_compose_message_view.xml
+++ b/mail_attach_existing_attachment/wizard/mail_compose_message_view.xml
@@ -7,10 +7,9 @@
         <field name="model">mail.compose.message</field>
         <field name="inherit_id" ref="mail.email_compose_message_wizard_form" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='attachment_ids']" position="after">
+            <xpath expr="//field[@name='attachment_ids']/../.." position="after">
                 <field name="can_attach_attachment" invisible="1" />
                 <div attrs="{'invisible': [('can_attach_attachment', '=', False)]}">
-                    <br />
                     <field
                         name="object_attachment_ids"
                         widget="many2many_checkboxes"


### PR DESCRIPTION
BEFORE
![image](https://user-images.githubusercontent.com/4667326/230357330-f574f961-d382-4cc0-b90d-e67b38196487.png)
attachments are shown in between Load template and many2one field

AFTER
![image](https://user-images.githubusercontent.com/4667326/230372591-6a8dd1f6-5786-46da-b247-b4894ff0f63b.png)


cc: @SodexisTeam 