### PR TITLE
[16.0][FIX] mail_tracking debug mode t-key error

### DIFF
--- a/mail_tracking/__manifest__.py
+++ b/mail_tracking/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Email tracking",
     "summary": "Email tracking system for all mails sent",
-    "version": "16.0.1.0.1",
+    "version": "16.0.1.0.2",
     "category": "Social Network",
     "website": "https://github.com/OCA/social",
     "author": ("Tecnativa, " "Odoo Community Association (OCA)"),

--- a/mail_tracking/static/src/components/failed_message/failed_message.xml
+++ b/mail_tracking/static/src/components/failed_message/failed_message.xml
@@ -25,7 +25,7 @@
                 <t
                     t-foreach="messageView.message.failedRecipients"
                     t-as="recipient"
-                    t-key="recipient_localId"
+                    t-key="recipient[0]"
                 >
                     <a
                         class="o_mail_action_tracking_partner"


### PR DESCRIPTION
Bug fix concerning the issue https://github.com/OCA/social/issues/1253

The t-key was 'undefined' in debug mode, I set it as the partner ID which is unique