### PR TITLE
[17.0][IMP] mail_activity_team: add team fields on mail.activity.schedule

### DIFF
--- a/mail_activity_team/README.rst
+++ b/mail_activity_team/README.rst
@@ -101,6 +101,10 @@ Contributors
 
    -  Son Ho sonhd@trobz.com
 
+-  [Camptocamp] (https://camptocamp.com):
+
+   -  Italo LOPES italo.lopes@camptocamp.com
+
 Other credits
 -------------
 

--- a/mail_activity_team/__init__.py
+++ b/mail_activity_team/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizard

--- a/mail_activity_team/__manifest__.py
+++ b/mail_activity_team/__manifest__.py
@@ -20,6 +20,7 @@
         "views/mail_activity_team_views.xml",
         "views/mail_activity_views.xml",
         "views/res_users_views.xml",
+        "wizard/mail_activity_schedule.xml",
     ],
     "assets": {
         "web.assets_backend": [

--- a/mail_activity_team/readme/CONTRIBUTORS.md
+++ b/mail_activity_team/readme/CONTRIBUTORS.md
@@ -9,3 +9,5 @@
   - Raf Ven
 - [Trobz] (https://trobz.com):
   - Son Ho <sonhd@trobz.com>
+- [Camptocamp] (https://camptocamp.com):
+  - Italo LOPES <italo.lopes@camptocamp.com>

--- a/mail_activity_team/static/description/index.html
+++ b/mail_activity_team/static/description/index.html
@@ -447,6 +447,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Son Ho <a class="reference external" href="mailto:sonhd&#64;trobz.com">sonhd&#64;trobz.com</a></li>
 </ul>
 </li>
+<li>[Camptocamp] (<a class="reference external" href="https://camptocamp.com">https://camptocamp.com</a>):<ul>
+<li>Italo LOPES <a class="reference external" href="mailto:italo.lopes&#64;camptocamp.com">italo.lopes&#64;camptocamp.com</a></li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="other-credits">

--- a/mail_activity_team/wizard/__init__.py
+++ b/mail_activity_team/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import mail_activity_schedule

--- a/mail_activity_team/wizard/mail_activity_schedule.py
+++ b/mail_activity_team/wizard/mail_activity_schedule.py
@@ -1,0 +1,28 @@
+# Copyright 2024 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class MailActivitySchedule(models.TransientModel):
+    _inherit = "mail.activity.schedule"
+
+    def _get_default_team_id(self, user_id=None):
+        if not user_id:
+            user_id = self.env.uid
+        res_model = self.env.context.get("default_res_model")
+        model = self.sudo().env["ir.model"].search([("model", "=", res_model)], limit=1)
+        domain = [("member_ids", "in", [user_id])]
+        if res_model:
+            domain.extend(
+                ["|", ("res_model_ids", "=", False), ("res_model_ids", "in", model.ids)]
+            )
+        return self.env["mail.activity.team"].search(domain, limit=1)
+
+    team_user_id = fields.Many2one(
+        string="Team user", related="activity_user_id", readonly=False
+    )
+
+    team_id = fields.Many2one(
+        comodel_name="mail.activity.team", default=lambda s: s._get_default_team_id()
+    )

--- a/mail_activity_team/wizard/mail_activity_schedule.xml
+++ b/mail_activity_team/wizard/mail_activity_schedule.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+<odoo>
+
+    <record id="mail_activity_schedule_view_form" model="ir.ui.view">
+        <field name="name">mail.activity.schedule.view.form.popup</field>
+        <field name="model">mail.activity.schedule</field>
+        <field name="inherit_id" ref="mail.mail_activity_schedule_view_form" />
+        <field name="arch" type="xml">
+            <field name="activity_user_id" position="attributes">
+                <attribute name="invisible">team_id</attribute>
+            </field>
+            <field name="activity_user_id" position="after">
+                <field name="res_model_id" invisible="1" />
+                <field
+                    name="team_user_id"
+                    invisible="not team_id"
+                    domain="[('activity_team_ids', '=', team_id)]"
+                />
+                <field
+                    name="team_id"
+                    options="{'no_create': True, 'no_open': True}"
+                    domain="['|', ('res_model_ids', '=', False), ('res_model_ids', '=', res_model_id)]"
+                />
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
When creating an activity, it is not possible to assign it to a team.
A team can be selected on an activity but only through editing it.