### PR TITLE
[15.0][IMP] mail_activity_board: Add group so that the activity dashboard is only visible if the user has the permission.

### DIFF
--- a/mail_activity_board/__manifest__.py
+++ b/mail_activity_board/__manifest__.py
@@ -12,7 +12,7 @@
     "license": "AGPL-3",
     "installable": True,
     "depends": ["calendar", "board"],
-    "data": ["views/mail_activity_view.xml"],
+    "data": ["security/groups.xml", "views/mail_activity_view.xml"],
     "assets": {
         "web.assets_backend": [
             "mail_activity_board/static/src/components/chatter_topbar/chatter_topbar.esm.js",

--- a/mail_activity_board/i18n/es.po
+++ b/mail_activity_board/i18n/es.po
@@ -6,15 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2020-02-02 21:13+0000\n"
+"POT-Creation-Date: 2023-07-05 11:10+0000\n"
+"PO-Revision-Date: 2023-07-05 13:11+0200\n"
 "Last-Translator: eduardgm <eduard.garcia@qubiq.es>\n"
 "Language-Team: none\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.10\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: mail_activity_board
 #: model_terms:ir.ui.view,arch_db:mail_activity_board.mail_activity_view_kanban
@@ -69,7 +70,7 @@ msgstr "Asistentes"
 #. module: mail_activity_board
 #: model:ir.model.fields,field_description:mail_activity_board.field_mail_activity__related_model_instance
 msgid "Document"
-msgstr ""
+msgstr "Documento"
 
 #. module: mail_activity_board
 #: model:ir.model.fields,field_description:mail_activity_board.field_mail_activity__duration
@@ -98,6 +99,11 @@ msgid "Show activities scheduled for next month."
 msgstr "Mostrar las actividades programadas para el próximo mes."
 
 #. module: mail_activity_board
+#: model:res.groups,name:mail_activity_board.group_show_mail_activity_board
+msgid "Show mail activity board"
+msgstr "Mostrar el tablero de actividades"
+
+#. module: mail_activity_board
 #: model:ir.model.fields,field_description:mail_activity_board.field_mail_activity__calendar_event_id_start
 msgid "Start"
 msgstr "Inicio"
@@ -105,8 +111,7 @@ msgstr "Inicio"
 #. module: mail_activity_board
 #: model:ir.model.fields,help:mail_activity_board.field_mail_activity__calendar_event_id_start
 msgid "Start date of an event, without time for full days events"
-msgstr ""
-"Fecha de inicio de un evento, sin tiempo para eventos de días completos"
+msgstr "Fecha de inicio de un evento, sin tiempo para eventos de días completos"
 
 #. module: mail_activity_board
 #: model_terms:ir.ui.view,arch_db:mail_activity_board.mail_activity_view_form_board
@@ -122,6 +127,3 @@ msgstr "Usuario"
 #: model_terms:ir.ui.view,arch_db:mail_activity_board.mail_activity_view_form_board
 msgid "e.g. Discuss proposal"
 msgstr "Ej. Discutir propuesta"
-
-#~ msgid "See activities list"
-#~ msgstr "Ver lista de actividades"

--- a/mail_activity_board/i18n/mail_activity_board.pot
+++ b/mail_activity_board/i18n/mail_activity_board.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-05 11:10+0000\n"
+"PO-Revision-Date: 2023-07-05 11:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -92,6 +94,11 @@ msgstr ""
 #. module: mail_activity_board
 #: model_terms:ir.ui.view,arch_db:mail_activity_board.mail_activity_view_search
 msgid "Show activities scheduled for next month."
+msgstr ""
+
+#. module: mail_activity_board
+#: model:res.groups,name:mail_activity_board.group_show_mail_activity_board
+msgid "Show mail activity board"
 msgstr ""
 
 #. module: mail_activity_board

--- a/mail_activity_board/models/mail_activity.py
+++ b/mail_activity_board/models/mail_activity.py
@@ -52,7 +52,9 @@ class MailActivity(models.Model):
 
     @api.model
     def action_activities_board(self):
-        action = self.env.ref("mail_activity_board.open_boards_activities").read()[0]
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "mail_activity_board.open_boards_activities"
+        )
         return action
 
     @api.model

--- a/mail_activity_board/security/groups.xml
+++ b/mail_activity_board/security/groups.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<odoo>
+    <record model="res.groups" id="group_show_mail_activity_board">
+        <field name="name">Show mail activity board</field>
+        <field
+            name="users"
+            eval="[Command.link(ref('base.user_root')), Command.link(ref('base.user_admin'))]"
+        />
+    </record>
+</odoo>

--- a/mail_activity_board/views/mail_activity_view.xml
+++ b/mail_activity_board/views/mail_activity_view.xml
@@ -331,6 +331,7 @@ Menus
         name="Activities"
         parent="base.menu_board_root"
         action="open_boards_activities"
+        groups="group_show_mail_activity_board"
         sequence="1"
     />
 


### PR DESCRIPTION
Add group so that the activity dashboard is only visible if the user has the permission.

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT43037