### PR TITLE
[FIX] mail_composer_cc_bcc: fix duplicate key value error "unique_mail_message_id_res_partner_id_if_set"

### DIFF
--- a/mail_composer_cc_bcc/models/mail_thread.py
+++ b/mail_composer_cc_bcc/models/mail_thread.py
@@ -62,9 +62,10 @@ class MailThread(models.AbstractModel):
         recipients_cc_bcc = MailFollowers._get_recipient_data(
             None, message_type, subtype_id, partners_cc_bcc.ids
         )
+        partners_already_marked_as_recipient = [r.get('id', False) for r in rdata]
         for _, value in recipients_cc_bcc.items():
-            for _, data in value.items():
-                if not data.get("id"):
+            for _, data in value.items():                
+                if not data.get("id") or data.get("id") in partners_already_marked_as_recipient:
                     continue
                 if not data.get(
                     "notif"


### PR DESCRIPTION
Fix duplicate key value violates unique constraint "unique_mail_message_id_res_partner_id_if_set" 
when adding the same user to CC field that is already set as a follower
![image](https://github.com/user-attachments/assets/fcbe83ee-232e-4cd9-9b15-49ce582252c7)
