### PR TITLE
mail_activity_team: Fix bug of the Team Activities filter.

### DIFF
--- a/mail_activity_team/models/mail_activity.py
+++ b/mail_activity_team/models/mail_activity.py
@@ -26,7 +26,9 @@ class MailActivity(models.Model):
     )
 
     team_id = fields.Many2one(
-        comodel_name="mail.activity.team", default=lambda s: s._get_default_team_id()
+        comodel_name="mail.activity.team",
+        default=lambda s: s._get_default_team_id(),
+        index=True,
     )
 
     @api.onchange("user_id")

--- a/mail_activity_team/models/mail_activity_mixin.py
+++ b/mail_activity_team/models/mail_activity_mixin.py
@@ -21,27 +21,13 @@ class MailActivityMixin(models.AbstractModel):
     def _search_my_activity_date_deadline(self, operator, operand):
         if not self._context.get("team_activities", False):
             return super()._search_my_activity_date_deadline(operator, operand)
-        query = """
-        SELECT res_users_id
-        FROM mail_activity_team_users_rel
-        WHERE mail_activity_team_id IN (
-            SELECT mail_activity_team_id
-            FROM mail_activity_team_users_rel
-            WHERE res_users_id = %(user_id)s)
-        """
-        user = self.env.uid
-        self.env.cr.execute(
-            query,
-            {
-                "user_id": user,
-            },
-        )
-        users = [row[0] for row in self.env.cr.fetchall()]
         activity_ids = self.env["mail.activity"]._search(
             [
                 ("date_deadline", operator, operand),
                 ("res_model", "=", self._name),
-                ("user_id", "in", users),
+                "|",
+                ("user_id", "=", self.env.user.id),
+                ("team_id", "in", self.env.user.activity_team_ids.ids),
             ]
         )
         return [("activity_ids", "in", activity_ids)]
@@ -96,3 +82,19 @@ class MailActivityMixin(models.AbstractModel):
             note=note,
             **act_values
         )
+
+    @api.depends(
+        "activity_ids.date_deadline", "activity_ids.user_id", "activity_ids.team_id"
+    )
+    @api.depends_context("uid")
+    def _compute_my_activity_date_deadline(self):
+        for record in self:
+            record.my_activity_date_deadline = next(
+                (
+                    activity.date_deadline
+                    for activity in record.activity_ids
+                    if activity.user_id.id == record.env.uid
+                    or activity.team_id in record.env.user.activity_team_ids
+                ),
+                False,
+            )

--- a/mail_activity_team/tests/test_mail_activity_team.py
+++ b/mail_activity_team/tests/test_mail_activity_team.py
@@ -1,6 +1,8 @@
 # Copyright 2018-22 ForgeFlow S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from datetime import date
+
 from odoo.exceptions import ValidationError
 from odoo.tests.common import Form, TransactionCase
 
@@ -318,3 +320,24 @@ class TestMailActivityTeam(TransactionCase):
         action.activity_team_id = self.team2
         action.with_context(active_model=partner._name, active_ids=partner.ids).run()
         self.assertEqual(partner.activity_ids[-1].team_id, self.team2)
+
+    def test_my_activity_date_deadline(self):
+        """This test case checks
+        - if the team activities are properly filtered
+        """
+        today = date.today()
+        self.act2.write(
+            {
+                "user_id": False,
+                "team_id": self.team1.id,
+                "date_deadline": today,
+            }
+        )
+        partner = (
+            self.env["res.partner"]
+            .with_context(team_activities=True)
+            .with_user(self.employee.id)
+            .search([("my_activity_date_deadline", "=", today)])
+        )
+        self.assertEqual(partner, self.partner_client)
+        self.assertEqual(partner.my_activity_date_deadline, today)


### PR DESCRIPTION
Bugfix: If you go to the tray menu via the activities and then display Late/Today/Future activities, activities that are only assigned to the team and not to the user are not displayed. 

Reproduce:
. create a new team
. add user/s to the team
. create an Activity for today for the team, but leave the "Team user" field empty
. go to the Tray menu
. click Team Activities
. click Today
Before: nothing was shown
Now: the related object from the team today's activity is shown