### PR TITLE
[15.0][FIX] mail_drop_target: drop multiple files

### DIFF
--- a/mail_drop_target/static/src/js/mail_drop_target.esm.js
+++ b/mail_drop_target/static/src/js/mail_drop_target.esm.js
@@ -27,7 +27,7 @@ patch(Chatter.prototype, "mail_drop_target.mail_drop", {
                 } else if (drop_file.name.endsWith(".eml")) {
                     mail_processor = "message_drop";
                 } else {
-                    this._fileUploaderRef.comp.uploadFiles(ev.detail.files);
+                    this._fileUploaderRef.comp.uploadFiles([drop_file]);
                     this.chatter.update({isAttachmentBoxVisible: true});
                 }
                 if (mail_processor) {


### PR DESCRIPTION
I have noticed that when you try to upload multiple files that are not emails, it uploads them multiple times.

![image](https://github.com/user-attachments/assets/f25e74d6-7dd6-462e-86bb-30bfa830b8fb)
