### PR TITLE
[16.0][IMP] mail_gateway: Allow to use expand on Gateway messages

### DIFF
--- a/mail_gateway/__manifest__.py
+++ b/mail_gateway/__manifest__.py
@@ -12,6 +12,7 @@
     "depends": ["mail"],
     "pre_init_hook": "pre_init_hook",
     "data": [
+        "wizards/mail_compose_gateway_message.xml",
         "wizards/mail_message_gateway_link.xml",
         "wizards/mail_message_gateway_send.xml",
         "wizards/mail_guest_manage.xml",

--- a/mail_gateway/models/res_partner.py
+++ b/mail_gateway/models/res_partner.py
@@ -66,6 +66,23 @@ class ResPartnerGatewayChannel(models.Model):
         "res.company", related="gateway_id.company_id", store=True
     )
 
+    def name_get(self):
+        result = []
+        origin = super().name_get()
+        if not self.env.context.get("mail_gateway_partner_info", False):
+            return origin
+        origin_dict = dict(origin)
+        for record in self:
+            result.append(
+                (
+                    record.id,
+                    "{} ({})".format(
+                        record.partner_id.display_name, origin_dict[record.id]
+                    ),
+                )
+            )
+        return result
+
     _sql_constraints = [
         (
             "unique_partner_gateway",

--- a/mail_gateway/security/ir.model.access.csv
+++ b/mail_gateway/security/ir.model.access.csv
@@ -8,4 +8,3 @@ access_mail_guest_manage,mail.telegram.bot.all,model_mail_guest_manage,base.grou
 access_mail_message_gateway_link,mail.message.link.all,model_mail_message_gateway_link,base.group_user,1,1,1,1
 access_mail_gateway_system,mail_gateway,model_mail_gateway,base.group_system,1,1,1,1
 access_mail_compose_gateway_message,access.mail.compose.gateway.message,model_mail_compose_gateway_message,base.group_user,1,1,1,0
-access_mail_compose_gateway_message_partner,access.mail.compose.gateway.message.partner,model_mail_compose_gateway_message_partner,base.group_user,1,1,1,0

--- a/mail_gateway/security/ir.model.access.csv
+++ b/mail_gateway/security/ir.model.access.csv
@@ -7,3 +7,5 @@ access_mail_gateway_all,mail.telegram.bot.all,model_mail_gateway,,1,0,0,0
 access_mail_guest_manage,mail.telegram.bot.all,model_mail_guest_manage,base.group_user,1,1,1,1
 access_mail_message_gateway_link,mail.message.link.all,model_mail_message_gateway_link,base.group_user,1,1,1,1
 access_mail_gateway_system,mail_gateway,model_mail_gateway,base.group_system,1,1,1,1
+access_mail_compose_gateway_message,access.mail.compose.gateway.message,model_mail_compose_gateway_message,base.group_user,1,1,1,0
+access_mail_compose_gateway_message_partner,access.mail.compose.gateway.message.partner,model_mail_compose_gateway_message_partner,base.group_user,1,1,1,0

--- a/mail_gateway/static/description/index.html
+++ b/mail_gateway/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -428,7 +429,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/mail_gateway/static/src/models/composer_view.esm.js
+++ b/mail_gateway/static/src/models/composer_view.esm.js
@@ -23,7 +23,6 @@ registerPatch({
                 const attachmentIds = this.composer.attachments.map(
                     (attachment) => attachment.id
                 );
-                console.log(this);
                 const context = {
                     default_attachment_ids: attachmentIds,
                     default_body: escapeAndCompactTextContent(
@@ -35,12 +34,21 @@ registerPatch({
                     ),
                     default_res_id: this.composer.activeThread.id,
                     mail_post_autofollow: this.composer.activeThread.hasWriteAccess,
-                    default_wizard_partner_ids:
-                        this.composer.composerGatewayFollowers.map((follower) => {
-                            return follower._getMessageData();
-                        }),
+                    default_wizard_partner_ids: Array.from(
+                        new Set(
+                            this.composer.composerGatewayFollowers.map((follower) => {
+                                return follower.follower.partner.id;
+                            })
+                        )
+                    ),
+                    default_wizard_channel_ids: Array.from(
+                        new Set(
+                            this.composer.composerGatewayFollowers.map((follower) => {
+                                return follower.channel;
+                            })
+                        )
+                    ),
                 };
-                console.log(context);
                 const action = {
                     type: "ir.actions.act_window",
                     name: this.env._t("Gateway message"),

--- a/mail_gateway/static/src/models/composer_view.esm.js
+++ b/mail_gateway/static/src/models/composer_view.esm.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import {clear} from "@mail/model/model_field_command";
+import {escapeAndCompactTextContent} from "@mail/js/utils";
 import {one} from "@mail/model/model_field";
 import {registerPatch} from "@mail/model/model_core";
 
@@ -17,6 +18,55 @@ registerPatch({
             }
             return result;
         },
+        async openFullComposer() {
+            if (this.composer.isGateway) {
+                const attachmentIds = this.composer.attachments.map(
+                    (attachment) => attachment.id
+                );
+                console.log(this);
+                const context = {
+                    default_attachment_ids: attachmentIds,
+                    default_body: escapeAndCompactTextContent(
+                        this.composer.textInputContent
+                    ),
+                    default_model: this.composer.activeThread.model,
+                    default_partner_ids: this.composer.recipients.map(
+                        (partner) => partner.id
+                    ),
+                    default_res_id: this.composer.activeThread.id,
+                    mail_post_autofollow: this.composer.activeThread.hasWriteAccess,
+                    default_wizard_partner_ids:
+                        this.composer.composerGatewayFollowers.map((follower) => {
+                            return follower._getMessageData();
+                        }),
+                };
+                console.log(context);
+                const action = {
+                    type: "ir.actions.act_window",
+                    name: this.env._t("Gateway message"),
+                    res_model: "mail.compose.gateway.message",
+                    view_mode: "form",
+                    views: [[false, "form"]],
+                    target: "new",
+                    context: context,
+                };
+                const composer = this.composer;
+                const options = {
+                    onClose: () => {
+                        if (!composer.exists()) {
+                            return;
+                        }
+                        composer._reset();
+                        if (composer.activeThread) {
+                            composer.activeThread.fetchData(["messages"]);
+                        }
+                    },
+                };
+                await this.env.services.action.doAction(action, options);
+                return;
+            }
+            return await this._super(...arguments);
+        },
     },
     fields: {
         hasFollowers: {
@@ -30,17 +80,6 @@ registerPatch({
         hasHeader: {
             compute() {
                 return Boolean(this._super() || this.composer.isGateway);
-            },
-        },
-        isExpandable: {
-            /*
-                We will not allow to expand on this composer due to all complexity of selection
-            */
-            compute() {
-                if (this.composer.isGateway) {
-                    return clear();
-                }
-                return this._super();
             },
         },
         composerGatewayChannelView: one("GatewayChannelView", {

--- a/mail_gateway/wizards/__init__.py
+++ b/mail_gateway/wizards/__init__.py
@@ -1,3 +1,4 @@
 from . import mail_guest_manage
 from . import mail_message_gateway_send
 from . import mail_message_gateway_link
+from . import mail_compose_gateway_message

--- a/mail_gateway/wizards/mail_compose_gateway_message.py
+++ b/mail_gateway/wizards/mail_compose_gateway_message.py
@@ -1,0 +1,54 @@
+# Copyright 2024 Dixmit
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class MailComposeGatewayMessage(models.TransientModel):
+    _name = "mail.compose.gateway.message"
+    _inherit = "mail.compose.message"
+    _description = "Mail Compose Gateway Message"
+
+    wizard_partner_ids = fields.One2many(
+        "mail.compose.gateway.message.partner", "wizard_id", "Recipents"
+    )
+    attachment_ids = fields.Many2many(
+        "ir.attachment",
+        "mail_compose_gateway_message_ir_attachments_rel",
+        "wizard_id",
+        "attachment_id",
+        "Attachments",
+    )
+
+    partner_ids = fields.Many2many(
+        "res.partner",
+        "mail_compose_gateway_message_res_partner_rel",
+        "wizard_id",
+        "partner_id",
+        "Additional Contacts",
+        domain=lambda r: r._partner_ids_domain(),
+    )
+
+    def get_mail_values(self, res_ids):
+        self.ensure_one()
+        res = super(MailComposeGatewayMessage, self).get_mail_values(res_ids)
+        res[res_ids[0]]["gateway_notifications"] = [
+            {
+                "partner_id": partner.partner_id.id,
+                "channel_type": partner.channel_type,
+                "gateway_channel_id": partner.gateway_channel_id.id,
+            }
+            for partner in self.wizard_partner_ids
+        ]
+        return res
+
+
+class MailComposeGatewayMessagePartner(models.TransientModel):
+    _name = "mail.compose.gateway.message.partner"
+
+    wizard_id = fields.Many2one(
+        "mail.compose.gateway.message", "Wizard", required=True, ondelete="cascade"
+    )
+    partner_id = fields.Many2one("res.partner", "Contact", required=True, readonly=True)
+    gateway_channel_id = fields.Many2one("res.partner.gateway.channel", "Channel")
+    channel_type = fields.Char()

--- a/mail_gateway/wizards/mail_compose_gateway_message.py
+++ b/mail_gateway/wizards/mail_compose_gateway_message.py
@@ -9,8 +9,17 @@ class MailComposeGatewayMessage(models.TransientModel):
     _inherit = "mail.compose.message"
     _description = "Mail Compose Gateway Message"
 
-    wizard_partner_ids = fields.One2many(
-        "mail.compose.gateway.message.partner", "wizard_id", "Recipents"
+    wizard_partner_ids = fields.Many2many(
+        "res.partner",
+        "mail_compose_gateway_message_res_partner_rel",
+        "wizard_id",
+        "partner_id",
+    )
+    wizard_channel_ids = fields.Many2many(
+        "res.partner.gateway.channel",
+        "mail_compose_gateway_message_gateway_channel_rel",
+        "wizard_id",
+        "channel_id",
     )
     attachment_ids = fields.Many2many(
         "ir.attachment",
@@ -34,21 +43,10 @@ class MailComposeGatewayMessage(models.TransientModel):
         res = super(MailComposeGatewayMessage, self).get_mail_values(res_ids)
         res[res_ids[0]]["gateway_notifications"] = [
             {
-                "partner_id": partner.partner_id.id,
-                "channel_type": partner.channel_type,
-                "gateway_channel_id": partner.gateway_channel_id.id,
+                "partner_id": channel.partner_id.id,
+                "channel_type": "gateway",
+                "gateway_channel_id": channel.id,
             }
-            for partner in self.wizard_partner_ids
+            for channel in self.wizard_channel_ids
         ]
         return res
-
-
-class MailComposeGatewayMessagePartner(models.TransientModel):
-    _name = "mail.compose.gateway.message.partner"
-
-    wizard_id = fields.Many2one(
-        "mail.compose.gateway.message", "Wizard", required=True, ondelete="cascade"
-    )
-    partner_id = fields.Many2one("res.partner", "Contact", required=True, readonly=True)
-    gateway_channel_id = fields.Many2one("res.partner.gateway.channel", "Channel")
-    channel_type = fields.Char()

--- a/mail_gateway/wizards/mail_compose_gateway_message.xml
+++ b/mail_gateway/wizards/mail_compose_gateway_message.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 Dixmit
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="mail_compose_gateway_message_form_view">
+        <field name="model">mail.compose.gateway.message</field>
+        <field name="inherit_id" ref="mail.email_compose_message_wizard_form" />
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <field name="partner_ids" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+            <field name="body" position="before">
+                <field name="wizard_partner_ids">
+                    <tree create="0" editable="bottom">
+                        <field
+                            name="partner_id"
+                            options="{'no_create': True, 'no_open': True}"
+                            force_save="1"
+                        />
+                        <field
+                            name="gateway_channel_id"
+                            domain="[('partner_id', '=', partner_id)]"
+                            options="{'no_open': 1, 'no_create': 1}"
+                        />
+                        <field name="channel_type" invisible="1" />
+                    </tree>
+                </field>
+            </field>
+            <field name="subject" position="attributes">
+                <attribute name="invisible">1</attribute>
+                <attribute name="required">0</attribute>
+            </field>
+            <xpath
+                expr="//span[@name='document_followers_text']/.."
+                position="attributes"
+            >
+                <attribute name="invisible">1</attribute>
+                <attribute name="attrs" />
+            </xpath>
+        </field>
+    </record>
+
+
+
+</odoo>

--- a/mail_gateway/wizards/mail_compose_gateway_message.xml
+++ b/mail_gateway/wizards/mail_compose_gateway_message.xml
@@ -12,21 +12,13 @@
                 <attribute name="invisible">1</attribute>
             </field>
             <field name="body" position="before">
-                <field name="wizard_partner_ids">
-                    <tree create="0" editable="bottom">
-                        <field
-                            name="partner_id"
-                            options="{'no_create': True, 'no_open': True}"
-                            force_save="1"
-                        />
-                        <field
-                            name="gateway_channel_id"
-                            domain="[('partner_id', '=', partner_id)]"
-                            options="{'no_open': 1, 'no_create': 1}"
-                        />
-                        <field name="channel_type" invisible="1" />
-                    </tree>
-                </field>
+                <field name="wizard_partner_ids" invisible="1" />
+                <field
+                    name="wizard_channel_ids"
+                    widget="many2many_tags"
+                    context="{'mail_gateway_partner_info': 1}"
+                    domain="[('partner_id', 'in', wizard_partner_ids)]"
+                />
             </field>
             <field name="subject" position="attributes">
                 <attribute name="invisible">1</attribute>


### PR DESCRIPTION
This PR allows us to open a wizard for Gateway messages.

![Captura desde 2024-09-12 16-28-37](https://github.com/user-attachments/assets/575aae0b-0b78-4cb4-9fb4-a9502f56faa2)

Tested with telegram

There are two commits due to a first functional version I don't want to loose. Will be squashed just before merge.