### PR TITLE
[16.0][FIX] mail_composer_cc_bcc: make test work in the new year

### DIFF
--- a/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
+++ b/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
@@ -42,8 +42,12 @@ class TestMailCcBcc(TestMailComposer):
 
     def open_invoice_mail_composer_form(self):
         # Use form to populate data
-        for_name = [("name", "=", "INV/2023/00003")]
+        for_name = [("name", "like", "%INV/20__/00003")]
         self.test_invoice = test_record = self.env["account.move"].search(for_name)
+        self.assertTrue(
+            self.test_invoice,
+            "Test setup did not succeeed. Invoice not found.",
+        )
         ctx = {
             "active_ids": test_record.ids,
             "default_model": "account.move",

--- a/mass_mailing_unique/tests/test_mass_mailing_unique.py
+++ b/mass_mailing_unique/tests/test_mass_mailing_unique.py
@@ -11,7 +11,7 @@ from odoo.tools import mute_logger
 from ..hooks import pre_init_hook
 
 
-class TestMassMailingUnique(common.SavepointCase):
+class TestMassMailingUnique(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -34,7 +34,6 @@ class TestMassMailingUnique(common.SavepointCase):
         )
         # Create another list with the same exact name
         self.env["mailing.list"].create({"name": self.mailing_list.name})
-        self.env["mailing.list"].flush()
         with self.assertRaises(ValidationError):
             pre_init_hook(self.env.cr)
 


### PR DESCRIPTION
Fixes
```
 2024-01-04 08:40:16,443 320 ERROR odoo odoo.addons.mail_composer_cc_bcc.tests.test_mail_cc_bcc: ERROR: TestMailCcBcc.test_invoice_mail_cc_bcc
Traceback (most recent call last):
  File "/__w/social/social/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py", line 176, in test_invoice_mail_cc_bcc
    form = self.open_invoice_mail_composer_form()
  File "/__w/social/social/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py", line 53, in open_invoice_mail_composer_form
    form = Form(self.env["account.invoice.send"].with_context(**ctx))
  File "/opt/odoo/odoo/tests/common.py", line 1990, in __init__
    self._init_from_defaults(self._model)
  File "/opt/odoo/odoo/tests/common.py", line 2116, in _init_from_defaults
    self._perform_onchange([])
  File "/opt/odoo/odoo/tests/common.py", line 2405, in _perform_onchange
    result = record.onchange(self._onchange_values(), fields, spec)
  File "/opt/odoo/odoo/models.py", line 6438, in onchange
    defaults = self.default_get(missing_names)
  File "/opt/odoo/addons/account/wizard/account_invoice_send.py", line 40, in default_get
    raise UserError(_("You can only send invoices."))
odoo.exceptions.UserError: You can only send invoices.
```
https://github.com/OCA/social/actions/runs/7407270551/job/20153152461#step:8:818