### PR TITLE
[16.0][FIX]mail_quoted_reply: reply remove comments

### DIFF
--- a/mail_quoted_reply/models/mail_message.py
+++ b/mail_quoted_reply/models/mail_message.py
@@ -1,6 +1,8 @@
 # Copyright 2021 Creu Blanca
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import re
+
 from odoo import _, models
 from odoo.tools import format_datetime
 
@@ -9,7 +11,7 @@ class MailMessage(models.Model):
     _inherit = "mail.message"
 
     def _prep_quoted_reply_body(self):
-        return """
+        quoted_reply_body = """
             <div style="margin: 0px; padding: 0px;">
             <p style="margin:0px 0 12px 0;box-sizing:border-box;">
             <br />
@@ -35,6 +37,9 @@ class MailMessage(models.Model):
             str_subject=_("Subject"),
             str_from=_("From"),
         )
+        regex = "(<!--.*?-->)"
+        quoted_reply_body = re.sub(regex, "", quoted_reply_body, 0, re.DOTALL)
+        return quoted_reply_body
 
     def _default_reply_partner(self):
         return self.env["res.partner"].find_or_create(self.email_from).ids

--- a/mail_quoted_reply/tests/test_reply.py
+++ b/mail_quoted_reply/tests/test_reply.py
@@ -14,7 +14,7 @@ class TestMessageReply(TransactionCase):
         )
         # pylint: disable=C8107
         message = partner.message_post(
-            body="demo message",
+            body="demo message<!-- test comment -->",
             message_type="email",
             partner_ids=self.env.ref("base.partner_demo").ids,
         )
@@ -29,6 +29,10 @@ class TestMessageReply(TransactionCase):
             )
         )
         action = message.reply_message()
+
+        quote_body = action.get("context", {}).get("quote_body", "")
+        self.assertFalse("<!-- test comment -->" in quote_body)
+
         wizard = (
             self.env[action["res_model"]].with_context(**action["context"]).create({})
         )


### PR DESCRIPTION
Remove html comments of the reply body. They are normally not needed and caused errors in the wizard for our customer. For example: in case of 2 comments are right after each other the user cannot change the content of the composer. Odoo removes comments from all mail related html (No comments possible at mail template body).