### PR TITLE
[15.0][FIX] mail_show_follower: Use company from the document to render messages correctly

### DIFF
--- a/mail_show_follower/README.rst
+++ b/mail_show_follower/README.rst
@@ -45,7 +45,7 @@ Configuration
 To configure this module, you need to:
 
 #. Go General settings/Discuss/Show Followers on mails/Show Internal Users CC and set if want to show or not internal users in cc details.
-#. Go Settings/Users & Company salect any user in 'Preferences' check or not the 'Show in CC' field if this user need to appear in the cc note.
+#. Go Settings/Users & Company select any user in 'Preferences' check or not the 'Show in CC' field if this user need to appear in the cc note.
 #. Go General settings/Discuss/Show Followers on mails/Text 'Sent to' and set the initial part of the message.
 #. Go General settings/Discuss/Show Followers on mails/Partner format and choose desired fields to show on CC recipients.
 #. Go General settings/Discuss/Show Followers on mails/Text 'Replies' and choose desired warn message
@@ -82,6 +82,7 @@ Contributors
 * Valentin Vinagre <valentin.vinagre@sygel.es>
 * Lorenzo Battistini
 * Eduardo de Miguel <edu@moduon.team>
+* Vincent Van Rossem <vincent.vanrossem@camptocamp.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/mail_show_follower/models/__init__.py
+++ b/mail_show_follower/models/__init__.py
@@ -1,4 +1,5 @@
 from . import mail_mail
 from . import res_company
 from . import res_config_settings
+from . import res_partner
 from . import res_users

--- a/mail_show_follower/models/mail_mail.py
+++ b/mail_show_follower/models/mail_mail.py
@@ -59,97 +59,29 @@ class MailMail(models.Model):
         return full_text
 
     def _send(self, auto_commit=False, raise_exception=False, smtp_session=None):
-        group_portal = self.env.ref("base.group_portal")
-        for mail_id in self.ids:
-            mail = self.browse(mail_id)
-            message_recipients = self.search(
-                [
-                    ("message_id", "=", mail.message_id),
-                ]
-            ).mapped("recipient_ids")
-            # if the email has a model, id and it belongs to the portal group
-            if mail.model and mail.res_id and group_portal:
-                obj = self.env[mail.model].browse(mail.res_id)
-                # those partners are obtained, who do not have a user and
-                # if they do it must be a portal, we exclude internal
-                # users of the system.
-                if hasattr(obj, "message_follower_ids"):
-                    partners_obj = (
-                        obj.message_follower_ids.mapped("partner_id")
-                        | message_recipients
-                    )
-                    # internal partners
-                    user_partner_ids = (
-                        self.env["res.users"]
-                        .search(
-                            [
-                                ("active", "in", (True, False)),
-                                ("show_in_cc", "=", False),
-                            ]
-                        )
-                        .filtered(lambda x: group_portal not in x.groups_id)
-                        .mapped("partner_id")
-                        .ids
-                    )
-                    partners_len = len(
-                        partners_obj.filtered(
-                            lambda x: x.id not in user_partner_ids
-                            and (
-                                not x.user_ids
-                                or group_portal in x.user_ids.mapped("groups_id")
-                            )
-                        )
-                    )
-                    if partners_len > 1:
-                        # get partners
-                        cc_internal = True
-                        # else get company in object
-                        if hasattr(obj, "company_id") and obj.company_id:
-                            cc_internal = obj.company_id.show_internal_users_cc
-                        # get company in user
-                        elif mail.env and mail.env.user and mail.env.user.company_id:
-                            cc_internal = (
-                                self.env.user.company_id.show_internal_users_cc
-                            )
-                        if cc_internal:
-                            partners = partners_obj.filtered(
-                                lambda x: x.id not in user_partner_ids
-                                and (
-                                    not x.user_ids
-                                    or any(x.mapped("user_ids.show_in_cc"))
-                                )
-                            )
-                        else:
-                            partners = partners_obj.filtered(
-                                lambda x: x.id not in user_partner_ids
-                                and (
-                                    not x.user_ids
-                                    or group_portal in x.user_ids.mapped("groups_id")
-                                )
-                            )
-                        partners = partners.filtered(
-                            lambda x: not x.user_ids
-                            or x.user_ids  # otherwise, email is not sent
-                            and "email" in x.user_ids.mapped("notification_type")
-                        )
-                        # set proper lang for recipients
-                        langs = list(
-                            filter(
-                                bool,
-                                mail.mapped("recipient_ids.lang")
-                                + [
-                                    mail.author_id.lang,
-                                    self.env.company.partner_id.lang,
-                                ],
-                            )
-                        )
-                        # get show follower text
-                        final_cc = mail.with_context(
-                            lang=langs and langs[0]
-                        )._build_cc_text(partners)
-                        # it is saved in the body_html field so that it does
-                        # not appear in the odoo log
-                        mail.body_html = final_cc + mail.body_html
+        group_user = self.env.ref("base.group_user")
+
+        for mail in self:
+            if not (mail.model and mail.res_id and group_user):
+                continue
+            # recipients from any Notification Type (i.e. email, inbox, etc.)
+            recipients = mail.notification_ids.res_partner_id
+            record = self.env[mail.model].browse(mail.res_id)
+            company = getattr(record, "company_id", self.env.company)
+            show_internal_users = company and company.show_internal_users_cc
+            show_in_cc_recipients = recipients._filter_shown_in_cc(show_internal_users)
+            if len(show_in_cc_recipients) <= 1:
+                continue
+
+            langs = (
+                mail.notification_ids.res_partner_id.mapped("lang")
+                or mail.author_id.lang
+                or company.partner_id.lang
+            )
+            final_cc = mail.with_context(lang=langs[0])._build_cc_text(
+                show_in_cc_recipients
+            )
+            mail.body_html = final_cc + mail.body_html
         return super()._send(
             auto_commit=auto_commit,
             raise_exception=raise_exception,

--- a/mail_show_follower/models/mail_mail.py
+++ b/mail_show_follower/models/mail_mail.py
@@ -72,14 +72,16 @@ class MailMail(models.Model):
             show_in_cc_recipients = recipients._filter_shown_in_cc(show_internal_users)
             if len(show_in_cc_recipients) <= 1:
                 continue
-
-            langs = (
-                mail.notification_ids.res_partner_id.mapped("lang")
+            lang = (
+                mail.notification_ids.res_partner_id[:1].lang
                 or mail.author_id.lang
                 or company.partner_id.lang
+                or "en_US"
             )
-            final_cc = mail.with_context(lang=langs[0])._build_cc_text(
-                show_in_cc_recipients
+            final_cc = (
+                mail.with_context(lang=lang)
+                .with_company(company)
+                ._build_cc_text(show_in_cc_recipients)
             )
             mail.body_html = final_cc + mail.body_html
         return super()._send(

--- a/mail_show_follower/models/res_partner.py
+++ b/mail_show_follower/models/res_partner.py
@@ -1,0 +1,26 @@
+from odoo import models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    def _filter_shown_in_cc(self, show_internal_users):
+        """Get partners that should be displayed as CC on mails."""
+        # Never display hidden users
+        result = self.filtered_domain(
+            [
+                "|",
+                ("user_ids", "=", False),
+                ("user_ids.show_in_cc", "=", True),
+            ]
+        )
+        # Remove internal users from result if needed
+        if not show_internal_users:
+            internal_users = result.filtered_domain(
+                [
+                    ("user_ids.active", "=", True),
+                    ("user_ids.groups_id", "in", self.env.ref("base.group_user").ids),
+                ]
+            )
+            result -= internal_users
+        return result

--- a/mail_show_follower/readme/CONFIGURE.rst
+++ b/mail_show_follower/readme/CONFIGURE.rst
@@ -1,7 +1,7 @@
 To configure this module, you need to:
 
 #. Go General settings/Discuss/Show Followers on mails/Show Internal Users CC and set if want to show or not internal users in cc details.
-#. Go Settings/Users & Company salect any user in 'Preferences' check or not the 'Show in CC' field if this user need to appear in the cc note.
+#. Go Settings/Users & Company select any user in 'Preferences' check or not the 'Show in CC' field if this user need to appear in the cc note.
 #. Go General settings/Discuss/Show Followers on mails/Text 'Sent to' and set the initial part of the message.
 #. Go General settings/Discuss/Show Followers on mails/Partner format and choose desired fields to show on CC recipients.
 #. Go General settings/Discuss/Show Followers on mails/Text 'Replies' and choose desired warn message

--- a/mail_show_follower/readme/CONTRIBUTORS.rst
+++ b/mail_show_follower/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Valentin Vinagre <valentin.vinagre@sygel.es>
 * Lorenzo Battistini
 * Eduardo de Miguel <edu@moduon.team>
+* Vincent Van Rossem <vincent.vanrossem@camptocamp.com>

--- a/mail_show_follower/static/description/index.html
+++ b/mail_show_follower/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -437,9 +436,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/mail_show_follower/static/description/index.html
+++ b/mail_show_follower/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -395,7 +395,7 @@ In the cc, only appear when:</p>
 <p>To configure this module, you need to:</p>
 <ol class="arabic simple">
 <li>Go General settings/Discuss/Show Followers on mails/Show Internal Users CC and set if want to show or not internal users in cc details.</li>
-<li>Go Settings/Users &amp; Company salect any user in ‘Preferences’ check or not the ‘Show in CC’ field if this user need to appear in the cc note.</li>
+<li>Go Settings/Users &amp; Company select any user in ‘Preferences’ check or not the ‘Show in CC’ field if this user need to appear in the cc note.</li>
 <li>Go General settings/Discuss/Show Followers on mails/Text ‘Sent to’ and set the initial part of the message.</li>
 <li>Go General settings/Discuss/Show Followers on mails/Partner format and choose desired fields to show on CC recipients.</li>
 <li>Go General settings/Discuss/Show Followers on mails/Text ‘Replies’ and choose desired warn message</li>
@@ -431,12 +431,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Valentin Vinagre &lt;<a class="reference external" href="mailto:valentin.vinagre&#64;sygel.es">valentin.vinagre&#64;sygel.es</a>&gt;</li>
 <li>Lorenzo Battistini</li>
 <li>Eduardo de Miguel &lt;<a class="reference external" href="mailto:edu&#64;moduon.team">edu&#64;moduon.team</a>&gt;</li>
+<li>Vincent Van Rossem &lt;<a class="reference external" href="mailto:vincent.vanrossem&#64;camptocamp.com">vincent.vanrossem&#64;camptocamp.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
In a multi-company environment, if one company uses the `show_followers_partner_format` by `partner_name` and another company uses `partner_email`, a user with permissions in both companies may experience issues. If a document belongs to Company A, but the current company is set to Company B, the message format is taken from the current company (Company B) instead of the document’s company (Company A). This fix ensures that the message format is rendered based on the document's company.

TT51022 @Tecnativa
@pedrobaeza @chienandalu could you please review it, thanks