### PR TITLE
[16.0][FIX] mail_show_follower: Company identification in _send()

### DIFF
--- a/mail_show_follower/models/mail_mail.py
+++ b/mail_show_follower/models/mail_mail.py
@@ -73,7 +73,9 @@ class MailMail(models.Model):
             # recipients from any Notification Type (i.e. email, inbox, etc.)
             recipients = mail.notification_ids.res_partner_id
             record = self.env[mail.model].browse(mail.res_id)
-            company = getattr(record, "company_id", self.env.company)
+            company = getattr(record, "company_id", False)
+            if not company:
+                company = self.env.company
             show_internal_users = company and company.show_internal_users_cc
             show_in_cc_recipients = recipients._filter_shown_in_cc(show_internal_users)
             if len(show_in_cc_recipients) <= 1:


### PR DESCRIPTION
Before this commit, 'Show Internal Users CC' would always be False, regardless of the setting in the company, in case the message came from a record with a company_id field but without a value assignment to it (e.g., a partner record with no company), as company would be an empty record.

This commit fixes the behavior by capturing company from self.env in these cases.

@qrtl QT5021