### PR TITLE
[16.0][IMP] mail_debrand: keep the decoration (grey border) where the branding was

### DIFF
--- a/mail_debrand/models/mail_render_mixin.py
+++ b/mail_debrand/models/mail_render_mixin.py
@@ -41,9 +41,9 @@ class MailRenderMixin(models.AbstractModel):
                 # Remove "Powered by", "using" etc.
                 previous = elem.getprevious()
                 if previous is not None:
-                    previous.tail = ""
+                    previous.tail = etree.CDATA("&nbsp;")
                 elif parent.text:
-                    parent.text = ""
+                    parent.text = etree.CDATA("&nbsp;")
                 parent.remove(elem)
             value = etree.tostring(
                 tree, pretty_print=True, method="html", encoding="unicode"


### PR DESCRIPTION
when using `mail.mail_notification_light` as a wrapper

Before:
![image](https://github.com/OCA/social/assets/1033124/105dbb27-dda1-4cea-ab21-1f99f6fd25bc)

After:
![image](https://github.com/OCA/social/assets/1033124/04186409-ad62-48be-9683-8be36635e2ad)
