### PR TITLE
[16.0][FIX] mail_template_substitute: Corrected method name override _onchange_template_id_wrapper

### DIFF
--- a/mail_template_substitute/tests/test_mail_template_substitute.py
+++ b/mail_template_substitute/tests/test_mail_template_substitute.py
@@ -87,7 +87,7 @@ class TestMailTemplateSubstitute(TransactionCase):
         self.smt1.mail_template_substitution_rule_ids.domain = "[]"
         self.mail_compose.with_context(
             active_ids=self.partners.ids
-        ).onchange_template_id_wrapper()
+        )._onchange_template_id_wrapper()
         self.assertEqual(self.mail_compose.template_id, self.smt2)
 
     def test_default_get(self):

--- a/mail_template_substitute/wizards/mail_compose_message.py
+++ b/mail_template_substitute/wizards/mail_compose_message.py
@@ -32,10 +32,10 @@ class MailComposeMessage(models.TransientModel):
         return result
 
     @api.onchange("template_id")
-    def onchange_template_id_wrapper(self):
+    def _onchange_template_id_wrapper(self):
         substitution_template = self._get_substitution_template(
             self.composition_mode, self.template_id, [self.res_id]
         )
         if substitution_template:
             self.template_id = substitution_template
-        return super().onchange_template_id_wrapper()
+        return super()._onchange_template_id_wrapper()


### PR DESCRIPTION
The name of the method on which this override was based has been renamed in the report_substitute module in the reporting-engine repository.

https://github.com/OCA/reporting-engine/blob/e444d4ead5bba908071e8abf7f6268a6f990463b/report_substitute/wizards/mail_compose_message.py#L12

The commit in question to change the signature of the method is:
https://github.com/OCA/reporting-engine/commit/077bd63b0de5644f41c82dc62b4611b30cab7ad7