### PR TITLE
[FIX] mail_attach_existing_attachment: fix wizard view

### DIFF
--- a/mail_attach_existing_attachment/wizard/mail_compose_message_view.xml
+++ b/mail_attach_existing_attachment/wizard/mail_compose_message_view.xml
@@ -9,14 +9,12 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='attachment_ids']" position="after">
                 <field name="can_attach_attachment" invisible="1" />
-                <div attrs="{'invisible': [('can_attach_attachment', '=', False)]}">
-                    <br />
                     <field
-                        name="object_attachment_ids"
-                        widget="many2many_checkboxes"
-                        domain="[('res_model', '=', model), ('res_id', '=', res_id)]"
-                    />
-                </div>
+                    name="object_attachment_ids"
+                    widget="many2many_checkboxes"
+                    domain="[('res_model', '=', model), ('res_id', '=', res_id)]"
+                    attrs="{'invisible': [('can_attach_attachment', '=', False)]}"
+                />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Wizard view is broken - template field is cut

before fix (manually modified visibility of "can attach Attachment" field for testing purpose):
![image](https://github.com/OCA/social/assets/59824990/5a3392f6-8489-4d32-bf77-1bd9d3625307)

after:
![image](https://github.com/OCA/social/assets/59824990/c3ef27c3-b9f8-4b60-b8e2-f0dfb0739777)
