### PR TITLE
[FIX] Take mimetype from the mimetype option (attrs)

### DIFF
--- a/mail_preview_base/static/src/js/preview.js
+++ b/mail_preview_base/static/src/js/preview.js
@@ -108,7 +108,7 @@ odoo.define("mail_preview_base.preview", function (require) {
         }),
         init: function () {
             this._super.apply(this, arguments);
-            this.mimetype_value = this.recordData.mimetype;
+            this.mimetype_value = this.recordData[this.attrs.mimetype];
         },
         _previewFile: function (event) {
             event.stopPropagation();

--- a/mail_preview_base/views/ir_attachment_view.xml
+++ b/mail_preview_base/views/ir_attachment_view.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='datas']" position="attributes">
                 <attribute name="widget">preview_binary</attribute>
+                <attribute name="mimetype">mimetype</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Not from the field named "mimetype"