### PR TITLE
[15.0][FIX] mail_composer_cc_bcc

### DIFF
--- a/mail_composer_cc_bcc/models/mail_mail.py
+++ b/mail_composer_cc_bcc/models/mail_mail.py
@@ -28,18 +28,18 @@ class MailMail(models.Model):
     def _send(  # noqa: max-complexity: 4
         self, auto_commit=False, raise_exception=False, smtp_session=None
     ):
-        env = self.env
-        IrMailServer = env["ir.mail_server"]
-        IrAttachment = env["ir.attachment"]
-        ICP = env["ir.config_parameter"].sudo()
-        # Mail composer only sends 1 mail at a time.
+        is_from_composer = self.env.context.get("is_from_composer", False)
         is_out_of_scope = len(self.ids) > 1
-        if is_out_of_scope or not (self.email_cc or self.email_bcc):
+        if not is_from_composer or is_out_of_scope:
             return super()._send(
                 auto_commit=auto_commit,
                 raise_exception=raise_exception,
                 smtp_session=smtp_session,
             )
+        env = self.env
+        IrMailServer = env["ir.mail_server"]
+        IrAttachment = env["ir.attachment"]
+        ICP = env["ir.config_parameter"].sudo()
         mail = self
         success_pids = []
         failure_type = None


### PR DESCRIPTION
- One of the main goals of `mail_composer_cc_bcc` is to get the Mail Composer wizard to behave like a normal Mail Client
- Concretely, instead of sending one email per partner as Odoo does by default in [`mail.mail:_send()`](https://github.com/odoo/odoo/blob/15.0/addons/mail/models/mail_mail.py#L394), it only [sends one](https://github.com/oca/social/blob/15.0/mail_composer_cc_bcc/models/mail_mail.py#L71) so that headers To: and Cc: would be shown with all recipients, as end users expect
- But in the case where no Cc/Bcc is defined, `To` header is modified by `mail_composer_cc_bcc` while the original `mail.mail:_send()` is still used
- As a consequence, both behaviors are combined and multiple emails are sent to the same recipients :(
- This PR fixes this bug, by relying on the context-key `is_from_composer` to be consistent with the rest of the code
