### PR TITLE
[17.0] oca-port: store 'mail_improved_tracking_value' data

### DIFF
--- a/.oca/oca-port/blacklist/mail_improved_tracking_value.json
+++ b/.oca/oca-port/blacklist/mail_improved_tracking_value.json
@@ -1,0 +1,3 @@
+{
+  "no_migration": "included in standard"
+}


### PR DESCRIPTION
### Context
- From Odoo 17.0, Many2many and one2many are supported in [here](https://github.com/odoo/odoo/blob/561cb2da8452175ec701fa1202ce9b978d5212cd/addons/mail/models/mail_tracking_value.py#L102)