### PR TITLE
[15.0][FIX] mail_composer_cc_bcc: fix error _action_send_mail()

### DIFF
--- a/mail_composer_cc_bcc/wizards/mail_compose_message.py
+++ b/mail_composer_cc_bcc/wizards/mail_compose_message.py
@@ -77,5 +77,5 @@ class MailComposeMessage(models.TransientModel):
         }
         context.update(self.env.context)
         self_super = super(MailComposeMessage, self.with_context(**context))
-        res = self_super._action_send_mail(auto_commit)
+        res = self_super._action_send_mail(auto_commit=auto_commit)
         return res


### PR DESCRIPTION
Got this error when confirm Purchase Order, add `auto_commit` fixed it

```
`RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/../odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/../odoo/http.py", line 687, in dispatch
    result = self._call_function(**self.params)
  File "/../odoo/http.py", line 359, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/../odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/../odoo/http.py", line 348, in checked_call
    result = self.endpoint(*a, **kw)
  File "/../odoo/http.py", line 910, in __call__
    return self.method(*args, **kw)
  File "/../odoo/http.py", line 535, in response_wrap
    response = f(*args, **kw)
  File "/../addons/web/controllers/main.py", line 1330, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/../addons/web/controllers/main.py", line 1318, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/../odoo/api.py", line 464, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/../odoo/api.py", line 451, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/../addons/purchase_requisition/models/purchase.py", line 80, in button_confirm
    res = super(PurchaseOrder, self).button_confirm()
  File "/../addons/purchase/models/purchase.py", line 439, in button_confirm
    order.button_approve()
  File "/.../enterprise/sale_purchase_inter_company_rules/models/purchase_order.py", line 15, in button_approve
    res = super(purchase_order, self).button_approve(force=force)
  File "/../addons/purchase_stock/models/purchase.py", line 95, in button_approve
    self._create_picking()
  File "/../addons/purchase_stock/models/purchase.py", line 237, in _create_picking
    picking.message_post_with_view('mail.message_origin_link',
  File "/../addons/mail/models/mail_thread.py", line 1943, in message_post_with_view
    self._message_compose_with_view(views_or_xmlid, **kwargs)
  File "/../addons/mail/models/mail_thread.py", line 1937, in _message_compose_with_view
    record.message_post_with_template(False, **kwargs)
  File "/../addons/mass_mailing/models/mail_thread.py", line 37, in message_post_with_template
    return super(MailThread, no_massmail).message_post_with_template(template_id, **kwargs)
  File "/../addons/mail/models/mail_thread.py", line 1974, in message_post_with_template
    return composer._action_send_mail(auto_commit=auto_commit)
  File "/../addons/sale/wizard/mail_compose_message.py", line 15, in _action_send_mail
    return super(MailComposeMessage, self)._action_send_mail(auto_commit=auto_commit)
  File "/../addons/purchase/models/mail_compose_message.py", line 15, in _action_send_mail
    return super(MailComposeMessage, self)._action_send_mail(auto_commit=auto_commit)
  File "/.../social/mail_composer_cc_bcc/wizards/mail_compose_message.py", line 80, in _action_send_mail
    res = self_super._action_send_mail(auto_commit)
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/../odoo/http.py", line 643, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/../odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
TypeError: _action_send_mail() takes 1 positional argument but 2 were given`
```