### PR TITLE
[FIX] mail_post_defer: recover "view $model" button

### DIFF
--- a/mail_post_defer/models/mail_message_schedule.py
+++ b/mail_post_defer/models/mail_message_schedule.py
@@ -19,7 +19,7 @@ class MailMessageSchedule(models.Model):
         result = super()._group_by_model()
         for model, records in result.copy().items():
             # Move records without mail.thread mixin to a False key
-            if model and not hasattr(model, "_notify_thread"):
+            if model and not hasattr(self.env.get(model), "_notify_thread"):
                 result.pop(model)
                 result.setdefault(False, self.browse())
                 result[False] += records


### PR DESCRIPTION
Fixes a regression in https://github.com/OCA/social/pull/1380 that made posted messages lose the "View $model" button, even if the recipient had access.

@moduon MT-6348