### PR TITLE
[17.0][IMP] mail_send_confirmation: wizard

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -17,7 +17,8 @@ odoo_test_flavor: Both
 odoo_version: 17.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
-rebel_module_groups: []
+rebel_module_groups:
+  - mail_send_confirmation
 repo_description: '{''TODO'': ''add repo description.''}'
 repo_name: social
 repo_slug: social

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,20 @@ jobs:
         include:
           - container: ghcr.io/oca/oca-ci/py3.10-odoo17.0:latest
             name: test with Odoo
+            exclude: "mail_send_confirmation"
           - container: ghcr.io/oca/oca-ci/py3.10-ocb17.0:latest
             name: test with OCB
             makepot: "true"
+            exclude: "mail_send_confirmation"
+          - container: ghcr.io/oca/oca-ci/py3.10-odoo17.0:latest
+            name: test with Odoo
+            include: "mail_send_confirmation"
+          - container: ghcr.io/oca/oca-ci/py3.10-ocb17.0:latest
+            name: test with OCB
+            include: "mail_send_confirmation"
+    env:
+      INCLUDE: "${{ matrix.include }}"
+      EXCLUDE: "${{ matrix.exclude }}"
     services:
       postgres:
         image: postgres:12.0

--- a/mail_send_confirmation/README.rst
+++ b/mail_send_confirmation/README.rst
@@ -66,13 +66,13 @@ Authors
 Contributors
 ------------
 
--  `Quartile <https://www.quartile.co>`__:
+- `Quartile <https://www.quartile.co>`__:
 
-   -  Aung Ko Ko Lin
+  - Aung Ko Ko Lin
 
--  `360ERP <https://www.360erp.com>`__:
+- `360ERP <https://www.360erp.com>`__:
 
-   -  Andrea Stirpe
+  - Andrea Stirpe
 
 Maintainers
 -----------

--- a/mail_send_confirmation/__manifest__.py
+++ b/mail_send_confirmation/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Quartile Limited
+# Copyright 2025 CorporateHub
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Mail Send Confirmation",
@@ -13,5 +14,8 @@
             "mail_send_confirmation/static/src/models/composer_view.esm.js",
         ],
     },
+    "data": [
+        "views/mail_compose_message.xml",
+    ],
     "installable": True,
 }

--- a/mail_send_confirmation/readme/CONTRIBUTORS.md
+++ b/mail_send_confirmation/readme/CONTRIBUTORS.md
@@ -2,3 +2,5 @@
   - Aung Ko Ko Lin
 - [360ERP](https://www.360erp.com):
   - Andrea Stirpe
+- [CorporateHub](https://corporatehub.eu/)
+  - Alexey Pelykh \<<alexey.pelykh@corphub.eu>\>

--- a/mail_send_confirmation/readme/DESCRIPTION.md
+++ b/mail_send_confirmation/readme/DESCRIPTION.md
@@ -1,10 +1,3 @@
 This module asks for confirmation when 'Send' button in the message
-composer of the chatter is pressed, to reduce the chances of
-accidentally sending an internal message to the external followers.
-
-## Limitation
-
-As of now, this module does not change the behavior of the full composer
-(i.e. no confirmation will be requested), which shows the recipients and
-therefore the extra confirmation step may not be as necessary as in the
-simple composer.
+composer is pressed, to reduce the chances of accidentally sending an
+internal message to the external followers.

--- a/mail_send_confirmation/static/description/index.html
+++ b/mail_send_confirmation/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -419,7 +420,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h1>Maintainers</h1>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/mail_send_confirmation/views/mail_compose_message.xml
+++ b/mail_send_confirmation/views/mail_compose_message.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="mail__email_compose_message_wizard_form" model="ir.ui.view">
+        <field name="name">mail.compose.message.form</field>
+        <field name="model">mail.compose.message</field>
+        <field name="inherit_id" ref="mail.email_compose_message_wizard_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_send_mail']" position="attributes">
+                <attribute
+                    name="confirm"
+                >This message will be sent to external partners as well. Are you sure you would like to send this message?</attribute>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Add confirmation to the wizard as well since even though the emails are shown in both cases, a confirmation reduces wrongfully sent messages
![Screenshot 2025-01-15 at 18 25 24](https://github.com/user-attachments/assets/2b32e576-217f-4452-bdba-7f189a8e0abb)
