### PR TITLE
[15.0][FIX]: Prevent error when the result is empty

### DIFF
--- a/mail_activity_board/models/mail_activity.py
+++ b/mail_activity_board/models/mail_activity.py
@@ -112,6 +112,6 @@ class MailActivity(models.Model):
             count=count,
             access_rights_uid=access_rights_uid,
         )
-        if limit is not None:
+        if limit is not None and result:
             result = result[:limit]
         return result


### PR DESCRIPTION
Replaces #1392 