### PR TITLE
[14.0][IMP] generate attachment name regarding partner lang

### DIFF
--- a/mail_template_multi_attachment/models/mail_template.py
+++ b/mail_template_multi_attachment/models/mail_template.py
@@ -30,7 +30,10 @@ class MailTemplate(models.Model):
         if isinstance(res_ids, int):
             multi_mode = False
             results = {res_ids: results}
-        self.generate_attachments(results)
+        for lang, (_template, _template_res_ids) in self._classify_per_lang(
+            [res_ids] if not isinstance(res_ids, (list, tuple)) else res_ids
+        ).items():
+            self.with_context(lang=lang).generate_attachments(results)
         return multi_mode and results or results[res_ids]
 
     def generate_attachments(self, results):


### PR DESCRIPTION
Currently, the attachment's name is generated in the user's language.  This PR makes the the attachment's name to be generated in the customer language. 