### PR TITLE
[16.0][IMP] mail_show_follower: Add an option to exclude specific models from the CC note

### DIFF
--- a/mail_show_follower/README.rst
+++ b/mail_show_follower/README.rst
@@ -49,6 +49,7 @@ To configure this module, you need to:
 #. Go General settings/Discuss/Show Followers on mails/Text 'Sent to' and set the initial part of the message.
 #. Go General settings/Discuss/Show Followers on mails/Partner format and choose desired fields to show on CC recipients.
 #. Go General settings/Discuss/Show Followers on mails/Text 'Replies' and choose desired warn message
+#. Go General settings/Discuss/Show Followers in 'Models to exclude' enter the models you want to exclude from the CC note.
 
 Usage
 =====

--- a/mail_show_follower/__manifest__.py
+++ b/mail_show_follower/__manifest__.py
@@ -15,6 +15,7 @@
     "depends": ["base", "mail"],
     "maintainers": ["yajo"],
     "data": [
+        "data/config_parameter_data.xml",
         "views/res_config_settings.xml",
         "views/res_users.xml",
     ],

--- a/mail_show_follower/data/config_parameter_data.xml
+++ b/mail_show_follower/data/config_parameter_data.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="models_to_exclude_config_parameter" model="ir.config_parameter">
+        <field name="key">show_followers.models_to_exclude</field>
+        <field name="value">blog.blog,blog.post</field>
+    </record>
+</odoo>

--- a/mail_show_follower/data/config_parameter_data.xml
+++ b/mail_show_follower/data/config_parameter_data.xml
@@ -2,6 +2,8 @@
 <odoo noupdate="1">
     <record id="models_to_exclude_config_parameter" model="ir.config_parameter">
         <field name="key">show_followers.models_to_exclude</field>
-        <field name="value">blog.blog,blog.post</field>
+        <field
+            name="value"
+        >blog.blog,blog.post,slide.slide,slide.channel,forum.forum,forum.post</field>
     </record>
 </odoo>

--- a/mail_show_follower/models/mail_mail.py
+++ b/mail_show_follower/models/mail_mail.py
@@ -60,9 +60,15 @@ class MailMail(models.Model):
 
     def _send(self, auto_commit=False, raise_exception=False, smtp_session=None):
         group_user = self.env.ref("base.group_user")
-
+        models_to_exclude = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("show_followers.models_to_exclude", "")
+        )
         for mail in self:
             if not (mail.model and mail.res_id and group_user):
+                continue
+            if models_to_exclude and mail.model in models_to_exclude.split(","):
                 continue
             # recipients from any Notification Type (i.e. email, inbox, etc.)
             recipients = mail.notification_ids.res_partner_id

--- a/mail_show_follower/models/res_config_settings.py
+++ b/mail_show_follower/models/res_config_settings.py
@@ -29,6 +29,10 @@ class ResConfigSettings(models.TransientModel):
         readonly=True,
         store=False,
     )
+    show_followers_models_to_exclude = fields.Char(
+        help="Tecnichal model names separated by coma",
+        config_parameter="show_followers.models_to_exclude",
+    )
 
     @api.onchange(
         "show_followers_message_sent_to",

--- a/mail_show_follower/readme/CONFIGURE.rst
+++ b/mail_show_follower/readme/CONFIGURE.rst
@@ -5,3 +5,4 @@ To configure this module, you need to:
 #. Go General settings/Discuss/Show Followers on mails/Text 'Sent to' and set the initial part of the message.
 #. Go General settings/Discuss/Show Followers on mails/Partner format and choose desired fields to show on CC recipients.
 #. Go General settings/Discuss/Show Followers on mails/Text 'Replies' and choose desired warn message
+#. Go General settings/Discuss/Show Followers in 'Models to exclude' enter the models you want to exclude from the CC note.

--- a/mail_show_follower/static/description/index.html
+++ b/mail_show_follower/static/description/index.html
@@ -399,6 +399,7 @@ In the cc, only appear when:</p>
 <li>Go General settings/Discuss/Show Followers on mails/Text ‘Sent to’ and set the initial part of the message.</li>
 <li>Go General settings/Discuss/Show Followers on mails/Partner format and choose desired fields to show on CC recipients.</li>
 <li>Go General settings/Discuss/Show Followers on mails/Text ‘Replies’ and choose desired warn message</li>
+<li>Go General settings/Discuss/Show Followers in ‘Models to exclude’ enter the models you want to exclude from the CC note.</li>
 </ol>
 </div>
 <div class="section" id="usage">

--- a/mail_show_follower/views/res_config_settings.xml
+++ b/mail_show_follower/views/res_config_settings.xml
@@ -62,6 +62,19 @@
                                         style="display:inline-block;"
                                     />
                                 </div>
+                                <div>
+                                    <label
+                                        for="show_followers_models_to_exclude"
+                                        string="Models to exclude"
+                                        class="o_light_label"
+                                        style="vertical-align: top;"
+                                    />
+                                    <field
+                                        name="show_followers_models_to_exclude"
+                                        placeholder="blog.blog,blog.post"
+                                        style="display:inline-block;"
+                                    />
+                                </div>
                             </div>
                             <label
                                 for="show_followers_message_preview"


### PR DESCRIPTION
Forward-port of  https://github.com/OCA/social/pull/1483 and https://github.com/OCA/social/pull/1491.

@qrtl QT4946