### PR TITLE
Odoo 14 mail_debrand, ignore remove default_parent by default

### DIFF
--- a/mail_debrand/models/mail_render_mixin.py
+++ b/mail_debrand/models/mail_render_mixin.py
@@ -102,7 +102,9 @@ class MailRenderMixin(models.AbstractModel):
         )
 
         for key in res_ids:
-            orginal_rendered[key] = self.remove_href_odoo(orginal_rendered[key])
+            orginal_rendered[key] = self.remove_href_odoo(
+                orginal_rendered[key], remove_parent=False
+            )
 
         return orginal_rendered
 


### PR DESCRIPTION
[FIX] mail_debrand: don't remove by default parent
This fix an empty content message for <record id="set_password_email" model="mail.template">

Maybe this break something else.
Thanks for your review.