### PR TITLE
[16.0][FIX]mail_composer_cc_bcc: recipients ignored

### DIFF
--- a/mail_composer_cc_bcc/models/mail_mail.py
+++ b/mail_composer_cc_bcc/models/mail_mail.py
@@ -268,8 +268,8 @@ class MailMail(models.Model):
             body=email.get("body"),
             body_alternative=email.get("body_alternative"),
             # ===== Different than native Odoo =====
-            email_cc=mail.email_cc,
-            email_bcc=mail.email_bcc,
+            email_cc=email.get("email_cc"),
+            email_bcc=email.get("email_bcc"),
             # ===== Same with native Odoo =====
             reply_to=mail.reply_to,
             attachments=attachments,
@@ -291,6 +291,18 @@ class MailMail(models.Model):
         partner_to_ids = [r.id for r in self.recipient_ids if r not in partners_cc_bcc]
         partner_to = self.env["res.partner"].browse(partner_to_ids)
         res["email_to"] = format_emails(partner_to)
-        res["email_cc"] = format_emails(self.recipient_cc_ids)
-        res["email_bcc"] = format_emails(self.recipient_bcc_ids)
+        mail_recipients_cc_bcc = {}
+        email_cc = format_emails(self.recipient_cc_ids)
+        res["email_cc"] = email_cc
+        if email_cc:
+            mail_recipients_cc_bcc.update({"email_cc": email_cc})
+        email_bcc = format_emails(self.recipient_bcc_ids)
+        res["email_bcc"] = email_bcc
+        if email_bcc:
+            mail_recipients_cc_bcc.update({"email_bcc": email_bcc})
+        if mail_recipients_cc_bcc:
+            self.write(mail_recipients_cc_bcc)
+        if res.get("email_to_normalized", []):
+            res.get("email_to_normalized").append(tools.email_normalize_all(email_cc))
+            res.get("email_to_normalized").append(tools.email_normalize_all(email_bcc))
         return res

--- a/mail_composer_cc_bcc/models/mail_thread.py
+++ b/mail_composer_cc_bcc/models/mail_thread.py
@@ -3,8 +3,6 @@
 
 from odoo import models
 
-from .mail_mail import format_emails
-
 
 class MailThread(models.AbstractModel):
     _inherit = "mail.thread"
@@ -18,24 +16,6 @@ class MailThread(models.AbstractModel):
         partners_bcc = context.get("partner_bcc_ids", None)
         if partners_bcc:
             res.recipient_bcc_ids = partners_bcc
-        return res
-
-    def _notify_by_email_get_base_mail_values(self, message, additional_values=None):
-        """
-        This is to add cc, bcc addresses to mail.mail objects so that email
-        can be sent to those addresses.
-        """
-        context = self.env.context
-
-        res = super()._notify_by_email_get_base_mail_values(
-            message, additional_values=additional_values
-        )
-        partners_cc = context.get("partner_cc_ids", None)
-        if partners_cc:
-            res["email_cc"] = format_emails(partners_cc)
-        partners_bcc = context.get("partner_bcc_ids", None)
-        if partners_bcc:
-            res["email_bcc"] = format_emails(partners_bcc)
         return res
 
     def _notify_get_recipients(self, message, msg_vals, **kwargs):


### PR DESCRIPTION
Odoo added the context 'send_validated_to' for Mails see commit https://github.com/odoo/odoo/pull/185793.
send_validated_to is a list of valid recipients. If the list contains at least one entry only the recipients of send_validated_to are valid. If the list is empty all recipients are valid. When sending an email from a composer the list of send_validated_to contains only the CC recipients and not the TO recipients. Therefore, only the CC recipients are valid and no TO recipient will receive the email.
