### PR TITLE
[16.0] [IMP] mail_activity_done: exclude completed activities from progress bar

### DIFF
--- a/mail_activity_done/models/mail_activity.py
+++ b/mail_activity_done/models/mail_activity.py
@@ -1,6 +1,7 @@
 # Copyright 2018-22 ForgeFlow <http://www.forgeflow.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 from odoo import api, fields, models
+from odoo.osv import expression
 
 delete_sentinel = object()
 
@@ -83,3 +84,11 @@ class MailActivityMixin(models.AbstractModel):
     activity_ids = fields.One2many(
         domain=lambda self: [("res_model", "=", self._name), ("active", "=", True)]
     )
+
+    def _read_progress_bar(self, domain, group_by, progress_bar):
+        """
+        Exclude completed activities from progress bar result.
+        Pass an extra domain to super to filter out records with only done activities.
+        """
+        domain = expression.AND([domain, [("activity_ids.done", "=", False)]])
+        return super()._read_progress_bar(domain, group_by, progress_bar)

--- a/mail_activity_done/tests/test_mail_activity_done.py
+++ b/mail_activity_done/tests/test_mail_activity_done.py
@@ -41,3 +41,20 @@ class TestMailActivityDoneMethods(TransactionCase):
         self.assertEqual(
             len(act_count), 1, "Number of activities should be equal to one"
         )
+
+    def test_read_progress_bar(self):
+        res_partner = self.env["res.partner"].browse(self.act1.res_model_id)
+        params = {
+            "domain": [],
+            "group_by": "id",
+            "progress_bar": {
+                "field": "activity_state"
+            }
+        }
+        result = res_partner._read_progress_bar(**params)
+        self.assertEqual(result[0]["__count"], 1)
+
+        self.act1._action_done()
+        self.assertEqual(self.act1.state, "done")
+        result = res_partner._read_progress_bar(**params)
+        self.assertEqual(len(result), 0)


### PR DESCRIPTION
Completed activities are displayed in the progress bar even if they are marked as DONE.
This fix filters out all completed activities from progress bar result.