### PR TITLE
[17.0][IMP] Correct team activities domain

### DIFF
--- a/mail_activity_team/i18n/de.po
+++ b/mail_activity_team/i18n/de.po
@@ -1,0 +1,201 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* mail_activity_team
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__active
+msgid "Active"
+msgstr "Aktiv"
+
+#. module: mail_activity_team
+#: model:ir.model,name:mail_activity_team.model_mail_activity
+msgid "Activity"
+msgstr "Aktivität"
+
+#. module: mail_activity_team
+#: model:ir.model,name:mail_activity_team.model_mail_activity_mixin
+msgid "Activity Mixin"
+msgstr "Aktivitäts-Mixin"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_ir_actions_server__activity_team_id
+#: model:ir.model.fields,field_description:mail_activity_team.field_ir_cron__activity_team_id
+#: model_terms:ir.ui.view,arch_db:mail_activity_team.mail_activity_team_view_form
+msgid "Activity Team"
+msgstr "Aktivitätsteam"
+
+#. module: mail_activity_team
+#: model:ir.actions.act_window,name:mail_activity_team.mail_activity_team_action
+#: model:ir.model.fields,field_description:mail_activity_team.field_res_users__activity_team_ids
+#: model:ir.ui.menu,name:mail_activity_team.menu_mail_activity_team
+msgid "Activity Teams"
+msgstr "Aktivitätsteams"
+
+#. module: mail_activity_team
+#: model:ir.model,name:mail_activity_team.model_mail_activity_type
+msgid "Activity Type"
+msgstr "Aktivitätstyp"
+
+#. module: mail_activity_team
+#: model_terms:ir.ui.view,arch_db:mail_activity_team.mail_activity_team_view_form
+msgid "Archived"
+msgstr "Archiviert"
+
+#. module: mail_activity_team
+#: model_terms:ir.ui.view,arch_db:mail_activity_team.mail_activity_team_view_form
+msgid "Assign to missing activities"
+msgstr "Fehlenden Aktivitäten zuweisen"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__create_uid
+msgid "Created by"
+msgstr "Erstellt von"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__create_date
+msgid "Created on"
+msgstr "Erstellt am"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_type__default_team_id
+msgid "Default Team"
+msgstr "Standardteam"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__display_name
+msgid "Display Name"
+msgstr "Anzeigename"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__id
+msgid "ID"
+msgstr "ID"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__write_uid
+msgid "Last Updated by"
+msgstr "Zuletzt aktualisiert von"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__write_date
+msgid "Last Updated on"
+msgstr "Zuletzt aktualisiert am"
+
+#. module: mail_activity_team
+#: model:ir.model,name:mail_activity_team.model_mail_activity_team
+msgid "Mail Activity Team"
+msgstr "E-Mail-Aktivitätsteam"
+
+#. module: mail_activity_team
+#: model_terms:ir.ui.view,arch_db:mail_activity_team.mail_activity_team_view_form
+msgid "Members"
+msgstr "Mitglieder"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__count_missing_activities
+msgid "Missing Activities"
+msgstr "Fehlende Aktivitäten"
+
+#. module: mail_activity_team
+#. odoo-javascript
+#: code:addons/mail_activity_team/static/src/components/activity_menu_view/activity_menu_view.xml:0
+#, python-format
+msgid "My Activities"
+msgstr "Meine Aktivitäten"
+
+#. module: mail_activity_team
+#: model_terms:ir.ui.view,arch_db:mail_activity_team.mail_activity_view_search
+msgid "My Team Activities"
+msgstr "Aktivitäten meines Teams"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__name
+msgid "Name"
+msgstr "Name"
+
+#. module: mail_activity_team
+#: model:ir.model,name:mail_activity_team.model_ir_actions_server
+msgid "Server Action"
+msgstr "Serveraktion"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity__team_id
+#: model_terms:ir.ui.view,arch_db:mail_activity_team.mail_activity_view_search
+msgid "Team"
+msgstr "Team"
+
+#. module: mail_activity_team
+#. odoo-javascript
+#: code:addons/mail_activity_team/static/src/components/activity_menu_view/activity_menu_view.xml:0
+#, python-format
+msgid "Team Activities"
+msgstr "Teamaktivitäten"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__user_id
+msgid "Team Leader"
+msgstr "Teamleiter"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__member_ids
+msgid "Team Members"
+msgstr "Teammitglieder"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity__team_user_id
+msgid "Team user"
+msgstr "Teambenutzer"
+
+#. module: mail_activity_team
+#: model_terms:ir.ui.view,arch_db:mail_activity_team.mail_activity_view_kanban
+msgid "Team:"
+msgstr "Team:"
+
+#. module: mail_activity_team
+#. odoo-python
+#: code:addons/mail_activity_team/models/mail_activity.py:0
+#, python-format
+msgid ""
+"The assigned user %(user_name)s is not member of the team %(team_name)s."
+msgstr ""
+"Der zugewiesene Benutzer %(user_name)s ist kein Mitglied des Teams %(team_name)s."
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__res_model_ids
+msgid "Used models"
+msgstr "Verwendete Modelle"
+
+#. module: mail_activity_team
+#: model:ir.model,name:mail_activity_team.model_res_users
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity__user_id
+msgid "User"
+msgstr "Benutzer"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_account_bank_statement_line__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_account_journal__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_account_move__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_account_payment__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_account_setup_bank_manual_config__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_mixin__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_mailing_mailing__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_product_pricelist__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_product_product__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_product_template__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_res_partner__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_res_partner_bank__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_res_users__activity_team_user_ids
+msgid "test field"
+msgstr "Testfeld"

--- a/mail_activity_team/models/mail_activity_mixin.py
+++ b/mail_activity_team/models/mail_activity_mixin.py
@@ -18,6 +18,20 @@ class MailActivityMixin(models.AbstractModel):
         for rec in self:
             rec.activity_team_user_ids = rec.activity_ids.mapped("team_id.member_ids")
 
+    @api.model
+    def _search_activity_user_id(self, operator, operand):
+        if not self._context.get("team_activities", False):
+            return super()._search_activity_user_id(operator, operand)
+        activity_ids = self.env["mail.activity"]._search(
+            [
+                ("res_model", "=", self._name),
+                "|",
+                ("user_id", "=", self.env.user.id),
+                ("team_id", "in", self.env.user.activity_team_ids.ids),
+            ]
+        )
+        return [('activity_ids', 'any', [('active', 'in', [True, False])]), ("activity_ids", "in", activity_ids)]
+
     def _search_my_activity_date_deadline(self, operator, operand):
         if not self._context.get("team_activities", False):
             return super()._search_my_activity_date_deadline(operator, operand)

--- a/mail_activity_team/models/mail_activity_mixin.py
+++ b/mail_activity_team/models/mail_activity_mixin.py
@@ -30,7 +30,10 @@ class MailActivityMixin(models.AbstractModel):
                 ("team_id", "in", self.env.user.activity_team_ids.ids),
             ]
         )
-        return [('activity_ids', 'any', [('active', 'in', [True, False])]), ("activity_ids", "in", activity_ids)]
+        return [
+            ("activity_ids", "any", [("active", "in", [True, False])]),
+            ("activity_ids", "in", activity_ids),
+        ]
 
     def _search_my_activity_date_deadline(self, operator, operand):
         if not self._context.get("team_activities", False):

--- a/mail_activity_team/tests/test_mail_activity_team.py
+++ b/mail_activity_team/tests/test_mail_activity_team.py
@@ -355,8 +355,10 @@ class TestMailActivityTeam(TransactionCase):
 
     def test_my_team_activity(self):
         """
-        Test the activity of my team by writing data for a specific user and team, then checking the number of partners with the specified activity user ID.
-        Rerurns 2 partners for both user activities and team activities.
+        * Test the activity of my team by writing data for a specific user
+        and team, then checking the number of partners with the specified
+        activity user ID.
+        * Returns 2 partners for both user activities and team activities.
         """
         self.act3.write({"user_id": self.employee2.id, "team_id": self.team2.id})
 


### PR DESCRIPTION
**User Story**
- As a team member using Odoo, I want to be able to view all activities assigned to my team when I click on the "Team Activities" tab in the user menu (Clock-symbol), so that I can efficiently manage and track team tasks.

**Scope**
- The scope of this task is to fix the OCA module mail_activity_teams.
- Currently, when a user selects an object (e.g., Contacts) in the "Team Activities" tab, it shows an empty search result.
- This is due to an incorrect domain being applied, which filters by Activity User instead of Team.
- The fix should involve correcting the domain to filter by Team instead of User.

**Acceptance Criteria**
- Selecting an object (e.g., Contacts) in the "Team Activities" tab should display all team activities related to that object.
- The domain used for filtering activities should be based on the team, not the individual user.
- The fix should work consistently across different object types (Contacts, Sales, etc.).