### PR TITLE
[15.0][IMP] mail_quoted_reply: set email author as default reply partner

### DIFF
--- a/mail_quoted_reply/models/mail_message.py
+++ b/mail_quoted_reply/models/mail_message.py
@@ -29,6 +29,9 @@ class MailMessage(models.Model):
             body=self.body,
         )
 
+    def _default_reply_partner(self):
+        return self.env["res.partner"].find_or_create(self.email_from).ids
+
     def reply_message(self):
         action = self.env["ir.actions.actions"]._for_xml_id(
             "mail.action_email_compose_message_wizard"
@@ -43,6 +46,6 @@ class MailMessage(models.Model):
             "is_quoted_reply": True,
             "default_notify": True,
             "force_email": True,
-            "default_partner_ids": self.partner_ids.ids,
+            "default_partner_ids": self._default_reply_partner(),
         }
         return action

--- a/mail_quoted_reply/tests/test_reply.py
+++ b/mail_quoted_reply/tests/test_reply.py
@@ -33,7 +33,7 @@ class TestMessageReply(TransactionCase):
             self.env[action["res_model"]].with_context(**action["context"]).create({})
         )
         self.assertTrue(wizard.partner_ids)
-        self.assertEqual(message.partner_ids, wizard.partner_ids)
+        self.assertEqual(message.email_from, wizard.partner_ids.email_formatted)
         # the onchange in the composer isn't triggered in tests, so we check for the
         # correct quote in the context
         email_quote = re.search("<p>.*?</p>", wizard._context["quote_body"]).group()


### PR DESCRIPTION
Thus far, the mail_message.partner_ids field was used for default partner_ids when opening the composer from the reply button. However, for most messages, partner_ids will not be set. When replying to a message, it is most intuitive for users if the default recipient of the message will be the author of the original message.
Instead of using the author_id field, we're using the find_or_create method of res.partner to ensure that a default partner is set. The author_id field will be empty if the email address does not match any existing partners.