### PR TITLE
[15.0][IMP] mail_composer_cc_bcc: filter out partner with no email address and set "" for partner with no name

### DIFF
--- a/mail_composer_cc_bcc/models/mail_mail.py
+++ b/mail_composer_cc_bcc/models/mail_mail.py
@@ -14,9 +14,7 @@ _logger = logging.getLogger(__name__)
 
 
 def format_emails(partners):
-    emails = [
-        tools.formataddr((p.name or "False", p.email or "False")) for p in partners
-    ]
+    emails = [tools.formataddr((p.name, p.email)) for p in partners if p.email]
     return ", ".join(emails)
 
 


### PR DESCRIPTION
- Normally a wizard opens on Odoo client side to prompt user to define an email address for partners that don't have one
- But it's possible to bypass it, so we explicitly filter out partners with no email address
- We also return "" instead of "False" for partner with no name, and odoo's tools.formataddr will just use the partner's email address

The original PR can be found in: https://github.com/OCA/social/pull/1293
I'm opening a new one to try to have it merged and to be able to do the followup