### PR TITLE
[16.0][FIX] mail_tracking: bounces and others

### DIFF
--- a/mail_tracking/controllers/main.py
+++ b/mail_tracking/controllers/main.py
@@ -42,7 +42,7 @@ class MailTrackingController(MailController):
 
     @http.route(
         [
-            "/mail/tracking/open/<string:db>" "/<int:tracking_email_id>/blank.gif",
+            "/mail/tracking/open/<string:db>/<int:tracking_email_id>/blank.gif",
             "/mail/tracking/open/<string:db>"
             "/<int:tracking_email_id>/<string:token>/blank.gif",
         ],

--- a/mail_tracking/models/mail_message.py
+++ b/mail_tracking/models/mail_message.py
@@ -24,7 +24,7 @@ class MailMessage(models.Model):
         string="Mail Trackings",
     )
     mail_tracking_needs_action = fields.Boolean(
-        help="The message tracking will be considered" " to filter tracking issues",
+        help="The message tracking will be considered to filter tracking issues",
         default=False,
     )
     is_failed_message = fields.Boolean(
@@ -41,6 +41,7 @@ class MailMessage(models.Model):
         "mail_tracking_needs_action",
         "author_id",
         "notification_ids",
+        "mail_tracking_ids",
         "mail_tracking_ids.state",
     )
     def _compute_is_failed_message(self):

--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -317,13 +317,8 @@ class MailTrackingEmail(models.Model):
         )
         if self.token:
             path_url = (
-                "mail/tracking/open/%(db)s/%(tracking_email_id)s/%(token)s/"
-                "blank.gif"
-                % {
-                    "db": self.env.cr.dbname,
-                    "tracking_email_id": self.id,
-                    "token": self.token,
-                }
+                f"mail/tracking/open/{self.env.cr.dbname}/{self.id}/{self.token}/"
+                f"blank.gif"
             )
         else:
             # This is here for compatibility with older records
@@ -331,11 +326,8 @@ class MailTrackingEmail(models.Model):
                 db=self.env.cr.dbname, tracking_email_id=self.id
             )
         track_url = urllib.parse.urljoin(base_url, path_url)
-        return (
-            '<img src="%(url)s" alt="" '
-            'data-odoo-tracking-email="%(tracking_email_id)s"/>'
-            % {"url": track_url, "tracking_email_id": self.id}
-        )
+        _logger.debug(f"Sending email will tracking url: {track_url}")
+        return f'<img src="{track_url}" alt="" data-odoo-tracking-email="{self.id}"/>'
 
     def _partners_email_bounced_set(self, reason, event=None):
         recipients = []

--- a/mail_tracking/static/src/components/message/message.xml
+++ b/mail_tracking/static/src/components/message/message.xml
@@ -72,7 +72,8 @@
                         t-if="tracking['partner_id']"
                         t-attf-class="o_mail_action_tracking_partner #{tracking['isCc'] ? 'o_mail_cc' : ''}"
                         t-att-data-partner="tracking['partner_id']"
-                        t-attf-href="#model=res.partner&amp;id={{tracking['partner_id']}}"
+                        data-oe-model="res.partner"
+                        t-att-data-oe-id="tracking['partner_id']"
                         t-out="tracking['recipient']"
                     />
                     <span

--- a/mail_tracking/tests/test_mail_tracking.py
+++ b/mail_tracking/tests/test_mail_tracking.py
@@ -613,7 +613,7 @@ class TestMailTracking(TransactionCase):
         message.mail_tracking_ids = [Command.link(tracking.id)]
         mail.mail_message_id = message
         message_dict = {
-            "bounced_email": "test@test.net",
+            "bounced_email": self.recipient.email,
             "bounced_message": message,
             "bounced_msg_id": [message.message_id],
             "bounced_partner": self.recipient,


### PR DESCRIPTION
Some improvements/fixes detected in https://github.com/OCA/social/pull/1367 and brought to  `16.0`:

- Add `mail_tracking_ids` to `_compute_is_failed_message` triggers.
- Handle bounces to avoid flagging recipients which aren't bounced.
- Add a logger.debug to research tracking issues
- Make the links in the trackings respect the breadcrumb actions.

cc @Tecnativa