### PR TITLE
[15.0][FIX] mail_quoted_reply: avoid rendering reply icon multiple times

### DIFF
--- a/mail_quoted_reply/static/src/components/mail_message_reply.esm.js
+++ b/mail_quoted_reply/static/src/components/mail_message_reply.esm.js
@@ -30,7 +30,12 @@ patch(
                     );
                 }
                 actionLists.forEach((actionList) => {
-                    actionList.append(MessageQuotedReplyIcon);
+                    if (
+                        !actionList.querySelectorAll(".o_mail_quoted_reply_command")
+                            .length > 0
+                    ) {
+                        actionList.append(MessageQuotedReplyIcon);
+                    }
                 });
             });
         },

--- a/mail_quoted_reply/static/src/xml/mail_message_reply.xml
+++ b/mail_quoted_reply/static/src/xml/mail_message_reply.xml
@@ -2,7 +2,7 @@
 <template>
     <t t-name="MessageQuotedReplyButton">
         <span
-            class="p-2 fa fa-lg fa-reply o_MessageActionList_action"
+            class="p-2 fa fa-lg fa-reply o_MessageActionList_action o_mail_quoted_reply_command"
             t-on-click="_onClickMailMessageReply"
             title="Reply"
         />


### PR DESCRIPTION
Sometimes, the quoted reply icon is rendered and appended to the message action list multiple times in the chatter. With this fix, the icon is added to the action list only if it is not already contained within the list.