### PR TITLE
[17.0][FIX] mail_composer_cc_bcc_account: use _get_partner_ids_from_mail method

### DIFF
--- a/mail_composer_cc_bcc_account/wizards/account_move_send.py
+++ b/mail_composer_cc_bcc_account/wizards/account_move_send.py
@@ -89,10 +89,10 @@ class AccountMoveSend(models.TransientModel):
             or self._get_default_mail_attachments_widget(move, mail_template),
             "partner_cc_ids": wizard
             and wizard.partner_cc_ids
-            or self._get_default_mail_partner_cc_ids(move, mail_template),
+            or self._get_partner_ids_from_mail(move, mail_template.email_cc),
             "partner_bcc_ids": wizard
             and wizard.partner_bcc_ids
-            or self._get_default_mail_partner_bcc_ids(move, mail_template),
+            or self._get_partner_ids_from_mail(move, mail_template.email_bcc),
         }
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
This fix replaces the use of deprecated methods `_get_default_mail_partner_cc_ids` and `_get_default_mail_partner_bcc_ids` with the correct method `_get_partner_ids_from_mail` suggested here #1312.

**Impact**: Without this PR, the app cannot be used. When trying to send an email from an invoice, an error occurs immediately because the old methods no longer exist.
