### PR TITLE
[17.0][IMP] mail_activity_team: filter fix, follow-up comments

### DIFF
--- a/mail_activity_team/models/mail_activity.py
+++ b/mail_activity_team/models/mail_activity.py
@@ -26,7 +26,9 @@ class MailActivity(models.Model):
     )
 
     team_id = fields.Many2one(
-        comodel_name="mail.activity.team", default=lambda s: s._get_default_team_id()
+        comodel_name="mail.activity.team",
+        default=lambda s: s._get_default_team_id(),
+        index=True,
     )
 
     @api.onchange("user_id")

--- a/mail_activity_team/models/mail_activity_mixin.py
+++ b/mail_activity_team/models/mail_activity_mixin.py
@@ -94,7 +94,7 @@ class MailActivityMixin(models.AbstractModel):
                     activity.date_deadline
                     for activity in record.activity_ids
                     if activity.user_id.id == record.env.uid
-                    or activity.team_id.id in record.env.user.activity_team_ids.ids
+                    or activity.team_id in record.env.user.activity_team_ids
                 ),
                 False,
             )

--- a/mail_activity_team/tests/test_mail_activity_team.py
+++ b/mail_activity_team/tests/test_mail_activity_team.py
@@ -322,6 +322,9 @@ class TestMailActivityTeam(TransactionCase):
         self.assertEqual(partner.activity_ids[-1].team_id, self.team2)
 
     def test_my_activity_date_deadline(self):
+        """This test case checks
+        - if the team activities are properly filtered
+        """
         today = date.today()
         self.act2.write(
             {


### PR DESCRIPTION
Taken from the 16.0 branch after the merge of https://github.com/OCA/social/pull/1280 which was picked for the migration of this module for 17.0 in an earlier stage.