### PR TITLE
[15.0][FW] mail_activity_board: Open board from systray, Actions buttons in kanban

### DIFF
--- a/mail_activity_board/__manifest__.py
+++ b/mail_activity_board/__manifest__.py
@@ -16,9 +16,11 @@
     "assets": {
         "web.assets_backend": [
             "mail_activity_board/static/src/components/chatter_topbar/chatter_topbar.esm.js",
+            "mail_activity_board/static/src/js/systray.esm.js",
         ],
         "web.assets_qweb": [
             "mail_activity_board/static/src/components/chatter_topbar/chatter_topbar.xml",
+            "mail_activity_board/static/src/xml/systray.xml",
         ],
     },
 }

--- a/mail_activity_board/static/description/index.html
+++ b/mail_activity_board/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -437,7 +438,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/mail_activity_board/static/src/js/systray.esm.js
+++ b/mail_activity_board/static/src/js/systray.esm.js
@@ -1,0 +1,24 @@
+odoo.define('mail_activity_board.systray.ActivityMenu', function (require) {
+    "use strict";
+
+    var ActivityMenu = require('mail.systray.ActivityMenu');
+    var session = require("web.session");
+
+    ActivityMenu.include({
+        events: _.extend({}, ActivityMenu.prototype.events, {
+            'click .o_all_activities_button': '_onClickOpenAllActivities',
+        }),
+
+        _open_boards_activities_domain: function () {
+            return {additional_context: {'search_default_activities_my':  1}};
+        },
+
+        _onClickOpenAllActivities: function () {
+            this.do_action(
+                "mail_activity_board.open_boards_activities",
+                this._open_boards_activities_domain()
+            )
+        },
+    });
+
+});

--- a/mail_activity_board/static/src/js/systray.esm.js
+++ b/mail_activity_board/static/src/js/systray.esm.js
@@ -1,24 +1,19 @@
-odoo.define('mail_activity_board.systray.ActivityMenu', function (require) {
-    "use strict";
+/** @odoo-module **/
+import ActivityMenu from "@mail/js/systray/systray_activity_menu";
 
-    var ActivityMenu = require('mail.systray.ActivityMenu');
-    var session = require("web.session");
+ActivityMenu.include({
+    events: _.extend({}, ActivityMenu.prototype.events, {
+        "click .o_all_activities_button": "_onClickOpenAllActivities",
+    }),
 
-    ActivityMenu.include({
-        events: _.extend({}, ActivityMenu.prototype.events, {
-            'click .o_all_activities_button': '_onClickOpenAllActivities',
-        }),
+    _open_boards_activities_domain: function () {
+        return {additional_context: {search_default_activities_my: 1}};
+    },
 
-        _open_boards_activities_domain: function () {
-            return {additional_context: {'search_default_activities_my':  1}};
-        },
-
-        _onClickOpenAllActivities: function () {
-            this.do_action(
-                "mail_activity_board.open_boards_activities",
-                this._open_boards_activities_domain()
-            )
-        },
-    });
-
+    _onClickOpenAllActivities: function () {
+        this.do_action(
+            "mail_activity_board.open_boards_activities",
+            this._open_boards_activities_domain()
+        );
+    },
 });

--- a/mail_activity_board/static/src/xml/systray.xml
+++ b/mail_activity_board/static/src/xml/systray.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+
+    <t t-extend="mail.systray.ActivityMenu">
+        <t t-jquery=".o_mail_systray_dropdown_items" t-operation="before">
+            <div class="o_mail_systray_dropdown_top">
+                <button type="button" class="btn btn-link o_all_activities_button">Open All</button>
+            </div>
+        </t>
+    </t>
+
+</templates>

--- a/mail_activity_board/static/src/xml/systray.xml
+++ b/mail_activity_board/static/src/xml/systray.xml
@@ -1,10 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <templates>
 
     <t t-extend="mail.systray.ActivityMenu">
         <t t-jquery=".o_mail_systray_dropdown_items" t-operation="before">
             <div class="o_mail_systray_dropdown_top">
-                <button type="button" class="btn btn-link o_all_activities_button">Open All</button>
+                <button
+                    type="button"
+                    class="btn btn-link o_all_activities_button"
+                >Open All</button>
             </div>
         </t>
     </t>

--- a/mail_activity_board/views/mail_activity_view.xml
+++ b/mail_activity_board/views/mail_activity_view.xml
@@ -280,6 +280,11 @@
                     domain="[('date_deadline', '&lt;', (context_today()+datetime.timedelta(days=180)).strftime('%Y-%m-%d'))]"
                     help="Show activities scheduled for next 6 months."
                 />
+                <filter
+                    string="My Activities"
+                    name="activities_my"
+                    domain="[('user_id', '=', uid)]"
+                />
                 <separator />
             </xpath>
 

--- a/mail_activity_board/views/mail_activity_view.xml
+++ b/mail_activity_board/views/mail_activity_view.xml
@@ -176,9 +176,11 @@
                                     </strong>
                                 </div>
                                 <div>
-                                    <strong class="o_kanban_record_title"><field
-                                            name="res_name"
-                                        /></strong>
+                                    <strong class="o_kanban_record_title">
+                                      <a name="open_origin" type="object">
+                                        <field name="res_name" />
+                                      </a>
+                                    </strong>
                                 </div>
 
                                 <div class="o_kanban_record_bottom">
@@ -235,6 +237,29 @@
                                         </t>
                                     </div>
                                     <div class="oe_kanban_bottom_right">
+                                        <span>
+                                            <a name="action_done" type="object"><i
+                                                    class="fa fa-check"
+                                                    role="img"
+                                                    aria-label="Mark as Done"
+                                                    title="Mark as Done"
+                                                /></a>
+                                            <a
+                                                name="action_done_schedule_next"
+                                                type="object"
+                                            ><i
+                                                    class="fa fa-undo"
+                                                    role="img"
+                                                    aria-label="Done &amp; Schedule Next"
+                                                    title="Done &amp; Schedule Next"
+                                                /></a>
+                                            <a name="unlink" type="object"><i
+                                                    class="fa fa-times"
+                                                    role="img"
+                                                    aria-label="Cancel"
+                                                    title="Cancel"
+                                                /></a>
+                                        </span>
                                         <img
                                             t-att-src="kanban_image('res.users', 'avatar_128', record.user_id.raw_value)"
                                             t-att-title="record.user_id.value"

--- a/mail_activity_team/static/src/xml/systray.xml
+++ b/mail_activity_team/static/src/xml/systray.xml
@@ -2,7 +2,7 @@
 <templates>
 
     <t t-extend="mail.systray.ActivityMenu">
-        <t t-jquery=".o_mail_systray_dropdown_items" t-operation="before">
+        <t t-jquery=".o_all_activities_button" t-operation="before">
             <div class="o_mail_systray_dropdown_top">
                 <div>
                     <button

--- a/mail_activity_team/views/mail_activity_views.xml
+++ b/mail_activity_team/views/mail_activity_views.xml
@@ -91,7 +91,7 @@
             <xpath expr='//field[@name="user_id"]' position='before'>
                 <field name="team_id" />
             </xpath>
-            <xpath expr='//filter[@name="activities_6_month"]' position='after'>
+            <xpath expr='//filter[@name="activities_my"]' position='after'>
                 <filter
                     name="my_team_activities"
                     string="My Team Activities"


### PR DESCRIPTION
This is a forward port of missing features in mail_activity_board

Open board from systray: #612 from v12
Adds buttons to mark activity as done / mark as done + schedule next (as in activity window): PR #1350 (v14) / #771 (v12)