### PR TITLE
[16.0][FIX] mail_activity_team: prevent inconsistent team value

### DIFF
--- a/mail_activity_team/models/mail_activity_mixin.py
+++ b/mail_activity_team/models/mail_activity_mixin.py
@@ -39,11 +39,7 @@ class MailActivityMixin(models.AbstractModel):
     def activity_schedule(
         self, act_type_xmlid="", date_deadline=None, summary="", note="", **act_values
     ):
-        """With automatic activities, the user onchange won't act so we must
-        ensure the right group is set and no exceptions are raised due to
-        user-team missmatch. We can hook onto `act_values` dict as it's passed
-        to the create activity method.
-        """
+        """Suggest a default user from the default team's members"""
         if self.env.context.get("force_activity_team"):
             act_values["team_id"] = self.env.context["force_activity_team"].id
         if "team_id" not in act_values:
@@ -64,17 +60,6 @@ class MailActivityMixin(models.AbstractModel):
                     act_values.update(
                         {"user_id": activity_type.default_team_id.member_ids[:1].id}
                     )
-            else:
-                user_id = act_values.get("user_id")
-                if user_id:
-                    team = (
-                        self.env["mail.activity"]
-                        .with_context(
-                            default_res_model=self._name,
-                        )
-                        ._get_default_team_id(user_id=user_id)
-                    )
-                    act_values.update({"team_id": team.id})
         return super().activity_schedule(
             act_type_xmlid=act_type_xmlid,
             date_deadline=date_deadline,

--- a/mail_activity_team/tests/test_mail_activity_team.py
+++ b/mail_activity_team/tests/test_mail_activity_team.py
@@ -341,3 +341,21 @@ class TestMailActivityTeam(TransactionCase):
         )
         self.assertEqual(partner, self.partner_client)
         self.assertEqual(partner.my_activity_date_deadline, today)
+
+    def test_create_activity_for_user_not_in_team(self):
+        """As a member of a team, create an activity for a teamless member"""
+
+        activity = (
+            self.env["mail.activity"]
+            .with_user(self.employee)
+            .create(
+                {
+                    "activity_type_id": self.activity2.id,
+                    "note": "Partner activity 3",
+                    "res_id": self.partner_client.id,
+                    "res_model_id": self.partner_ir_model.id,
+                    "user_id": self.employee3.id,
+                }
+            )
+        )
+        self.assertFalse(activity.team_id)


### PR DESCRIPTION
Fixes 'Assigned user is not member of the team' when an activity is created in the backend for a user that is not in the same teams as the user creating the activity.

An example of such an activity is the one created for tax closing moves in enterprises' account_reports.