### PR TITLE
[13.0] mass_mailing_contact_active: Fix default value of active field in mass mailing subscription

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,18 +36,18 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.6-odoo13.0:latest
-            include: "mail_restrict_follower_selection,mass_mailing_contact_active,mass_mailing_partner_contact_active"
+            include: "mail_restrict_follower_selection"
             makepot: "true"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.6-ocb13.0:latest
-            include: "mail_restrict_follower_selection,mass_mailing_contact_active,mass_mailing_partner_contact_active"
+            include: "mail_restrict_follower_selection"
             name: test with OCB
           - container: ghcr.io/oca/oca-ci/py3.6-odoo13.0:latest
-            exclude: "mail_restrict_follower_selection,mass_mailing_contact_active,mass_mailing_partner_contact_active"
+            exclude: "mail_restrict_follower_selection"
             makepot: "true"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.6-ocb13.0:latest
-            exclude: "mail_restrict_follower_selection,mass_mailing_contact_active,mass_mailing_partner_contact_active"
+            exclude: "mail_restrict_follower_selection"
             name: test with OCB
     services:
       postgres:

--- a/mass_mailing_contact_active/__manifest__.py
+++ b/mass_mailing_contact_active/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Mass Mailing Contact Active",
     "summary": "Adds active feature on mailing list contact and subscriptions",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.1.0",
     "category": "Marketing/Email Marketing",
     "website": "https://github.com/OCA/social",
     "author": "Camptocamp, Odoo Community Association (OCA)",

--- a/mass_mailing_contact_active/models/mailing_contact_subscription.py
+++ b/mass_mailing_contact_active/models/mailing_contact_subscription.py
@@ -8,3 +8,29 @@ class MailingContactSubscription(models.Model):
     _inherit = "mailing.contact.subscription"
 
     active = fields.Boolean(default=True)
+
+    def init(self):
+        """Add default value in DB for active column.
+
+        Model mailing.contact.subscription is persisted using database table
+        mailing_contact_list_rel.
+        This model is used for following O2m fields:
+        - mailing.list.subscription_ids
+        - mailing.contact.subscription_list_ids
+
+        However it is also used to materialize a M2m relation on following fields:
+        - mailing.list.contact_ids
+        - mailing.contact.list_ids
+
+        If records are added using O2m fields, the ORM will properly get the default
+        value defined for the active field before inserting in the table.
+        However, if records are added using M2m fields, the ORM will only use the foreign
+        keys to insert since it's an associative table.
+
+        By defining a TRUE value as default for active field, we ensure the records
+        added using the M2m fields will be active by default.
+        """
+        super().init()
+        self.env.cr.execute(
+            """ALTER TABLE ONLY mailing_contact_list_rel ALTER COLUMN active SET DEFAULT TRUE;"""  # noqa
+        )

--- a/mass_mailing_list_dynamic/wizards/partner_merge.py
+++ b/mass_mailing_list_dynamic/wizards/partner_merge.py
@@ -11,5 +11,7 @@ class BasePartnerMergeAutomaticWizard(models.TransientModel):
         return super(
             BasePartnerMergeAutomaticWizard, self.with_context(syncing=True)
         )._merge(
-            partner_ids=partner_ids, dst_partner=dst_partner, extra_checks=extra_checks,
+            partner_ids=partner_ids,
+            dst_partner=dst_partner.with_context(syncing=True),
+            extra_checks=extra_checks,
         )


### PR DESCRIPTION
Add default value in DB for active column.

Model mailing.contact.subscription is persisted using database table mailing_contact_list_rel.
This model is used for following O2m fields:
  - mailing.list.subscription_ids
  - mailing.contact.subscription_list_ids

However it is also used to materialize a M2m relation on following fields:
  - mailing.list.contact_ids
  - mailing.contact.list_ids

If records are added using O2m fields, the ORM will properly get the default value defined for the active field before inserting in the table. However, if records are added using M2m fields, the ORM will only use the foreign keys to insert since it's an associative table.

By defining a TRUE value as default for active field, we ensure the records added using the M2m fields will be active by default.