### PR TITLE
[16.0][FIX] mail_tracking: validated mailbox when computing isInFailedDiscuss

### DIFF
--- a/mail_tracking/static/src/models/message_view.esm.js
+++ b/mail_tracking/static/src/models/message_view.esm.js
@@ -18,7 +18,9 @@ registerPatch({
                     this.messageListViewItemOwner.messageListViewOwner.threadViewOwner
                         .threadViewer.discuss;
                 return Boolean(
-                    discuss && discuss.threadView.thread.mailbox.messagingAsFailed
+                    discuss &&
+                        discuss.threadView.thread.mailbox &&
+                        discuss.threadView.thread.mailbox.messagingAsFailed
                 );
             },
         }),


### PR DESCRIPTION
Related issue: https://github.com/OCA/social/issues/1235

The error is triggered because there is no mailbox assigned to threads when clicking on a channel, and is also triggered when checking direct messages. This fix addresses both cases.