### PR TITLE
[fix] mail_layout_preview: no record to render

### DIFF
--- a/mail_layout_preview/wizard/email_template_preview.py
+++ b/mail_layout_preview/wizard/email_template_preview.py
@@ -16,7 +16,7 @@ class MailTemplatePreview(models.TransientModel):
     @api.depends("resource_ref", "model_id", "mail_template_id")
     def _compute_layout_preview_url(self):
         for rec in self:
-            if rec.mail_template_id:
+            if rec.mail_template_id and rec.resource_ref:
                 rec.layout_preview_url = self._url_pattern.format(
                     model=rec.model_id.model,
                     templ_id=rec.mail_template_id.id,


### PR DESCRIPTION
Fixing cases where the template doesn't have a record to render a preview.
Ported from: 
* https://github.com/OCA/social/pull/1143