### PR TITLE
[16.0][IMP] mail_activity_plan: Remove warning by several names with the same label

### DIFF
--- a/mail_activity_plan/models/mail_activity_plan.py
+++ b/mail_activity_plan/models/mail_activity_plan.py
@@ -13,7 +13,9 @@ class MailActivityPlan(models.Model):
     active = fields.Boolean(default=True)
     name = fields.Char(required=True)
     sequence = fields.Integer(required=True, default=10)
-    model = fields.Char(compute="_compute_model", compute_sudo=True, store=True)
+    model = fields.Char(
+        compute="_compute_model", string="Model name", compute_sudo=True, store=True
+    )
     model_id = fields.Many2one(
         comodel_name="ir.model",
         domain=[("transient", "=", False), ("model", "not like", "ir.")],


### PR DESCRIPTION
Remove warning by several names with the same label

`WARNING devel odoo.addons.base.models.ir_model: Two fields (model_id, model) of mail.activity.plan() have the same label: Model. [Modules: mail_activity_plan and mail_activity_plan]`

@Tecnativa TT51051