### PR TITLE
[16.0][FIX] base_search_mail_content: Allow messsage_content search only for internal users

### DIFF
--- a/base_search_mail_content/README.rst
+++ b/base_search_mail_content/README.rst
@@ -69,6 +69,14 @@ Usage
 Go to any model that contains a chatter (e.g. Contacts, ...). Search
 for content in field 'Message Content'.
 
+Known issues / Roadmap
+======================
+
+This module restricts the message_content search functionality
+to internal users only, addressing the issue faced by project collaborators (portal users)
+as described in https://github.com/OCA/social/issues/1204. Consequently, portal users no
+longer have the ability to search within mail content.
+
 Bug Tracker
 ===========
 

--- a/base_search_mail_content/models/mail_thread.py
+++ b/base_search_mail_content/models/mail_thread.py
@@ -44,7 +44,11 @@ class MailThread(models.AbstractModel):
         that inherits mail.thread
         """
         res = super().get_view(view_id=view_id, view_type=view_type, options=options)
-        if view_type == "search" and self._fields.get("message_content"):
+        if (
+            view_type == "search"
+            and self._fields.get("message_content")
+            and self.env.user.has_group("base.group_user")
+        ):
             doc = etree.XML(res["arch"])
             for node in doc.xpath("/search/field[last()]"):
                 # Add message_content in search view

--- a/base_search_mail_content/readme/ROADMAP.rst
+++ b/base_search_mail_content/readme/ROADMAP.rst
@@ -1,0 +1,4 @@
+This module restricts the message_content search functionality
+to internal users only, addressing the issue faced by project collaborators (portal users)
+as described in https://github.com/OCA/social/issues/1204. Consequently, portal users no
+longer have the ability to search within mail content.

--- a/base_search_mail_content/static/description/index.html
+++ b/base_search_mail_content/static/description/index.html
@@ -411,6 +411,13 @@ perform the searches on mail messages.</p>
 <p>Go to any model that contains a chatter (e.g. Contacts, …). Search
 for content in field ‘Message Content’.</p>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#id3">Known issues / Roadmap</a></h1>
+<p>This module restricts the message_content search functionality
+to internal users only, addressing the issue faced by project collaborators (portal users)
+as described in <a class="reference external" href="https://github.com/OCA/social/issues/1204">https://github.com/OCA/social/issues/1204</a>. Consequently, portal users no
+longer have the ability to search within mail content.</p>
+</div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/social/issues">GitHub Issues</a>.


### PR DESCRIPTION
Related issue: https://github.com/OCA/social/issues/1204

This PR adds a message_content search feature exclusively for internal users, considering constraints in specific model views like project.task. I welcome alternative solutions and suggestions.

@qrtl