### PR TITLE
[15.0][IMP] mail_print: Allow printing messages from incoming mail

### DIFF
--- a/mail_print/static/src/components/message_action_list/message_action_list.xml
+++ b/mail_print/static/src/components/message_action_list/message_action_list.xml
@@ -4,7 +4,7 @@
         <xpath expr="//span[@t-if='messageActionList.hasReplyIcon']" position="before">
             <!-- Show the "Print Message" button only on messages, not on notes. -->
             <PrintMessage
-                t-if="messageActionList.message.is_discussion &amp;&amp; !messageActionList.message.is_note"
+                t-if="!messageActionList.message.is_note"
                 message_id="messageActionList.message.id"
             />
         </xpath>


### PR DESCRIPTION
Before this commit, the option to print messages was only available for messages sent from Odoo. After this commit, it is now possible to print incoming messages as well.

@Tecnativa TT51261 
@pedrobaeza @victoralmau @chienandalu could you please review this

Incoming mail
![image](https://github.com/user-attachments/assets/64ca70fc-ef2c-4abc-a76c-8d7c2ad11095)
Outgoing mail
![image](https://github.com/user-attachments/assets/0581d4d1-36f9-431b-ac4b-fe82acaca6ca)
Internal Note
![image](https://github.com/user-attachments/assets/098e55f5-f6eb-45c1-8a75-32c03fce6c62)

