### PR TITLE
[16.0][FIX] mail_debrand: fix translated branding

### DIFF
--- a/mail_debrand/README.rst
+++ b/mail_debrand/README.rst
@@ -91,6 +91,8 @@ Contributors
   * Pedro M. Baeza
   * João Marques
 
+* Stefan Rijnhart <stefan@opener.amsterdam>
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/mail_debrand/README.rst
+++ b/mail_debrand/README.rst
@@ -45,6 +45,15 @@ To use this module, you need to:
 * Send an email.
 * Nobody will know it comes from Odoo.
 
+Known issues / Roadmap
+======================
+
+Known issues:
+
+* Not all branding is removed from auth_signup's invitation email because it is a
+  longer, more complex snippet of HTML. Only the line containing the link to Odoo.com
+  is removed.
+
 Changelog
 =========
 

--- a/mail_debrand/models/mail_mail.py
+++ b/mail_debrand/models/mail_mail.py
@@ -11,5 +11,5 @@ class MailMail(models.AbstractModel):
     def _send_prepare_body(self):
         body_html = super()._send_prepare_body()
         return self.env["mail.render.mixin"].remove_href_odoo(
-            body_html or "", remove_parent=0, to_keep=self.body
+            body_html or "", to_keep=self.body
         )

--- a/mail_debrand/models/mail_render_mixin.py
+++ b/mail_debrand/models/mail_render_mixin.py
@@ -8,7 +8,7 @@ import re
 from lxml import etree, html
 from markupsafe import Markup
 
-from odoo import api, models, tools
+from odoo import api, models
 
 
 class MailRenderMixin(models.AbstractModel):
@@ -17,12 +17,14 @@ class MailRenderMixin(models.AbstractModel):
     def remove_href_odoo(self, value, remove_parent=True, to_keep=None):
         if len(value) < 20:
             return value
-        # value can be bytes type; ensure we get a proper string
+        # value can be bytes or markup; ensure we get a proper string and preserve type
+        back_to_bytes = False
+        back_to_markup = False
         if type(value) is bytes:
             back_to_bytes = True
             value = value.decode()
-        else:
-            back_to_bytes = False
+        if type(value) is Markup:
+            back_to_markup = True
         has_dev_odoo_link = re.search(
             r"<a\s(.*)dev\.odoo\.com", value, flags=re.IGNORECASE
         )
@@ -40,11 +42,11 @@ class MailRenderMixin(models.AbstractModel):
                     # anchor <a href odoo has a parent powered by that must be removed
                     parent.getparent().remove(parent)
                 else:
-                    # also here can be powered by
-                    if parent.tag == "td" and parent.getparent():
-                        parent.getparent().remove(parent)
-                    else:
-                        parent.remove(elem)
+                    previous = elem.getprevious()
+                    if previous is not None:
+                        # Remove "Powered by", "using" etc.
+                        previous.tail = ""
+                    parent.remove(elem)
             value = etree.tostring(
                 tree, pretty_print=True, method="html", encoding="unicode"
             )
@@ -52,6 +54,8 @@ class MailRenderMixin(models.AbstractModel):
                 value = value.replace("<body_msg></body_msg>", to_keep)
         if back_to_bytes:
             value = value.encode()
+        elif back_to_markup:
+            value = Markup(value)
         return value
 
     @api.model
@@ -94,17 +98,3 @@ class MailRenderMixin(models.AbstractModel):
             orginal_rendered[key] = self.remove_href_odoo(orginal_rendered[key])
 
         return orginal_rendered
-
-    def _replace_local_links(self, html, base_url=None):
-        message = super()._replace_local_links(html, base_url=base_url)
-
-        wrapper = Markup if isinstance(message, Markup) else str
-        message = tools.ustr(message)
-        if isinstance(message, Markup):
-            wrapper = Markup
-
-        message = re.sub(
-            r"""(Powered by\s(.*)Odoo</a>)""", "<div>&nbsp;</div>", message
-        )
-
-        return wrapper(message)

--- a/mail_debrand/models/mail_render_mixin.py
+++ b/mail_debrand/models/mail_render_mixin.py
@@ -14,7 +14,7 @@ from odoo import api, models
 class MailRenderMixin(models.AbstractModel):
     _inherit = "mail.render.mixin"
 
-    def remove_href_odoo(self, value, remove_parent=True, to_keep=None):
+    def remove_href_odoo(self, value, to_keep=None):
         if len(value) < 20:
             return value
         # value can be bytes or markup; ensure we get a proper string and preserve type
@@ -38,15 +38,13 @@ class MailRenderMixin(models.AbstractModel):
             odoo_anchors = tree.xpath('//a[contains(@href,"www.odoo.com")]')
             for elem in odoo_anchors:
                 parent = elem.getparent()
-                if remove_parent and parent.getparent() is not None:
-                    # anchor <a href odoo has a parent powered by that must be removed
-                    parent.getparent().remove(parent)
-                else:
-                    previous = elem.getprevious()
-                    if previous is not None:
-                        # Remove "Powered by", "using" etc.
-                        previous.tail = ""
-                    parent.remove(elem)
+                # Remove "Powered by", "using" etc.
+                previous = elem.getprevious()
+                if previous is not None:
+                    previous.tail = ""
+                elif parent.text:
+                    parent.text = ""
+                parent.remove(elem)
             value = etree.tostring(
                 tree, pretty_print=True, method="html", encoding="unicode"
             )

--- a/mail_debrand/readme/CONTRIBUTORS.rst
+++ b/mail_debrand/readme/CONTRIBUTORS.rst
@@ -4,3 +4,5 @@
 
   * Pedro M. Baeza
   * João Marques
+
+* Stefan Rijnhart <stefan@opener.amsterdam>

--- a/mail_debrand/readme/ROADMAP.rst
+++ b/mail_debrand/readme/ROADMAP.rst
@@ -1,0 +1,5 @@
+Known issues:
+
+* Not all branding is removed from auth_signup's invitation email because it is a
+  longer, more complex snippet of HTML. Only the line containing the link to Odoo.com
+  is removed.

--- a/mail_debrand/static/description/index.html
+++ b/mail_debrand/static/description/index.html
@@ -375,16 +375,17 @@ specifically the ‘Powered by Odoo’</p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
-<li><a class="reference internal" href="#changelog" id="toc-entry-2">Changelog</a><ul>
-<li><a class="reference internal" href="#section-1" id="toc-entry-3">15.0.1.2.3 (2022-07-19)</a></li>
-<li><a class="reference internal" href="#section-2" id="toc-entry-4">12.0.1.0.0 (2018-11-06)</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#changelog" id="toc-entry-3">Changelog</a><ul>
+<li><a class="reference internal" href="#section-1" id="toc-entry-4">15.0.1.2.3 (2022-07-19)</a></li>
+<li><a class="reference internal" href="#section-2" id="toc-entry-5">12.0.1.0.0 (2018-11-06)</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-5">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-6">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-7">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-8">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-9">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-6">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-7">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-8">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-9">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-10">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -398,24 +399,33 @@ specifically the ‘Powered by Odoo’</p>
 <li>Nobody will know it comes from Odoo.</li>
 </ul>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h1>
+<p>Known issues:</p>
+<ul class="simple">
+<li>Not all branding is removed from auth_signup’s invitation email because it is a
+longer, more complex snippet of HTML. Only the line containing the link to Odoo.com
+is removed.</li>
+</ul>
+</div>
 <div class="section" id="changelog">
-<h1><a class="toc-backref" href="#toc-entry-2">Changelog</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Changelog</a></h1>
 <div class="section" id="section-1">
-<h2><a class="toc-backref" href="#toc-entry-3">15.0.1.2.3 (2022-07-19)</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-4">15.0.1.2.3 (2022-07-19)</a></h2>
 <ul class="simple">
 <li>[FIX] <a class="reference external" href="https://github.com/OCA/social/issues/915">https://github.com/OCA/social/issues/915</a></li>
 <li>[FIX] <a class="reference external" href="https://github.com/OCA/social/issues/936">https://github.com/OCA/social/issues/936</a></li>
 </ul>
 </div>
 <div class="section" id="section-2">
-<h2><a class="toc-backref" href="#toc-entry-4">12.0.1.0.0 (2018-11-06)</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">12.0.1.0.0 (2018-11-06)</a></h2>
 <ul class="simple">
 <li>[NEW] Initial V12 version. Complete rewrite from v11.</li>
 </ul>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-5">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-6">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/social/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -423,9 +433,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-6">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-7">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-7">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-8">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 <li>ForgeFlow</li>
@@ -435,7 +445,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-8">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-9">Contributors</a></h2>
 <ul class="simple">
 <li>Lois Rilo &lt;<a class="reference external" href="mailto:lois.rilo&#64;forgeflow.com">lois.rilo&#64;forgeflow.com</a>&gt;</li>
 <li>Graeme Gellatly &lt;<a class="reference external" href="mailto:graeme&#64;o4sb.com">graeme&#64;o4sb.com</a>&gt;</li>
@@ -448,7 +458,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-9">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-10">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/mail_debrand/static/description/index.html
+++ b/mail_debrand/static/description/index.html
@@ -444,6 +444,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>João Marques</li>
 </ul>
 </li>
+<li>Stefan Rijnhart &lt;<a class="reference external" href="mailto:stefan&#64;opener.amsterdam">stefan&#64;opener.amsterdam</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/mail_debrand/tests/__init__.py
+++ b/mail_debrand/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_mail_debrand
 from . import test_mail_debrand_digest
+from . import test_mail_debrand_signup

--- a/mail_debrand/tests/test_mail_debrand_signup.py
+++ b/mail_debrand/tests/test_mail_debrand_signup.py
@@ -1,0 +1,28 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("-at_install", "post_install")
+class TestMailDebrandSignup(TransactionCase):
+    def _has_module(self):
+        module = self.env["ir.module.module"].search([("name", "=", "auth_signup")])
+        self.assertTrue(module)
+        return module.state == "installed"
+
+    def test_debrand_auth_signup_set_password_email(self):
+        if not self._has_module():
+            return
+        template = self.env.ref(
+            "auth_signup.set_password_email",
+        )
+        self.assertIn("www.odoo.com", template.body_html)
+        self.assertIn("Accept invitation", template.body_html)
+        self.assertIn("to discover the tool", template.body_html)
+
+        mail_id = template.send_mail(self.env.user.id)
+        body = self.env["mail.mail"].browse(mail_id).body_html
+
+        # The essential button is preserved
+        self.assertIn("Accept invitation", body)
+        # But at least part of the branding was removed
+        self.assertNotIn("www.odoo.com", body)
+        self.assertNotIn("to discover the tool", body)


### PR DESCRIPTION
* Remove adjacent text like 'Powered by' regardless of language
* Don't remove access link in signup email
* Convert transformed Markup content back to Markup
* The result of `mail.template`'s `_render_mail` is a dictionary, not a rendered view
* Refactor tests to use `SetUpClass`