### PR TITLE
[13.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/mail_autosubscribe/__manifest__.py
+++ b/mail_autosubscribe/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Mail Autosubscribe",
     "summary": "Automatically subscribe partners to its company's business documents",
     "version": "13.0.1.0.0",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Marketing",
     "depends": ["mail"],

--- a/mail_layout_preview/__manifest__.py
+++ b/mail_layout_preview/__manifest__.py
@@ -7,7 +7,7 @@
         Preview email templates in the browser""",
     "version": "13.0.1.0.0",
     "license": "AGPL-3",
-    "author": "Camptocamp SA,Odoo Community Association (OCA)",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/social",
     "depends": ["mail"],
     "data": ["templates/email_preview.xml", "wizard/email_template_preview.xml"],


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 13.0.