### PR TITLE
[15.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/mail_autosubscribe/__manifest__.py
+++ b/mail_autosubscribe/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Mail Autosubscribe",
     "summary": "Automatically subscribe partners to its company's business documents",
     "version": "15.0.1.0.3",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Marketing",
     "depends": ["mail"],

--- a/mail_composer_cc_bcc/__manifest__.py
+++ b/mail_composer_cc_bcc/__manifest__.py
@@ -7,7 +7,7 @@
     "development_status": "Alpha",
     "category": "Social",
     "website": "https://github.com/OCA/social",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["hailangvn2023"],
     "license": "AGPL-3",
     "application": False,

--- a/mail_layout_preview/__manifest__.py
+++ b/mail_layout_preview/__manifest__.py
@@ -7,7 +7,7 @@
         Preview email templates in the browser""",
     "version": "15.0.0.1.0",
     "license": "AGPL-3",
-    "author": "Camptocamp SA,Odoo Community Association (OCA)",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/social",
     "depends": ["mail"],
     "data": ["templates/email_preview.xml", "wizard/email_template_preview.xml"],

--- a/outgoing_email_by_model/__manifest__.py
+++ b/outgoing_email_by_model/__manifest__.py
@@ -6,7 +6,7 @@
     "version": "15.0.1.0.0",
     "category": "Social",
     "website": "https://github.com/OCA/social",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["mmequignon"],
     "license": "AGPL-3",
     "installable": True,


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 15.0.