### PR TITLE
[15.0][FIX] mail_tracking: thread permissions

### DIFF
--- a/mail_tracking/models/mail_thread.py
+++ b/mail_tracking/models/mail_thread.py
@@ -71,7 +71,7 @@ class MailThread(models.AbstractModel):
                 email_extra_formated_list.extend(email_split_and_format(email))
         email_extra_formated_list = set(email_extra_formated_list)
         email_extra_list = [x[1] for x in getaddresses(email_extra_formated_list)]
-        partners_info = self._message_partner_info_from_emails(email_extra_list)
+        partners_info = self.sudo()._message_partner_info_from_emails(email_extra_list)
         for pinfo in partners_info:
             partner_id = pinfo["partner_id"]
             email = email_split(pinfo["full_name"])[0].lower()


### PR DESCRIPTION
If a user tries to read a thread on a record and one message is from a partner on which he has no permissions, there will be an exception as this method tries to fetch info from such partner.

cc @Tecnativa TT43075

please review @sergio-teruel @carlosdauden 