### PR TITLE
[14.0][IMP] mail_restrict_follower_selection: allow to use ref in domain

### DIFF
--- a/mail_restrict_follower_selection/__init__.py
+++ b/mail_restrict_follower_selection/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import models
+from . import utils

--- a/mail_restrict_follower_selection/models/mail_followers.py
+++ b/mail_restrict_follower_selection/models/mail_followers.py
@@ -5,6 +5,8 @@ from odoo import models
 from odoo.tools import config
 from odoo.tools.safe_eval import safe_eval
 
+from ..utils import _id_get
+
 
 class MailFollowers(models.Model):
     _inherit = "mail.followers"
@@ -38,7 +40,10 @@ class MailFollowers(models.Model):
             "mail.wizard.invite"
         ]._mail_restrict_follower_selection_get_domain(res_model=res_model)
         partners = self.env["res.partner"].search(
-            [("id", "in", partner_ids)] + safe_eval(domain)
+            [("id", "in", partner_ids)]
+            + safe_eval(
+                domain, locals_dict={"ref": lambda str_id: _id_get(self.env, str_id)}
+            )
         )
         _res_ids = res_ids.copy() or [0]
         new, update = super()._add_followers(

--- a/mail_restrict_follower_selection/models/mail_thread.py
+++ b/mail_restrict_follower_selection/models/mail_thread.py
@@ -2,6 +2,8 @@ from odoo import models
 from odoo.tools import config
 from odoo.tools.safe_eval import safe_eval
 
+from ..utils import _id_get
+
 
 class MailThread(models.AbstractModel):
     _inherit = "mail.thread"
@@ -20,7 +22,9 @@ class MailThread(models.AbstractModel):
         domain = self.env[
             "mail.wizard.invite"
         ]._mail_restrict_follower_selection_get_domain()
-        eval_domain = safe_eval(domain)
+        eval_domain = safe_eval(
+            domain, locals_dict={"ref": lambda str_id: _id_get(self.env, str_id)}
+        )
         for key in result:
             for partner_id, email, reason in result[key]:
                 if partner_id:

--- a/mail_restrict_follower_selection/models/mail_wizard_invite.py
+++ b/mail_restrict_follower_selection/models/mail_wizard_invite.py
@@ -5,6 +5,9 @@
 from lxml import etree
 
 from odoo import api, models
+from odoo.tools.safe_eval import safe_eval
+
+from ..utils import _id_get
 
 
 class MailWizardInvite(models.TransientModel):
@@ -34,7 +37,11 @@ class MailWizardInvite(models.TransientModel):
             view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu
         )
         arch = etree.fromstring(result["arch"])
+        domain = self._mail_restrict_follower_selection_get_domain()
+        eval_domain = safe_eval(
+            domain, locals_dict={"ref": lambda str_id: _id_get(self.env, str_id)}
+        )
         for field in arch.xpath('//field[@name="partner_ids"]'):
-            field.attrib["domain"] = self._mail_restrict_follower_selection_get_domain()
+            field.attrib["domain"] = str(eval_domain)
         result["arch"] = etree.tostring(arch)
         return result

--- a/mail_restrict_follower_selection/utils.py
+++ b/mail_restrict_follower_selection/utils.py
@@ -1,0 +1,10 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+
+def _id_get(env, id_str):
+    """Have a more secure ref function for use with safe_eval.
+
+    Returning only the ID of the record.
+    """
+    return env.ref(id_str).id


### PR DESCRIPTION
With this is change it is now possible to use the `ref` function in the domain set in a parameter, allowing to include xmlids in the domain.