### PR TITLE
[FIX][14.0] mail_debrand tour info on signup email

### DIFF
--- a/mail_debrand/models/mail_render_mixin.py
+++ b/mail_debrand/models/mail_render_mixin.py
@@ -53,8 +53,15 @@ class MailRenderMixin(models.AbstractModel):
                     # remove 'using' that is before <a and after </span>
                     previous.tail = ""
                 if remove_parent and len(parent.getparent()):
-                    # anchor <a href odoo has a parent powered by that must be removed
-                    parent.getparent().remove(parent)
+                    if previous is not None and previous.tag == "br":
+                        # remove odoo tour info
+                        # todo remove previous and next tag with generic claims
+                        parent.remove(elem)
+                        previous.getparent().remove(previous)
+                    else:
+                        # anchor <a href odoo has a parent powered by that must be
+                        # removed
+                        parent.getparent().remove(parent)
                 else:
                     if parent.tag == "td":  # also here can be powered by
                         parent.getparent().remove(parent)


### PR DESCRIPTION
The `Auth Signup: Odoo Connection` template is rendered partially because in this line: https://github.com/OCA/OCB/blob/26316dd56fa290b2a6d6366f325cdc9f4dcac0d6/addons/auth_signup/data/auth_signup_data.xml#L152 there is an `www.odoo.com` and the parent tag is the `div` with the main body of the email, which is then removed.