### PR TITLE
[14.0][FIX] mail tracking bounce notification not logged

### DIFF
--- a/mail_tracking/models/mail_thread.py
+++ b/mail_tracking/models/mail_thread.py
@@ -44,6 +44,13 @@ class MailThread(models.AbstractModel):
         )
         return super()._message_route_process(message, message_dict, routes)
 
+    def _routing_handle_bounce(self, email_message, message_dict):
+        bounced_message = message_dict["bounced_message"]
+        if bounced_message.mail_tracking_ids:
+            # TODO detect hard of soft bounce
+            bounced_message.mail_tracking_ids.event_create("soft_bounce", message_dict)
+        return super()._routing_handle_bounce(email_message, message_dict)
+
     def _message_get_suggested_recipients(self):
         """Adds email 'extra' recipients as suggested recipients.
 


### PR DESCRIPTION
This is to resolve the following issue:

* https://github.com/OCA/social/issues/1121