### PR TITLE
[15.0][FIX] mail_tracking: Index error

### DIFF
--- a/mail_tracking/__manifest__.py
+++ b/mail_tracking/__manifest__.py
@@ -7,10 +7,10 @@
 {
     "name": "Email tracking",
     "summary": "Email tracking system for all mails sent",
-    "version": "15.0.2.0.2",
+    "version": "15.0.2.0.3",
     "category": "Social Network",
     "website": "https://github.com/OCA/social",
-    "author": ("Tecnativa, " "Odoo Community Association (OCA)"),
+    "author": ("Tecnativa", "Odoo Community Association (OCA)"),
     "license": "AGPL-3",
     "application": False,
     "installable": True,

--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -163,15 +163,17 @@ class MailTrackingEmail(models.Model):
         partner_ids = self.env["res.partner"]._search(
             [("id", "in", [x for x in partner_ids if x])]
         )
-        return [
-            x[0]
-            for x in msg_linked
-            if (x[1] in msg_ids)  # We can read the linked message
-            or (
-                not any({x[1], x[2]}) and x[3] in partner_ids
-            )  # No linked msg/mail but we can read the linked partner
-            or (not any({x[1], x[2], x[3]}))  # No linked record
-        ]
+        res=[]
+        for tracking_id, message_id, partner_id in msg_linked:
+            # We can read the linked message
+            linked_message = message_id in msg_ids
+            # No linked msg/mail but we can read the linked partner
+            linked_partner = not any({tracking_id, message_id}) and partner_id in partner_ids
+            # No linked record
+            no_linked_record = not any({tracking_id, message_id, partner_id})
+            if linked_message or linked_partner or no_linked_record:
+                res.append(tracking_id)
+        return res
 
     @api.model
     def _search(

--- a/mail_tracking/models/res_partner.py
+++ b/mail_tracking/models/res_partner.py
@@ -8,25 +8,13 @@ class ResPartner(models.Model):
     _name = "res.partner"
     _inherit = ["res.partner", "mail.bounced.mixin"]
 
-    # tracking_emails_count and email_score are non-store fields in order
-    # to improve performance
-    tracking_emails_count = fields.Integer(
-        compute="_compute_email_score_and_count", readonly=True
-    )
+    # email_score is a non-store field in order to improve performance
     email_score = fields.Float(compute="_compute_email_score_and_count", readonly=True)
 
     @api.depends("email")
     def _compute_email_score_and_count(self):
         self.email_score = 50.0
-        self.tracking_emails_count = 0
         partners_mail = self.filtered("email")
         mt_obj = self.env["mail.tracking.email"].sudo()
         for partner in partners_mail:
             partner.email_score = mt_obj.email_score_from_email(partner.email)
-            # We don't want performance issues due to heavy ACLs check for large
-            # recordsets. Our option is to hide the number for regular users.
-            if not self.env.user.has_group("base.group_system"):
-                continue
-            partner.tracking_emails_count = len(
-                mt_obj._search([("recipient_address", "=", partner.email.lower())])
-            )

--- a/mail_tracking/views/res_partner_view.xml
+++ b/mail_tracking/views/res_partner_view.xml
@@ -18,13 +18,8 @@
                     class="oe_stat_button"
                     icon="fa-envelope-o"
                     attrs="{'invisible': [('email', '=', False)]}"
+                    string="Tracking e-mail"
                 >
-                <field
-                        name="tracking_emails_count"
-                        widget="statinfo"
-                        string="Tracking emails"
-                        attrs="{'invisible': [('tracking_emails_count', '=', False)]}"
-                    />
             </button>
         </div>
         <xpath expr="//field[@name='email']/.." position="after">


### PR DESCRIPTION
in multiple cases we get the the following error:
IndexError: tuple index out of range

In the current code for mail_tracking_email the index is not set correctly, 
X3] does not exist/has no value in the _find_allowed_tracking_ids method

        return [
            x[0]
            for x in msg_linked
            if (x[1] in msg_ids)  # We can read the linked message
            or (
                not any({x[1], x[2]}) and x[3] in partner_ids
            )  # No linked msg/mail but we can read the linked partner
            or (not any({x[1], x[2], x[3]}))  # No linked record
        ]
       
instead of just fixing the indexes, i opted to rewrite a small part of this code for readability
resulting in fixing the problem and making it more clear what is happening.


As for the tracking_emails_count. The counter only shows the mail count for the admin, 
If users get rights to view mailtracking their counter will still say 0, even if there are mails behind te smartbutton,
which is in my honest opinion misleading.
so i currently took the counter out because it is not funcion like it should.

It could also  work to just take out :
```
   if not self.env.user.has_group("base.group_system"):
                continue

```
like i did in my PR for the  14.0 branch, but since there is the comment that it is for performance, i opted to leave the counter out in this case.






