### PR TITLE
[16.0][FIX] mass_mailing_custom_unsubscribe: fix warning from override create method

### DIFF
--- a/mass_mailing_custom_unsubscribe/models/mail_unsubscription.py
+++ b/mass_mailing_custom_unsubscribe/models/mail_unsubscription.py
@@ -86,12 +86,13 @@ class MailUnsubscription(models.Model):
                     _("Please provide details on why you are unsubscribing.")
                 )
 
-    @api.model
-    def create(self, vals):
-        # No reasons for subscriptions
-        if vals.get("action") in {"subscription", "blacklist_rm"}:
-            vals = dict(vals, reason_id=False, details=False)
-        return super().create(vals)
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            # No reasons for subscriptions
+            if vals.get("action") in {"subscription", "blacklist_rm"}:
+                vals = dict(vals, reason_id=False, details=False)
+        return super().create(vals_list)
 
 
 class MailUnsubscriptionReason(models.Model):


### PR DESCRIPTION
Fixes an issue where the odoo.addons.mass_mailing_custom_unsubscribe.models.mail_unsubscribe model was not correctly overriding the create method to handle batch operations. The create method has now been adapted to handle batch record creation, ensuring that it works correctly in all situations.

cc @Tecnativa TT44333

@pedrobaeza @carolinafernandez-tecnativa please review 