### PR TITLE
[16.0][IMP] mail_quoted_reply: Sanitize HTML body before quoting

### DIFF
--- a/mail_quoted_reply/models/mail_message.py
+++ b/mail_quoted_reply/models/mail_message.py
@@ -2,11 +2,15 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, models
-from odoo.tools import format_datetime
+from odoo.tools import format_datetime, html_sanitize
 
 
 class MailMessage(models.Model):
     _inherit = "mail.message"
+
+    def _get_sanitized_body(self):
+        self.ensure_one()
+        return html_sanitize(self.body)
 
     def _prep_quoted_reply_body(self):
         return """
@@ -29,7 +33,7 @@ class MailMessage(models.Model):
             email_from=self.email_from,
             date=format_datetime(self.env, self.date),
             subject=self.subject,
-            body=self.body,
+            body=self._get_sanitized_body(),
             signature=self.env.user.signature,
             str_date=_("Date"),
             str_subject=_("Subject"),

--- a/mail_quoted_reply/readme/CONTRIBUTORS.rst
+++ b/mail_quoted_reply/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
 * Giuseppe Borruso <gborruso@dinamicheaziendali.it>
 * Laurence Labusch <lala@labiso.de>
 * Dani Forga
+* Akim Juillerat <akim.juillerat@camptocamp.com>


### PR DESCRIPTION
As we are adding HTML from external messages into the mail composer HTML widget, we do not control what is in there and it could break the webclient or making it unresponsive depending on its content.

Sanitizing the body of the quoted message might not solve all the issues, but it at least provides a hook for extra processing.