### PR TITLE
[16.0][FIX] mail_composer_cc_bcc: fix duplicate key value error "unique_mail_message_id_res_partner_id_if_set"

### DIFF
--- a/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
+++ b/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
@@ -104,14 +104,14 @@ class TestMailCcBcc(TestMailComposer):
         # Company default values
         env.company.default_partner_cc_ids = self.partner_cc3
         env.company.default_partner_bcc_ids = self.partner_cc2
-        # Res Partner values
-        res_partner_model = env["ir.model"].search([("model", "=", "res.partner")])
+        # Partner template values
+        tmpl_model = env["ir.model"].search([("model", "=", "res.partner")])
         partner_cc = self.partner_cc
         partner_bcc = self.partner_bcc
         vals = {
-            "name": "Contact: New Contact",
-            "model_id": res_partner_model.id,
-            "subject": "Re: New Contact",
+            "name": "Test Template",
+            "model_id": tmpl_model.id,
+            "subject": "Re: [E-COM11] Cabinet with Doors",
             "body_html": """<p style="margin:0px 0 12px 0;box-sizing:border-box;">
         New Contact<br></p>""",
             "email_cc": tools.formataddr(
@@ -121,18 +121,18 @@ class TestMailCcBcc(TestMailComposer):
                 (partner_bcc.name or "False", partner_bcc.email or "False")
             ),
         }
-        mail_tmpl = env["mail.template"].create(vals)
+        partner_tmpl = env["mail.template"].create(vals)
         # Open mail composer form and check for default values from company
         form = self.open_mail_composer_form()
         composer = form.save()
         self.assertEqual(composer.partner_cc_ids, self.partner_cc3)
         self.assertEqual(composer.partner_bcc_ids, self.partner_cc2)
         # Change email template and check for values from it
-        form.template_id = mail_tmpl
+        form.template_id = partner_tmpl
         composer = form.save()
         # Beside existing Cc and Bcc, add template's ones
         form = Form(composer)
-        form.template_id = mail_tmpl
+        form.template_id = partner_tmpl
         composer = form.save()
         expecting = self.partner_cc3 + self.partner_cc
         self.assertEqual(composer.partner_cc_ids, expecting)
@@ -146,8 +146,8 @@ class TestMailCcBcc(TestMailComposer):
         form = Form(composer)
         form.template_id = env["mail.template"]
         form.save()
-        self.assertFalse(form.template_id)
-        form.template_id = mail_tmpl
+        self.assertFalse(form.template_id)  # no template
+        form.template_id = partner_tmpl
         composer = form.save()
         expecting = self.partner_cc3 + self.partner_cc
         self.assertEqual(composer.partner_cc_ids, expecting)

--- a/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
+++ b/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
@@ -4,11 +4,13 @@
 import hashlib
 import inspect
 import logging
+from unittest.mock import patch
 
 from odoo import tools
 from odoo.tests import Form
 
 from odoo.addons.mail.models.mail_mail import MailMail as upstream
+from odoo.addons.mail.models.mail_thread import MailThread
 from odoo.addons.mail.tests.test_mail_composer import TestMailComposer
 
 # When Odoo upstream function _send in the mall.mail model, that has been fully
@@ -194,3 +196,59 @@ class TestMailCcBcc(TestMailComposer):
             if subject == mail.get("subject"):
                 sent_mails += 1
         self.assertEqual(sent_mails, 1)
+
+    def test_tracking_mail_without_cc_bcc(self):
+        Partner = self.env["res.partner"]
+        p1 = Partner.create(
+            {"name": "Customer1", "email": "test1@test.example.com"}
+        ).with_context(mail_notrack=False)
+        self.cr.precommit.clear()
+        p2 = Partner.create({"name": "Customer2", "email": "test2@test.example.com"})
+
+        original_message_post = MailThread.message_post
+
+        def patched_message_post(self, **kwargs):
+            self = self.with_context(
+                mail_post_autofollow=self.env.context.get("mail_post_autofollow", True),
+            )
+            # to trigger tracking email
+            p1.write({"email": "test@test.example.com"})
+            return original_message_post(self, **kwargs)
+
+        ctx = {
+            "default_partner_ids": p1.ids,
+            "default_model": Partner._name,
+            "default_res_id": p1.id,
+            "mail_notify_force_send": True,
+        }
+        form = Form(self.env["mail.compose.message"].with_context(**ctx))
+        form.body = "<p>Hello</p>"
+        composer = form.save()
+        composer.partner_bcc_ids = p2.ids
+        with self.mock_mail_gateway(), self.mock_mail_app(), patch(
+            "odoo.addons.mail.models.mail_thread.MailThread.message_post",
+            new=patched_message_post,
+        ):
+            composer._action_send_mail()
+            self.flush_tracking()
+        self.assertEqual(
+            len(self._new_msgs),
+            2,
+        )
+        self.assertEqual(
+            self.ref("mail.mt_note"),
+            self._new_msgs[1].subtype_id.id,
+            "Expected a tracking message",
+        )
+
+        # Main email should include cc/bcc
+        main_message = self._new_msgs.filtered(lambda x: x.message_type == "comment")
+        self.assertEqual(len(main_message.notified_partner_ids), 2)
+        self.assertEqual(len(main_message.notification_ids), 2)
+        main_mail = main_message.mail_ids
+        self.assertEqual(len(main_mail.recipient_ids), 2)
+
+        # tracking email should not include cc/bcc
+        tracking_message = self._new_msgs.filtered(lambda x: x.message_type == "note")
+        tracking_field_mail = tracking_message.mail_ids
+        self.assertFalse(tracking_field_mail.email_bcc)


### PR DESCRIPTION
### Note
- Took over this PR: https://github.com/OCA/social/pull/1428
- depends on: https://github.com/OCA/social/pull/1519#pullrequestreview-2504965314
- Took this chance to
    - Fix `https://github.com/OCA/social/issues/1263`
       - it was fixed in `https://github.com/OCA/social/pull/1309`
       - But there is a case, described in `https://github.com/OCA/social/pull/1310#issuecomment-2186838432` , which was not covered.
    - Backport from `17.0`: using `res.partner `instead `product.template` in test. Otherwise, tests cannot run because model product.template is not in environment.

### Result

[mail_composer_cc_bcc_16.webm](https://github.com/user-attachments/assets/94096617-8331-4427-9364-ad5098ec63d9)
