### PR TITLE
[FIX] mail_drop_target: remove carriage returns and newlines from msg id

### DIFF
--- a/mail_drop_target/models/mail_thread.py
+++ b/mail_drop_target/models/mail_thread.py
@@ -103,7 +103,7 @@ class MailThread(models.AbstractModel):
             # prefer html bodies to text
             msg_body,
             email_cc=message_msg.cc,
-            message_id=message_id,
+            message_id=message_id.strip(),
             attachments=[
                 (attachment.longFilename, attachment.data, attachment.mimetype)
                 for attachment in message_msg.attachments


### PR DESCRIPTION

sometimes message_id has format:
 '\r\n <AS4PR02MA8445729A3270B2F11E55EBD29B2A2@XS4PR02MBBX.eurprd.prod.outlook.com>'
This causes returning ValueError: Header values may not contain linefeed or carriage return characters