### PR TITLE
[15.0][IMP] mail_activity_team: add multi-company check

### DIFF
--- a/mail_activity_team/security/mail_activity_team_security.xml
+++ b/mail_activity_team/security/mail_activity_team_security.xml
@@ -14,4 +14,11 @@
         <field name="perm_unlink" eval="True" />
     </record>
 
+    <record id="mail_activity_team_company" model="ir.rule">
+            <field name="name">Mail Activity Team Multi-Company</field>
+            <field name="model_id" ref="model_mail_activity_team" />
+            <field eval="True" name="global" />
+            <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+        </record>
+
 </odoo>

--- a/mail_activity_team/views/mail_activity_team_views.xml
+++ b/mail_activity_team/views/mail_activity_team_views.xml
@@ -41,6 +41,9 @@
                                 options="{'no_create': True, 'no_open': True}"
                             />
                         </group>
+                        <group name="company">
+                            <field name="company_id" options="{'no_create': True}" />
+                        </group>
                     </group>
                     <notebook>
                         <page name="members" string="Members">


### PR DESCRIPTION
When having two users in a activity team from different companies, it will raise an Exception of multicompany when adding the team to a document. This fix ensures that all the users in a team are from the same company (at least one of the companies available).

@ForgeFlow