### PR TITLE
[16.0][IMP] mail_activity_reminder: set message template on activity types

### DIFF
--- a/mail_activity_reminder/models/mail_activity_type.py
+++ b/mail_activity_reminder/models/mail_activity_type.py
@@ -16,6 +16,11 @@ class MailActivityType(models.Model):
             ' 5 means "5 calendar days before the deadline".'
         ),
     )
+    reminder_mail_template_id = fields.Many2one(
+        comodel_name="ir.ui.view",
+        string="Reminder eMail Template",
+        help="Optional reminder email template to use for this activity type",
+    )
 
     def _get_reminder_offsets(self):
         """Hook for extensions"""

--- a/mail_activity_reminder/views/mail_activity_type.xml
+++ b/mail_activity_reminder/views/mail_activity_type.xml
@@ -12,6 +12,7 @@
         <field name="arch" type="xml">
             <field name="summary" position="after">
                 <field name="reminders" />
+                <field name="reminder_mail_template_id" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Depends on:
- [x] #1228

Ability to define your own message template on activity types.

Reminders will be sent grouped on these message templates. If no message template is defined, the generic one will be used as usual.