### PR TITLE
[14.0][FW-PORT][IMP] mail_activity_board: Add action buttons in kanban view

### DIFF
--- a/mail_activity_board/views/mail_activity_view.xml
+++ b/mail_activity_board/views/mail_activity_view.xml
@@ -175,9 +175,11 @@
                                     </strong>
                                 </div>
                                 <div>
-                                    <strong class="o_kanban_record_title"><field
-                                            name="res_name"
-                                        /></strong>
+                                    <strong class="o_kanban_record_title">
+                                        <a name="open_origin" type="object">
+                                            <field name="res_name" />
+                                        </a>
+                                    </strong>
                                 </div>
 
                                 <div class="o_kanban_record_bottom">
@@ -234,6 +236,29 @@
                                         </t>
                                     </div>
                                     <div class="oe_kanban_bottom_right">
+                                        <span>
+                                            <a name="action_done" type="object"><i
+                                                    class="fa fa-check"
+                                                    role="img"
+                                                    aria-label="Mark as Done"
+                                                    title="Mark as Done"
+                                                /></a>
+                                            <a
+                                                name="action_done_schedule_next"
+                                                type="object"
+                                            ><i
+                                                    class="fa fa-undo"
+                                                    role="img"
+                                                    aria-label="Done &amp; Schedule Next"
+                                                    title="Done &amp; Schedule Next"
+                                                /></a>
+                                            <a name="unlink" type="object"><i
+                                                    class="fa fa-times"
+                                                    role="img"
+                                                    aria-label="Cancel"
+                                                    title="Cancel"
+                                                /></a>
+                                        </span>
                                         <img
                                             t-att-src="kanban_image('res.users', 'image_128', record.user_id.raw_value)"
                                             t-att-title="record.user_id.value"


### PR DESCRIPTION
Adds buttons to mark activity as done / mark as done + schedule next (as in activity window)

This is a forward-port of v12 PR https://github.com/OCA/social/pull/771