### PR TITLE
[FIX] fix condition to call super

### DIFF
--- a/mail_composer_cc_bcc/models/mail_mail.py
+++ b/mail_composer_cc_bcc/models/mail_mail.py
@@ -34,7 +34,7 @@ class MailMail(models.Model):
         ICP = env["ir.config_parameter"].sudo()
         # Mail composer only sends 1 mail at a time.
         is_out_of_scope = len(self.ids) > 1
-        if is_out_of_scope or not (self.email_cc or self.email_bcc):
+        if is_out_of_scope:
             return super()._send(
                 auto_commit=auto_commit,
                 raise_exception=raise_exception,


### PR DESCRIPTION
We call super because due to lack of cc/bcc -> whole condition is True.
Then for each partner from recipient ids we call send_prepare_values (https://github.com/odoo/odoo/blob/6ec4ba7ba22626219ddd09241c274b09a21fac0b/addons/mail/models/mail_mail.py#L399) - seems originally this method in odoo handles only single partner's email so odoo sends one email per recipient (https://github.com/odoo/odoo/blob/6ec4ba7ba22626219ddd09241c274b09a21fac0b/addons/mail/models/mail_mail.py#L281)
but when this module is installed we fallback to override in which we assign all the recipients to "email_to" and return it back: https://github.com/OCA/social/blob/15.0/mail_composer_cc_bcc/models/mail_mail.py#L266
As a result we're ending up with mail values for every recipient defined on document where "mail_to" will always have same set of multiple partners: https://github.com/odoo/odoo/blob/6ec4ba7ba22626219ddd09241c274b09a21fac0b/addons/mail/models/mail_mail.py#L401 
That leads to situation where multiple emails for multiple recipients are created instead of sending one email with  multiple recipients.

from my observation:  if we have document with 3 followers and no cc/bcc we will send 3 emails - each email with all 3 followers in "email_to"