### PR TITLE
[14.0][ADD] email_template_configurator

### DIFF
--- a/email_template_configurator/__init__.py
+++ b/email_template_configurator/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/email_template_configurator/__manifest__.py
+++ b/email_template_configurator/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Email Template Configurator",
+    "summary": """
+        Simplifies use of placeholders in email templates""",
+    "version": "14.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/social",
+    "depends": [
+        "mail",
+    ],
+    "data": [
+        "security/groups.xml",
+        "security/email_template_placeholder.xml",
+        "views/email_template_placeholder.xml",
+        "views/mail_template.xml",
+    ],
+    "installable": True,
+}

--- a/email_template_configurator/models/__init__.py
+++ b/email_template_configurator/models/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import email_template_placeholder
+from . import mail_template

--- a/email_template_configurator/models/email_template_placeholder.py
+++ b/email_template_configurator/models/email_template_placeholder.py
@@ -1,0 +1,27 @@
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class EmailTemplatePlaceholder(models.Model):
+
+    _name = "email.template.placeholder"
+    _description = "Email Template Placeholder"
+
+    name = fields.Char(
+        required=True,
+    )
+    model_id = fields.Many2one(
+        comodel_name="ir.model",
+        string="Model",
+        required=True,
+        ondelete="cascade",
+    )
+    placeholder = fields.Char(
+        required=True,
+        default="${object.}",
+    )
+    active = fields.Boolean(
+        default=True,
+    )

--- a/email_template_configurator/models/mail_template.py
+++ b/email_template_configurator/models/mail_template.py
@@ -1,0 +1,22 @@
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class MailTemplate(models.Model):
+
+    _inherit = "mail.template"
+
+    # Fake field for auto-completing placeholder
+    placeholder_id = fields.Many2one(
+        comodel_name="email.template.placeholder",
+        string="Placeholder",
+    )
+    placeholder_value = fields.Char()
+
+    @api.onchange("placeholder_id")
+    def _onchange_placeholder_id(self):
+        for tmpl in self:
+            if tmpl.placeholder_id:
+                tmpl.placeholder_value = tmpl.placeholder_id.placeholder

--- a/email_template_configurator/readme/CONFIGURATION.rst
+++ b/email_template_configurator/readme/CONFIGURATION.rst
@@ -1,0 +1,4 @@
+To configure this module, you need to:
+
+1. Add your user to the "Template Placeholders Manager" group
+2. Go to Settings → Technical → Email → Template Placeholders to create new predefined placeholders

--- a/email_template_configurator/readme/CONTRIBUTORS.rst
+++ b/email_template_configurator/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Marie Lejeune (ACSONE) <marie.lejeune@acsone.eu>

--- a/email_template_configurator/readme/DESCRIPTION.rst
+++ b/email_template_configurator/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module implements a simpler interface for the email template dynamic fields. A configurator allows the creation of predefined named replacement strings, which can then be selected in the template.
+

--- a/email_template_configurator/readme/USAGE.rst
+++ b/email_template_configurator/readme/USAGE.rst
@@ -1,0 +1,3 @@
+To use this module, you need to:
+
+1. Create a new mail template and go to the Configured Placeholders tab

--- a/email_template_configurator/security/email_template_placeholder.xml
+++ b/email_template_configurator/security/email_template_placeholder.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2018 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.model.access" id="email_template_placeholder_access_user">
+        <field name="name">email.template.placeholder access user</field>
+        <field name="model_id" ref="model_email_template_placeholder" />
+        <field name="group_id" ref="base.group_user" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+
+    <record model="ir.model.access" id="email_template_placeholder_access_manager">
+        <field name="name">email.template.placeholder access manager</field>
+        <field name="model_id" ref="model_email_template_placeholder" />
+        <field name="group_id" ref="group_email_template_placeholders_manager" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_unlink" eval="1" />
+    </record>
+
+
+
+</odoo>

--- a/email_template_configurator/security/groups.xml
+++ b/email_template_configurator/security/groups.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2018 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="res.groups" id="group_mail_template_manager">
+        <field name="name">Mail template: manager</field>
+        <field name="category_id" ref="base.module_category_hidden" />
+        <field
+            name="users"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
+    </record>
+
+    <record id="group_email_template_placeholders_manager" model="res.groups">
+        <field name="name">Template Placeholders Manager</field>
+    </record>
+
+    <record model="res.groups" id="base.group_system">
+        <field
+            name="implied_ids"
+            eval="[
+            (4, ref('group_email_template_placeholders_manager')),
+        ]"
+        />
+    </record>
+
+</odoo>

--- a/email_template_configurator/tests/__init__.py
+++ b/email_template_configurator/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_configurator

--- a/email_template_configurator/tests/test_configurator.py
+++ b/email_template_configurator/tests/test_configurator.py
@@ -1,0 +1,37 @@
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestConfigurator(TransactionCase):
+    def test_configurator(self):
+        placeholder_obj = self.env["email.template.placeholder"]
+        template_obj = self.env["mail.template"]
+        partner_model_id = self.ref("base.model_res_partner")
+        placeholders_vals = [
+            {
+                "name": "Salesperson name",
+                "model_id": partner_model_id,
+                "placeholder": "${object.user_id.partner_id.name}",
+            },
+            {
+                "name": "Company vat",
+                "model_id": partner_model_id,
+                "placeholder": "${object.parent_id.vat}",
+            },
+        ]
+        for vals in placeholders_vals:
+            placeholder = placeholder_obj.create(vals)
+            res = template_obj.onchange(
+                {
+                    "placeholder_id": placeholder.id,
+                    "placeholder_value": False,
+                },
+                "placeholder_id",
+                {
+                    "placeholder_id": "1",
+                    "placeholder_value": False,
+                },
+            )["value"]
+            self.assertEqual(res["placeholder_value"], vals["placeholder"])

--- a/email_template_configurator/views/email_template_placeholder.xml
+++ b/email_template_configurator/views/email_template_placeholder.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2018 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="email_template_placeholder_form_view">
+        <field
+            name="name"
+        >email.template.placeholder.form (in email_template_configurator)</field>
+        <field name="model">email.template.placeholder</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button
+                            name="toggle_active"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-archive"
+                            groups="email_template_configurator.group_email_template_placeholders_manager"
+                        >
+                            <field
+                                name="active"
+                                widget="boolean_button"
+                                options="{&quot;terminology&quot;: &quot;archive&quot;}"
+                            />
+                        </button>
+                    </div>
+                    <div class="oe_title">
+                        <label for="name" class="oe_edit_only" />
+                        <h1><field name="name" /></h1>
+                    </div>
+                    <group>
+                        <field name="model_id" />
+                        <field name="placeholder" />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="email_template_placeholder_search_view">
+        <field
+            name="name"
+        >email.template.placeholder.search (in email_template_configurator)</field>
+        <field name="model">email.template.placeholder</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name" />
+                <field name="model_id" />
+                <group>
+                    <filter
+                        name="model_id"
+                        string="Model"
+                        domain="[]"
+                        context="{'group_by':'model_id'}"
+                    />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="email_template_placeholder_tree_view">
+        <field
+            name="name"
+        >email.template.placeholder.tree (in email_template_configurator)</field>
+        <field name="model">email.template.placeholder</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name" />
+                <field name="model_id" />
+                <field name="placeholder" />
+            </tree>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="email_template_placeholder_act_window">
+        <field name="name">Template Placeholders</field>
+        <field name="res_model">email.template.placeholder</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[]</field>
+        <field name="context">{}</field>
+    </record>
+
+    <record model="ir.ui.menu" id="email_template_placeholder_menu">
+        <field name="name">Template Placeholders</field>
+        <field name="parent_id" ref="base.menu_email" />
+        <field name="action" ref="email_template_placeholder_act_window" />
+        <field name="sequence" eval="22" />
+    </record>
+
+</odoo>

--- a/email_template_configurator/views/mail_template.xml
+++ b/email_template_configurator/views/mail_template.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2018 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="email_template_form_view">
+        <field name="name">mail.template.form (in email_template_configurator)</field>
+        <field name="model">mail.template</field>
+        <field name="inherit_id" ref="mail.email_template_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//page[.//field[@name='model_object_field']]"
+                position="attributes"
+            >
+                <attribute
+                    name="groups"
+                >email_template_configurator.group_email_template_placeholders_manager</attribute>
+            </xpath>
+            <page name="email_configuration" position="attributes">
+                <attribute name="groups">
+                    email_template_configurator.group_mail_template_manager
+                </attribute>
+            </page>
+            <page name="advanced_settings" position="attributes">
+                <attribute name="groups">
+                    email_template_configurator.group_mail_template_manager
+                </attribute>
+            </page>
+            <xpath expr="//page[.//field[@name='model_object_field']]" position="after">
+                <page name="configured_placeholders" string="Configured Placeholders">
+                    <group>
+                        <field
+                            name="placeholder_id"
+                            domain="[('model_id','=',model_id)]"
+                            options="{'no_quick_create':True,'no_create_edit':True}"
+                        />
+                        <field name="placeholder_value" />
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/email_template_configurator/odoo/addons/email_template_configurator
+++ b/setup/email_template_configurator/odoo/addons/email_template_configurator
@@ -1,0 +1,1 @@
+../../../../email_template_configurator

--- a/setup/email_template_configurator/setup.py
+++ b/setup/email_template_configurator/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module implements a simpler interface for the email template dynamic fields. A configurator allows the creation of predefined named replacement strings, which can then be selected in the template.

NB: This module works in production at Acsone since several years. :-)