### PR TITLE
[15.0][IMP] email_template_qweb Provide standard evaluation context

### DIFF
--- a/email_template_qweb/models/mail_template.py
+++ b/email_template_qweb/models/mail_template.py
@@ -30,9 +30,11 @@ class MailTemplate(models.Model):
                     not fields or "body_html" in fields
                 ):
                     for record in self_with_lang.env[self.model].browse(res_id):
-                        body_html = self_with_lang.body_view_id._render(
+                        values = self_with_lang._render_eval_context()
+                        values.update(
                             {"object": record, "email_template": self_with_lang}
                         )
+                        body_html = self_with_lang.body_view_id._render(values)
                         # Some wizards, like when sending a sales order, need this
                         # fix to display accents correctly
                         body_html = tools.ustr(body_html)


### PR DESCRIPTION
While using this module I have taken standard email template as a base (_sale.email_template_edi_sale_) and wanted to create my own slightly changed version. But rendering was crashing on things like **ctx** and **format_amount function** not being available.
So I went deep diving on how these things get present in standard templates and here's my attempt to make it work with this module as well. This is most probably relevant to all other versions as well. Any comments are welcome.