### PR TITLE
[14][FIX] base_search_mail_content: Avoid CacheMiss errors

### DIFF
--- a/base_search_mail_content/models/mail_thread.py
+++ b/base_search_mail_content/models/mail_thread.py
@@ -30,9 +30,13 @@ class MailThread(models.AbstractModel):
     message_content = fields.Text(
         string="Message Content",
         help="Message content, to be used only in searches",
-        compute=lambda self: False,
+        compute="_compute_message_content",
         search="_search_message_content",
     )
+
+    def _compute_message_content(self):
+        # Always assign a value to avoid CacheMiss errors
+        self.message_content = False
 
     @api.model
     def fields_view_get(


### PR DESCRIPTION
Backport of https://github.com/OCA/social/pull/897 using https://github.com/OCA/oca-port.

Error is raised in https://github.com/odoo/odoo/blob/8e0a4f5c24756bf4cf84a88089547ce7dc030b1b/odoo/fields.py#L1049.