### PR TITLE
[16.0][IMP] mail_gateway: Allow to use expand on Gateway messages

### DIFF
--- a/mail_gateway/__manifest__.py
+++ b/mail_gateway/__manifest__.py
@@ -12,6 +12,7 @@
     "depends": ["mail"],
     "pre_init_hook": "pre_init_hook",
     "data": [
+        "wizards/mail_compose_gateway_message.xml",
         "wizards/mail_message_gateway_link.xml",
         "wizards/mail_message_gateway_send.xml",
         "wizards/mail_guest_manage.xml",

--- a/mail_gateway/models/res_partner.py
+++ b/mail_gateway/models/res_partner.py
@@ -66,6 +66,23 @@ class ResPartnerGatewayChannel(models.Model):
         "res.company", related="gateway_id.company_id", store=True
     )
 
+    def name_get(self):
+        result = []
+        origin = super().name_get()
+        if not self.env.context.get("mail_gateway_partner_info", False):
+            return origin
+        origin_dict = dict(origin)
+        for record in self:
+            result.append(
+                (
+                    record.id,
+                    "{} ({})".format(
+                        record.partner_id.display_name, origin_dict[record.id]
+                    ),
+                )
+            )
+        return result
+
     _sql_constraints = [
         (
             "unique_partner_gateway",

--- a/mail_gateway/models/res_partner.py
+++ b/mail_gateway/models/res_partner.py
@@ -67,6 +67,8 @@ class ResPartnerGatewayChannel(models.Model):
     )
 
     def name_get(self):
+        # Be able to tell to which partner belongs the gateway partner channel
+        # e.g.: picking it from a selector
         result = []
         origin = super().name_get()
         if not self.env.context.get("mail_gateway_partner_info", False):

--- a/mail_gateway/security/ir.model.access.csv
+++ b/mail_gateway/security/ir.model.access.csv
@@ -7,3 +7,4 @@ access_mail_gateway_all,mail.telegram.bot.all,model_mail_gateway,,1,0,0,0
 access_mail_guest_manage,mail.telegram.bot.all,model_mail_guest_manage,base.group_user,1,1,1,1
 access_mail_message_gateway_link,mail.message.link.all,model_mail_message_gateway_link,base.group_user,1,1,1,1
 access_mail_gateway_system,mail_gateway,model_mail_gateway,base.group_system,1,1,1,1
+access_mail_compose_gateway_message,access.mail.compose.gateway.message,model_mail_compose_gateway_message,base.group_user,1,1,1,0

--- a/mail_gateway/wizards/__init__.py
+++ b/mail_gateway/wizards/__init__.py
@@ -1,3 +1,4 @@
 from . import mail_guest_manage
 from . import mail_message_gateway_send
 from . import mail_message_gateway_link
+from . import mail_compose_gateway_message

--- a/mail_gateway/wizards/mail_compose_gateway_message.py
+++ b/mail_gateway/wizards/mail_compose_gateway_message.py
@@ -28,7 +28,6 @@ class MailComposeGatewayMessage(models.TransientModel):
         "attachment_id",
         "Attachments",
     )
-
     partner_ids = fields.Many2many(
         "res.partner",
         "mail_compose_gateway_message_res_partner_rel",
@@ -36,6 +35,30 @@ class MailComposeGatewayMessage(models.TransientModel):
         "partner_id",
         "Additional Contacts",
         domain=lambda r: r._partner_ids_domain(),
+    )
+    # Dummy compatibility with other OCA modules
+    # OCA/mail_attach_existing_attachment
+    object_attachment_ids = fields.Many2many(
+        comodel_name="ir.attachment",
+        relation="mail_compose_gateway_message_ir_attachments_object_rel",
+        column1="wizard_id",
+        column2="attachment_id",
+        string="Object Attachments",
+    )
+    # OCA/mail_composer_cc_bcc
+    partner_cc_ids = fields.Many2many(
+        comodel_name="res.partner",
+        relation="mail_compose_gateway_message_res_partner_cc_rel",
+        column1="wizard_id",
+        column2="partner_id",
+        string="Cc",
+    )
+    partner_bcc_ids = fields.Many2many(
+        comodel_name="res.partner",
+        relation="mail_compose_gateway_message_res_partner_bcc_rel",
+        column1="wizard_id",
+        column2="partner_id",
+        string="Bcc",
     )
 
     def get_mail_values(self, res_ids):

--- a/mail_gateway/wizards/mail_compose_gateway_message.py
+++ b/mail_gateway/wizards/mail_compose_gateway_message.py
@@ -1,0 +1,52 @@
+# Copyright 2024 Dixmit
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class MailComposeGatewayMessage(models.TransientModel):
+    _name = "mail.compose.gateway.message"
+    _inherit = "mail.compose.message"
+    _description = "Mail Compose Gateway Message"
+
+    wizard_partner_ids = fields.Many2many(
+        "res.partner",
+        "mail_compose_gateway_message_res_partner_rel",
+        "wizard_id",
+        "partner_id",
+    )
+    wizard_channel_ids = fields.Many2many(
+        "res.partner.gateway.channel",
+        "mail_compose_gateway_message_gateway_channel_rel",
+        "wizard_id",
+        "channel_id",
+    )
+    attachment_ids = fields.Many2many(
+        "ir.attachment",
+        "mail_compose_gateway_message_ir_attachments_rel",
+        "wizard_id",
+        "attachment_id",
+        "Attachments",
+    )
+
+    partner_ids = fields.Many2many(
+        "res.partner",
+        "mail_compose_gateway_message_res_partner_rel",
+        "wizard_id",
+        "partner_id",
+        "Additional Contacts",
+        domain=lambda r: r._partner_ids_domain(),
+    )
+
+    def get_mail_values(self, res_ids):
+        self.ensure_one()
+        res = super(MailComposeGatewayMessage, self).get_mail_values(res_ids)
+        res[res_ids[0]]["gateway_notifications"] = [
+            {
+                "partner_id": channel.partner_id.id,
+                "channel_type": "gateway",
+                "gateway_channel_id": channel.id,
+            }
+            for channel in self.wizard_channel_ids
+        ]
+        return res

--- a/mail_gateway/wizards/mail_compose_gateway_message.xml
+++ b/mail_gateway/wizards/mail_compose_gateway_message.xml
@@ -8,13 +8,17 @@
         <field name="inherit_id" ref="mail.email_compose_message_wizard_form" />
         <field name="mode">primary</field>
         <field name="arch" type="xml">
+            <label for="partner_ids" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </label>
             <field name="partner_ids" position="attributes">
                 <attribute name="invisible">1</attribute>
             </field>
-            <field name="body" position="before">
+            <field name="subject" position="before">
                 <field name="wizard_partner_ids" invisible="1" />
                 <field
                     name="wizard_channel_ids"
+                    string="Gateways"
                     widget="many2many_tags"
                     context="{'mail_gateway_partner_info': 1}"
                     domain="[('partner_id', 'in', wizard_partner_ids)]"

--- a/mail_gateway/wizards/mail_compose_gateway_message.xml
+++ b/mail_gateway/wizards/mail_compose_gateway_message.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 Dixmit
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="mail_compose_gateway_message_form_view">
+        <field name="model">mail.compose.gateway.message</field>
+        <field name="inherit_id" ref="mail.email_compose_message_wizard_form" />
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <field name="partner_ids" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+            <field name="body" position="before">
+                <field name="wizard_partner_ids" invisible="1" />
+                <field
+                    name="wizard_channel_ids"
+                    widget="many2many_tags"
+                    context="{'mail_gateway_partner_info': 1}"
+                    domain="[('partner_id', 'in', wizard_partner_ids)]"
+                />
+            </field>
+            <field name="subject" position="attributes">
+                <attribute name="invisible">1</attribute>
+                <attribute name="required">0</attribute>
+            </field>
+            <xpath
+                expr="//span[@name='document_followers_text']/.."
+                position="attributes"
+            >
+                <attribute name="invisible">1</attribute>
+                <attribute name="attrs" />
+            </xpath>
+        </field>
+    </record>
+
+
+
+</odoo>


### PR DESCRIPTION
extending #1443 

Just added dummy compatibility with `mail_attach_existing_attachment` and `mail_composer_cc_bcc`


TT51108 cc @Tecnativa 

please check @etobella @pedrobaeza 