### PR TITLE
[15.0][FIX] *: `image_128` -> `avatar_128`

### DIFF
--- a/mail_activity_board/views/mail_activity_view.xml
+++ b/mail_activity_board/views/mail_activity_view.xml
@@ -236,7 +236,7 @@
                                     </div>
                                     <div class="oe_kanban_bottom_right">
                                         <img
-                                            t-att-src="kanban_image('res.users', 'image_small', record.user_id.raw_value)"
+                                            t-att-src="kanban_image('res.users', 'avatar_128', record.user_id.raw_value)"
                                             t-att-title="record.user_id.value"
                                             t-att-alt="record.user_id.value"
                                             width="24"

--- a/mail_activity_creator/static/src/xml/activity.xml
+++ b/mail_activity_creator/static/src/xml/activity.xml
@@ -5,7 +5,7 @@
             <dt>Creator</dt>
             <dd class="mb8">
                 <img
-                    t-attf-src="/web/image#{activity.creator_uid[0] >= 0 ? ('/res.users/' + activity.creator_uid[0] + '/image_small') : ''}"
+                    t-attf-src="/web/image#{activity.creator_uid[0] >= 0 ? ('/res.users/' + activity.creator_uid[0] + '/avatar_128') : ''}"
                     height="18"
                     width="18"
                     class="rounded-circle mr4"


### PR DESCRIPTION
The `image_small` field has been renamed to `image_small` since the use of `image.mixin`.

Forward port of:
- https://github.com/OCA/social/pull/1219
- https://github.com/OCA/social/pull/1229