### PR TITLE
[14.0][FIX] mail_activity_team: Use valid field for user avatar

### DIFF
--- a/mail_activity_board/views/mail_activity_view.xml
+++ b/mail_activity_board/views/mail_activity_view.xml
@@ -235,7 +235,7 @@
                                     </div>
                                     <div class="oe_kanban_bottom_right">
                                         <img
-                                            t-att-src="kanban_image('res.users', 'image_small', record.user_id.raw_value)"
+                                            t-att-src="kanban_image('res.users', 'image_128', record.user_id.raw_value)"
                                             t-att-title="record.user_id.value"
                                             t-att-alt="record.user_id.value"
                                             width="24"


### PR DESCRIPTION
Like said in #1218, this fixes the `image_small` field has been renamed to `image_128` since the use of `image.mixin`

Note that this replacement was forgotten during the migration of many modules.
![image](https://github.com/OCA/social/assets/22446243/d4a9ae7e-81c1-48f0-a87e-b9aa86c688c9)
