### PR TITLE
[FIX] mail_post_defer: notify from non-thread models and to author

### DIFF
--- a/mail_post_defer/models/mail_message_schedule.py
+++ b/mail_post_defer/models/mail_message_schedule.py
@@ -13,3 +13,14 @@ class MailMessageSchedule(models.Model):
         return super(MailMessageSchedule, _self)._send_notifications(
             default_notify_kwargs=default_notify_kwargs
         )
+
+    def _group_by_model(self):
+        """Make sure only mail.thread children are grouped with model."""
+        result = super()._group_by_model()
+        for model, records in result.copy().items():
+            # Move records without mail.thread mixin to a False key
+            if model and not hasattr(model, "_notify_thread"):
+                result.pop(model)
+                result.setdefault(False, self.browse())
+                result[False] += records
+        return result


### PR DESCRIPTION
In some places of Odoo, there are direct calls to `self.env["mail.thread"].message_notify()` where the target model isn't extending `mail.thread`. These cases were failing, due to the grouping done by `mail.message.schedule`.

In some of those cases, mails were sent with the special `mail_notify_author=True` context, which got lost after the deferring step. In those cases, if the author's message was expected to arrive at the author's inbox, it wouldn't happen anymore.

@moduon MT-6337