### PR TITLE
[15.0][FIX]mail_composer_cc_bcc: avoid sending multiple mails to all recipients when no cc or bcc is set

### DIFF
--- a/mail_composer_cc_bcc/models/mail_mail.py
+++ b/mail_composer_cc_bcc/models/mail_mail.py
@@ -34,7 +34,8 @@ class MailMail(models.Model):
         ICP = env["ir.config_parameter"].sudo()
         # Mail composer only sends 1 mail at a time.
         is_out_of_scope = len(self.ids) > 1
-        if is_out_of_scope or not (self.email_cc or self.email_bcc):
+        is_from_composer = self.env.context.get("is_from_composer", False)
+        if is_out_of_scope or not is_from_composer:
             return super()._send(
                 auto_commit=auto_commit,
                 raise_exception=raise_exception,

--- a/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
+++ b/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
@@ -178,3 +178,24 @@ Test Template<br></p>""",
         # Only 4 partners notified
         self.assertEqual(len(message.notified_partner_ids), 4)
         self.assertEqual(len(message.notification_ids), 4)
+
+    def test_mail_without_cc_bcc(self):
+        # Test without any partner in cc/bcc -> only 1 mail should be sent
+        self.set_company()
+        form = self.open_mail_composer_form()
+        subject = "Testing without cc/bcc single mail"
+        form.subject = subject
+        composer = form.save()
+        composer.partner_cc_ids = None
+        composer.partner_bcc_ids = None
+        composer.partner_ids = self.partner + self.partner_cc
+        ctx = {"mail_notify_force_send": True}
+        ctx.update(composer.env.context)
+        composer = composer.with_context(**ctx)
+        with self.mock_mail_gateway():
+            composer._action_send_mail()
+        sent_mails = 0
+        for mail in self._mails:
+            if subject == mail.get("subject"):
+                sent_mails += 1
+        self.assertEqual(sent_mails, 1)


### PR DESCRIPTION
It can happen that the same email will be sent multiple times to the same recipient.

Steps to recreate the error:
- Open a composer (for example from the chatter for a single contact or a single task in project)
- Enter multiple recipients in the to-field
- Leave the cc- and bcc-field empty
- Fill out subject and body
- Send the mail

The mail will be sent to each recipient as many times as there are recipients. For example: if there are 3 recipients in the to-field, each recipient gets the same mail 3 times.