### PR TITLE
[16.0][FIX] mail_activity_team, fix double send activity notification

### DIFF
--- a/mail_activity_team/models/mail_activity.py
+++ b/mail_activity_team/models/mail_activity.py
@@ -31,6 +31,15 @@ class MailActivity(models.Model):
         index=True,
     )
 
+    @api.model_create_multi
+    def create(self, values):
+        for value in values:
+            if "team_user_id" in value and value.get(
+                "team_user_id", False
+            ) != value.get("user_id"):
+                value.update({"user_id": value.get("team_user_id", False)})
+        return super().create(values)
+
     @api.onchange("user_id")
     def _onchange_user_id(self):
         if not self.user_id or (


### PR DESCRIPTION
First notification is sent by

https://github.com/odoo/odoo/blob/16.0/addons/mail/models/mail_activity.py#L348

Because new field team_user_id is a related field, when both field are passed to create function, trigger a write to sync fields, because that in validation of change of user is trigger and send as a write

Second notification is send by this one, this is default when record is created

https://github.com/odoo/odoo/blob/16.0/addons/mail/models/mail_activity.py#L302-L303

With change proposed, send same value to both fields if team_user_id is filled

@ForgeFlow