### PR TITLE
[16.0][FIX] mail_improved_tracking_value: support tracking Many2one field

### DIFF
--- a/mail_improved_tracking_value/models/mail_tracking_value.py
+++ b/mail_improved_tracking_value/models/mail_tracking_value.py
@@ -36,7 +36,7 @@ class MailTrackingValue(models.Model):
     def _compute_formatted_value(self):
         """Sets the value formatted field used in the view"""
         for record in self:
-            if record.field_type in ("many2many", "one2many", "char"):
+            if record.field_type in ("many2many", "one2many", "char", "many2one"):
                 record.new_value_formatted = record.new_value_char
                 record.old_value_formatted = record.old_value_char
             elif record.field_type == "integer":

--- a/mail_improved_tracking_value/readme/CONTRIBUTORS.rst
+++ b/mail_improved_tracking_value/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Tris Doan <tridm@trobz.com>


### PR DESCRIPTION
### Steps to reproduce
1. Change value Many2one field
2. Open tracking value form: Setting -> Technical -> Email -> Improved Tracking Values
3. Get this error

> ValueError: Compute method failed to assign mail.tracking.value(1,).old_value_formatted
