### PR TITLE
[15.0][IMP] mail_tracking: New config parameter to disable the tracking image

### DIFF
--- a/mail_tracking/README.rst
+++ b/mail_tracking/README.rst
@@ -43,6 +43,15 @@ you need to add ``mail_tracking`` addon to wide load addons list
 (by default, only ``web`` addon), setting ``--load`` option.
 For example, ``--load=web,mail_tracking``
 
+Configuration
+=============
+
+As there can be scenarios where sending a tracking img in the email body is
+not desired, there is a global system parameter
+"mail_tracking.tracking_img_disabled" that can be set to True to remove
+the tracking img from all outgoing emails. Note that the **Opened** status
+will not be available in this case.
+
 Usage
 =====
 

--- a/mail_tracking/models/mail_mail.py
+++ b/mail_tracking/models/mail_mail.py
@@ -30,7 +30,11 @@ class MailMail(models.Model):
 
     def _send_prepare_values(self, partner=None):
         """Creates the mail.tracking.email record and adds the image tracking
-        to the email"""
+        to the email. Please note that because we can't add mail headers in this
+        function, the added tracking image will later (IrMailServer.build_email)
+        also be used to extract the mail.tracking.email record id and to set the
+        X-Odoo-MailTracking-ID header there.
+        """
         email = super()._send_prepare_values(partner=partner)
         vals = self._tracking_email_prepare(partner, email)
         tracking_email = self.env["mail.tracking.email"].sudo().create(vals)

--- a/mail_tracking/readme/CONFIGURE.rst
+++ b/mail_tracking/readme/CONFIGURE.rst
@@ -1,0 +1,5 @@
+As there can be scenarios where sending a tracking img in the email body is
+not desired, there is a global system parameter
+"mail_tracking.tracking_img_disabled" that can be set to True to remove
+the tracking img from all outgoing emails. Note that the **Opened** status
+will not be available in this case.

--- a/mail_tracking/static/description/index.html
+++ b/mail_tracking/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Email tracking</title>
 <style type="text/css">
 
@@ -375,17 +375,18 @@ right to his name.</p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#installation" id="id1">Installation</a></li>
-<li><a class="reference internal" href="#usage" id="id2">Usage</a></li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="id3">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id4">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id5">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id6">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id7">Contributors</a></li>
-<li><a class="reference internal" href="#other-credits" id="id8">Other credits</a><ul>
-<li><a class="reference internal" href="#images" id="id9">Images</a></li>
+<li><a class="reference internal" href="#configuration" id="id2">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="id3">Usage</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id4">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id5">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id6">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id7">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id8">Contributors</a></li>
+<li><a class="reference internal" href="#other-credits" id="id9">Other credits</a><ul>
+<li><a class="reference internal" href="#images" id="id10">Images</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#maintainers" id="id10">Maintainers</a></li>
+<li><a class="reference internal" href="#maintainers" id="id11">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -398,8 +399,16 @@ you need to add <tt class="docutils literal">mail_tracking</tt> addon to wide lo
 (by default, only <tt class="docutils literal">web</tt> addon), setting <tt class="docutils literal"><span class="pre">--load</span></tt> option.
 For example, <tt class="docutils literal"><span class="pre">--load=web,mail_tracking</span></tt></p>
 </div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#id2">Configuration</a></h1>
+<p>As there can be scenarios where sending a tracking img in the email body is
+not desired, there is a global system parameter
+“mail_tracking.tracking_img_disabled” that can be set to True to remove
+the tracking img from all outgoing emails. Note that the <strong>Opened</strong> status
+will not be available in this case.</p>
+</div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#id2">Usage</a></h1>
+<h1><a class="toc-backref" href="#id3">Usage</a></h1>
 <p>When user sends a message in mail_thread (chatter), for instance in partner
 form, then an email tracking is created for each email notification. Then a
 status icon will appear just right to name of notified partner.</p>
@@ -438,13 +447,13 @@ with messages in failed status and that needs an user action.</p>
 </ul>
 </div>
 <div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#id3">Known issues / Roadmap</a></h1>
+<h1><a class="toc-backref" href="#id4">Known issues / Roadmap</a></h1>
 <ul class="simple">
 <li>Add pivot for tracking events and mail trackings</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id4">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id5">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/social/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -452,15 +461,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id5">Credits</a></h1>
+<h1><a class="toc-backref" href="#id6">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id6">Authors</a></h2>
+<h2><a class="toc-backref" href="#id7">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id7">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id8">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Pedro M. Baeza</li>
@@ -476,9 +485,9 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="other-credits">
-<h2><a class="toc-backref" href="#id8">Other credits</a></h2>
+<h2><a class="toc-backref" href="#id9">Other credits</a></h2>
 <div class="section" id="images">
-<h3><a class="toc-backref" href="#id9">Images</a></h3>
+<h3><a class="toc-backref" href="#id10">Images</a></h3>
 <ul class="simple">
 <li>Odoo Community Association: <a class="reference external" href="https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg">Icon</a>.</li>
 <li>Thanks to <a class="reference external" href="https://openclipart.org/user-detail/LlubNek">LlubNek</a> and <a class="reference external" href="https://openclipart.org">Openclipart</a> for <a class="reference external" href="https://openclipart.org/detail/19342/open-envelope">the icon</a>.</li>
@@ -486,7 +495,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </div>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id10">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id11">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose


### PR DESCRIPTION
- As the tracker img in the body is currently also used to set the X-Odoo-MailTracking-ID mail header we can remove the tag only after this is done
- Added tests to check for the presence and absence of the tracking image tag depending on the new configuration parameter