### PR TITLE
[16.0][FW][FIX] mail_show_follower: Use company from the document to render messages correctly + proper lang handle

### DIFF
--- a/mail_show_follower/models/mail_mail.py
+++ b/mail_show_follower/models/mail_mail.py
@@ -72,14 +72,16 @@ class MailMail(models.Model):
             show_in_cc_recipients = recipients._filter_shown_in_cc(show_internal_users)
             if len(show_in_cc_recipients) <= 1:
                 continue
-
-            langs = (
-                mail.notification_ids.res_partner_id.mapped("lang")
+            lang = (
+                mail.notification_ids.res_partner_id[:1].lang
                 or mail.author_id.lang
                 or company.partner_id.lang
+                or "en_US"
             )
-            final_cc = mail.with_context(lang=langs[0])._build_cc_text(
-                show_in_cc_recipients
+            final_cc = (
+                mail.with_context(lang=lang)
+                .with_company(company)
+                ._build_cc_text(show_in_cc_recipients)
             )
             mail.body_html = final_cc + mail.body_html
 


### PR DESCRIPTION
Forward-port of  https://github.com/OCA/social/pull/1464
In a multi-company environment, if one company uses the show_followers_partner_format by partner_name and another company uses partner_email, a user with permissions in both companies may experience issues. If a document belongs to Company A, but the current company is set to Company B, the message format is taken from the current company (Company B) instead of the document’s company (Company A). This fix ensures that the message format is rendered based on the document's company.

It also fixes the lang handling for cases with False values.

TT51022
@Tecnativa @pedrobaeza @yajo @chienandalu 