### PR TITLE
[15.0][FIX] mail_tracking: allowed trackings compute

### DIFF
--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -164,13 +164,13 @@ class MailTrackingEmail(models.Model):
             [("id", "in", [x for x in partner_ids if x])]
         )
         return [
-            x[0]
-            for x in msg_linked
-            if (x[1] in msg_ids)  # We can read the linked message
+            track_id
+            for track_id, mail_msg_id, partner_id in msg_linked
+            if (mail_msg_id in msg_ids)  # We can read the linked message
             or (
-                not any({x[1], x[2]}) and x[3] in partner_ids
-            )  # No linked msg/mail but we can read the linked partner
-            or (not any({x[1], x[2], x[3]}))  # No linked record
+                not mail_msg_id and partner_id in partner_ids
+            )  # No linked mail.message but we can read the linked partner
+            or (not any({mail_msg_id, partner_id}))  # No linked record
         ]
 
     @api.model


### PR DESCRIPTION
fw of https://github.com/OCA/social/pull/1148

In the forward port of the permission check, a column was dropped from the tuple, but the following code wasn't adapted to the new tuple length. For clarity sake we also name the tuple unpacking into proper variables.

cc @Tecnativa TT43453

ping @pedrobaeza 