### PR TITLE
[16.0][IMP] mail_activity_team: Add responsible as activity team leader if exists on server actions

### DIFF
--- a/mail_activity_team/models/ir_actions_server.py
+++ b/mail_activity_team/models/ir_actions_server.py
@@ -2,7 +2,7 @@
 # @author Iván Todorovich <ivan.todorovich@camptocamp.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class IrActionsServer(models.Model):
@@ -18,3 +18,8 @@ class IrActionsServer(models.Model):
         if self.activity_user_type == "specific" and self.activity_team_id:
             self = self.with_context(force_activity_team=self.activity_team_id)
         return super()._run_action_next_activity(eval_context=eval_context)
+
+    @api.onchange("activity_team_id")
+    def onchange_activity_team_id(self):
+        if self.activity_team_id.user_id:
+            self.activity_user_id = self.activity_team_id.user_id

--- a/mail_activity_team/tests/test_mail_activity_team.py
+++ b/mail_activity_team/tests/test_mail_activity_team.py
@@ -321,6 +321,22 @@ class TestMailActivityTeam(TransactionCase):
         action.with_context(active_model=partner._name, active_ids=partner.ids).run()
         self.assertEqual(partner.activity_ids[-1].team_id, self.team2)
 
+    def test_server_action_onchanges_activity_team_id_activity_user_id(self):
+        self.team1.user_id = self.team1.member_ids[0]
+        server_action = self.env["ir.actions.server"].create(
+            {
+                "name": "Test Server Action 2",
+                "model_id": self.partner_ir_model.id,
+                "state": "next_activity",
+                "activity_type_id": self.activity2.id,
+                "activity_user_type": "specific",
+                "activity_user_id": self.employee.id,
+            }
+        )
+        with Form(server_action) as form:
+            form.activity_team_id = self.team1
+            self.assertEqual(form.activity_user_id, self.team1.user_id)
+
     def test_my_activity_date_deadline(self):
         """This test case checks
         - if the team activities are properly filtered


### PR DESCRIPTION
Just add an onchange to don't manually look for the responsible if the activity team is set.

CC @ForgeFlow 