### PR TITLE
[IMP] mail_post_defer: defer more mails

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -15,7 +15,8 @@ odoo_test_flavor: Both
 odoo_version: 16.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
-rebel_module_groups: []
+rebel_module_groups:
+- mail_post_defer
 repo_description: '{''TODO'': ''add repo description.''}'
 repo_name: social
 repo_slug: social

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,17 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
+            include: "mail_post_defer"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest
+            include: "mail_post_defer"
+            name: test with OCB
+            makepot: "true"
+          - container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
+            exclude: "mail_post_defer"
+            name: test with Odoo
+          - container: ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest
+            exclude: "mail_post_defer"
             name: test with OCB
             makepot: "true"
     services:
@@ -49,6 +58,9 @@ jobs:
           POSTGRES_DB: odoo
         ports:
           - 5432:5432
+    env:
+      INCLUDE: "${{ matrix.include }}"
+      EXCLUDE: "${{ matrix.exclude }}"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/mail_post_defer/models/__init__.py
+++ b/mail_post_defer/models/__init__.py
@@ -1,2 +1,3 @@
 from . import mail_message
+from . import mail_message_schedule
 from . import mail_thread

--- a/mail_post_defer/models/mail_message_schedule.py
+++ b/mail_post_defer/models/mail_message_schedule.py
@@ -1,0 +1,15 @@
+# Copyright 2024 Moduon Team S.L. <info@moduon.team>
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import models
+
+
+class MailMessageSchedule(models.Model):
+    _inherit = "mail.message.schedule"
+
+    def _send_notifications(self, default_notify_kwargs=None):
+        """Avoid deferring notifications when they should be sent."""
+        _self = self.with_context(mail_defer_seconds=0)
+        return super(MailMessageSchedule, _self)._send_notifications(
+            default_notify_kwargs=default_notify_kwargs
+        )

--- a/mail_post_defer/static/description/index.html
+++ b/mail_post_defer/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -466,7 +466,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
In the previous version of this module, only emails sent through the chatter were explicitly deferred. However, there are more mails that are auto-generated by Odoo and could benefit a lot from the deferring system. One of such cases is the automatic assignation mail.

To cover that and more cases, now the auto-deferring is done at a lower level. If we get some hint that the mail sending is forced, or that it's already deferred, we skip the machinery. If we get nothing about all that, then we just add our defaults to avoid force-sending and defer by default.

The result is that more Odoo internal systems will use the mail queue, and thus there'll be less blocking.

As an exception, when running `_send_notifications()`, we force-disable the deferring system. That is executed by a cron, or by the user when force-sending a notification. So, only in that case the queue should be skipped by default.

@moduon MT-6204