### PR TITLE
[16.0][FIX] fetchmail_thread_default, mail_activity_team, mail_gateway, mass_mailing_custom_unsubscribe,add sudo call in models without explicit access

### DIFF
--- a/fetchmail_thread_default/models/fetchmail_server.py
+++ b/fetchmail_thread_default/models/fetchmail_server.py
@@ -23,6 +23,7 @@ class FetchmailServer(models.Model):
         """
         models = (
             self.env["ir.model.fields"]
+            .sudo()
             .search([("name", "=", "message_partner_ids")])
             .mapped("model_id")
         )

--- a/mail_activity_team/models/mail_activity.py
+++ b/mail_activity_team/models/mail_activity.py
@@ -12,7 +12,7 @@ class MailActivity(models.Model):
         if not user_id:
             user_id = self.env.uid
         res_model = self.env.context.get("default_res_model")
-        model = self.sudo().env["ir.model"].search([("model", "=", res_model)], limit=1)
+        model = self.env["ir.model"].sudo().search([("model", "=", res_model)], limit=1)
         domain = [("member_ids", "in", [user_id])]
         if res_model:
             domain.extend(

--- a/mail_gateway/wizards/mail_message_gateway_link.py
+++ b/mail_gateway/wizards/mail_message_gateway_link.py
@@ -16,7 +16,7 @@ class MailMessageGatewayLink(models.TransientModel):
 
     @api.model
     def _selection_target_model(self):
-        models = self.env["ir.model"].search([("is_mail_thread", "=", True)])
+        models = self.env["ir.model"].sudo().search([("is_mail_thread", "=", True)])
         return [(model.model, model.name) for model in models]
 
     def link_message(self):

--- a/mass_mailing_custom_unsubscribe/models/mail_unsubscription.py
+++ b/mass_mailing_custom_unsubscribe/models/mail_unsubscription.py
@@ -62,8 +62,12 @@ class MailUnsubscription(models.Model):
     @api.model
     def _selection_unsubscriber_id(self):
         """Models that can be linked to a ``mailing.mailing``."""
-        models = self.env["ir.model"].search(
-            [("is_mailing_enabled", "=", True), ("model", "!=", "mailing.list")]
+        models = (
+            self.env["ir.model"]
+            .sudo()
+            .search(
+                [("is_mailing_enabled", "=", True), ("model", "!=", "mailing.list")]
+            )
         )
         return [(model.model, model.name) for model in models]
 


### PR DESCRIPTION
This commit (https://github.com/odoo/odoo/commit/5dc4cff60a557e14b08440c227423291c407899b) explain why should be change access to this classes 

- ir.model
- ir.model.fields
- ir.model.data
- ir.model.fields.selection
- ir.ui.view