### PR TITLE
mail_activity_board: fix limit issue on list view

### DIFF
--- a/mail_activity_board/models/mail_activity.py
+++ b/mail_activity_board/models/mail_activity.py
@@ -81,3 +81,25 @@ class MailActivity(models.Model):
                 continue
             allowed_ids |= self._find_allowed_model_wise(doc_model, doc_dict)
         return allowed_ids
+
+    @api.model
+    def _search(
+        self,
+        args,
+        offset=0,
+        limit=None,
+        order=None,
+        count=False,
+        access_rights_uid=None,
+    ):
+        result = super()._search(
+            args,
+            offset=offset,
+            limit=None,
+            order=order,
+            count=count,
+            access_rights_uid=access_rights_uid,
+        )
+        if limit is not None:
+            result = result[:limit]
+        return result

--- a/mail_activity_board/models/mail_activity.py
+++ b/mail_activity_board/models/mail_activity.py
@@ -92,6 +92,18 @@ class MailActivity(models.Model):
         count=False,
         access_rights_uid=None,
     ):
+        # The mail.activity model has a custom search view which removes records from
+        # the search based on the access rules of the related res_model/res_id records.
+        # This has a side effect when search() is called with a limit, as is the case
+        # for instance when displaying mail.activity records in list view, which is
+        # enabled by this module: in some cases, the list will be truncated and the
+        # pager will not work, and grouping by assigned users will show for instance
+        # 100 records for a given user, but filtering on the same user will only
+        # display a total number of 70 records which is very confusing for the users.
+        #
+        # The fix consists in using an unlimited search when calling super()._search
+        # and applying the limit after the access rights filtering has been applied.
+
         result = super()._search(
             args,
             offset=offset,


### PR DESCRIPTION
The mail.activity model has a custom search view which removes records from the search based on the access rules of the related res_model/res_id records. This has a side effect when search() is called with a limit, as is the case for instance when displaying mail.activity records in list view, which is enabled by this module: in some cases, the list will be truncated and the pager will not work, and grouping by assigned users will show for instance 100 records for a given user, but filtering on the same user will only display a total number of 70 records which is very confusing for the users.

The fix consists in using an unlimited search when calling super()._search and applying the limit after the access rights filtering has been applied.