### PR TITLE
Fix mail_composer_cc_bcc conflicting with mass.mailing.

### DIFF
--- a/mail_composer_cc_bcc/models/mail_mail.py
+++ b/mail_composer_cc_bcc/models/mail_mail.py
@@ -263,7 +263,10 @@ class MailMail(models.Model):
         partners_cc_bcc = self.recipient_cc_ids + self.recipient_bcc_ids
         partner_to_ids = [r.id for r in self.recipient_ids if r not in partners_cc_bcc]
         partner_to = self.env["res.partner"].browse(partner_to_ids)
-        res["email_to"] = format_emails(partner_to)
-        res["email_cc"] = format_emails(self.recipient_cc_ids)
-        res["email_bcc"] = format_emails(self.recipient_bcc_ids)
+        if partner_to:
+            res["email_to"] = format_emails(partner_to)
+        if self.recipient_cc_ids:
+            res["email_cc"] = format_emails(self.recipient_cc_ids)
+        if self.recipient_bcc_ids:
+            res["email_bcc"] = format_emails(self.recipient_bcc_ids)
         return res


### PR DESCRIPTION
Email from a mass mailing are not being sent. On the related mailing.trace record the failure type is `Missing email address`.

Uninstalling the module `mail_composer_cc_bcc module` fixes the problem.

The reason this module interfere with sending mass email is that the `mass_mailing` module uses the mail.compose.message wizard.

The failure type mentionned above happens because the dictionary generated containing the info for sending the email has no data in the `email_to` key !