### PR TITLE
[FIX] mail_send_copy: work with existing BCC+adding tests

### DIFF
--- a/mail_send_copy/models/ir_mail_server.py
+++ b/mail_send_copy/models/ir_mail_server.py
@@ -2,9 +2,12 @@
 # @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import logging
 from email.utils import COMMASPACE
 
 from odoo import api, models
+
+_logger = logging.getLogger(__name__)
 
 
 class IrMailServer(models.Model):
@@ -14,8 +17,20 @@ class IrMailServer(models.Model):
     def send_email(self, message, *args, **kwargs):
         do_not_send_copy = self.env.context.get("do_not_send_copy", False)
         if not do_not_send_copy:
-            if message["Bcc"]:
-                message["Bcc"] = message["Bcc"].join(COMMASPACE, message["From"])
+            # Get existing Bcc recipients (if any)
+            bcc = message.get("Bcc", "")
+            from_addr = message.get("From", "")
+
+            # Combine existing Bcc with From address
+            if bcc:
+                all_bcc = COMMASPACE.join([bcc, from_addr])
             else:
-                message["Bcc"] = message["From"]
+                all_bcc = from_addr
+
+            # Set the combined Bcc
+            if "Bcc" in message:
+                message.replace_header("Bcc", all_bcc)
+            else:
+                message.add_header("Bcc", all_bcc)
+
         return super().send_email(message, *args, **kwargs)

--- a/mail_send_copy/static/description/index.html
+++ b/mail_send_copy/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -431,7 +431,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h3><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/mail_send_copy/tests/__init__.py
+++ b/mail_send_copy/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_mail_send_copy

--- a/mail_send_copy/tests/test_mail_send_copy.py
+++ b/mail_send_copy/tests/test_mail_send_copy.py
@@ -1,0 +1,105 @@
+# Copyright from 2024: Alwinen GmbH (https://www.alwinen.de)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+# TODO: find a way to test sending email with existing BCC
+
+from unittest.mock import patch
+
+from odoo.tests import tagged
+
+from odoo.addons.mail.tests.test_mail_composer import TestMailComposer
+
+
+class TestMailSendCopy(TestMailComposer):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context={"testing": True})
+
+        # Create test partner
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Test Partner",
+                "email": "test@example.com",
+            }
+        )
+
+    def test_send_email_with_copy(self):
+        """Test that sender is added to BCC when sending email"""
+        composer = self.env["mail.compose.message"].create(
+            {
+                "partner_ids": [(6, 0, [self.partner.id])],
+                "subject": "Test Subject",
+                "body": "<p>Test Body</p>",
+                "email_from": "sender@example.com",
+            }
+        )
+
+        # Mock the send_email method
+        with patch(
+            "odoo.addons.base.models.ir_mail_server.IrMailServer.send_email"
+        ) as mock_send_email:
+            composer._action_send_mail()
+            # Verify that send_email was called
+            self.assertTrue(mock_send_email.called)
+            # Get the arguments passed to send_email
+            call_args = mock_send_email.call_args[0]
+            # The message is the first argument
+            message = call_args[0]
+            # Check BCC in the email message
+            self.assertIn("sender@example.com", message["Bcc"])
+
+    def test_send_email_without_copy(self):
+        """Test that sender is not added to BCC when do_not_send_copy is True"""
+        composer = (
+            self.env["mail.compose.message"]
+            .with_context(do_not_send_copy=True)
+            .create(
+                {
+                    "partner_ids": [(6, 0, [self.partner.id])],
+                    "subject": "Test Subject No Copy",
+                    "body": "<p>Test Body</p>",
+                    "email_from": "sender@example.com",
+                }
+            )
+        )
+
+        with patch(
+            "odoo.addons.base.models.ir_mail_server.IrMailServer.send_email"
+        ) as mock_send_email:
+            composer._action_send_mail()
+            self.assertTrue(mock_send_email.called)
+            message = mock_send_email.call_args[0][0]
+            self.assertNotIn("Bcc", message)
+
+
+# Code contributed by @trisdoan
+@tagged("post_install", "-at_install")
+class TestMailSendWithBcc(TestMailSendCopy):
+    def test_send_email_with_existing_bcc(self):
+        if not self.env["ir.module.module"].search(
+            [("name", "=", "mail_composer_cc_bcc"), ("state", "=", "installed")]
+        ):
+            self.skipTest("mail_composer_cc_bcc module is required for this test")
+
+        partner_bcc = self.env.ref("base.res_partner_main2")
+        composer = self.env["mail.compose.message"].create(
+            {
+                "partner_ids": [(6, 0, [self.partner.id])],
+                "subject": "Test Subject",
+                "body": "<p>Test Body</p>",
+                "email_from": "sender@example.com",
+            }
+        )
+        composer.partner_bcc_ids = partner_bcc
+
+        with patch(
+            "odoo.addons.base.models.ir_mail_server.IrMailServer.send_email"
+        ) as mock_send_email:
+            composer._action_send_mail()
+            # Verify that send_email was called
+            self.assertTrue(mock_send_email.called)
+            call_args = mock_send_email.call_args[0]
+            message = call_args[0]
+            # Check existing BCC in the email message
+            self.assertIn("dwayne.newman28@example.com", message["Bcc"])


### PR DESCRIPTION
1. mail_send_copy doesn't work with the module mail_composer_cc_bcc because there is a mistake in the line
`if message["Bcc"]:`
`      message["Bcc"] = message["Bcc"].join(COMMASPACE, message["From"])`
 This PR fixes this issue.
 
2. This PR adds tests as well