### PR TITLE
[17.0][IMP] mail_forward: Add option to forward a message to another thread

### DIFF
--- a/mail_forward/README.rst
+++ b/mail_forward/README.rst
@@ -29,13 +29,28 @@ Mail Forward Message
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module allows users to forward messages from the chatter of any
-document to other users, adding them as followers of the document
-without notifying the current followers.
+document to:
+
+- Other users in the same thread, adding them as followers of the
+  document without notifying the current followers.
+- Another thread, but not adding them as followers—only notifying the
+  current followers of the other thread.
 
 **Table of contents**
 
 .. contents::
    :local:
+
+Configuration
+=============
+
+To enable a model to forward messages to another thread:
+
+- With debug mode activated, go to
+  ``Settings -> Technical -> Database Structure -> Models``.
+- Search for the model you wish to enable.
+- Mark the option ``Enable Forward To`` and save. Transient models or
+  those without mail thread won't have this check visible.
 
 Usage
 =====
@@ -47,9 +62,11 @@ To use this module, follow these steps:
   notes).
 - A Forward icon will appear next to the message.
 - Click the button to display a wizard with the message.
-- Select the users to forward the message to.
-- Click the 'Send Mail' button to send the message to the selected
-  users.
+- Select the forward type (current thread or another thread).
+- Select the users to forward the message to, or select the other thread
+  according to the previous step.
+- Click the 'Send Mail' button to send the message to the selected users
+  or thread.
 
 Bug Tracker
 ===========
@@ -88,6 +105,14 @@ This module is maintained by the OCA.
 OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
+
+.. |maintainer-carlos-lopez-tecnativa| image:: https://github.com/carlos-lopez-tecnativa.png?size=40px
+    :target: https://github.com/carlos-lopez-tecnativa
+    :alt: carlos-lopez-tecnativa
+
+Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-carlos-lopez-tecnativa| 
 
 This module is part of the `OCA/social <https://github.com/OCA/social/tree/17.0/mail_forward>`_ project on GitHub.
 

--- a/mail_forward/__manifest__.py
+++ b/mail_forward/__manifest__.py
@@ -7,9 +7,7 @@
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/social",
     "depends": ["mail", "contacts"],
-    "data": [
-        "wizards/mail_compose_message_view.xml",
-    ],
+    "data": ["wizards/mail_compose_message_view.xml", "views/ir_model_views.xml"],
     "assets": {
         "web.assets_backend": [
             "mail_forward/static/src/**/*.esm.js",
@@ -22,4 +20,5 @@
     "installable": True,
     "auto_install": False,
     "license": "AGPL-3",
+    "maintainers": ["carlos-lopez-tecnativa"],
 }

--- a/mail_forward/i18n/es.po
+++ b/mail_forward/i18n/es.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.0\n"
+"Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-02 12:25+0000\n"
-"PO-Revision-Date: 2024-10-02 07:27-0500\n"
+"POT-Creation-Date: 2025-01-27 17:26+0000\n"
+"PO-Revision-Date: 2025-01-27 12:28-0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.0.1\n"
+"X-Generator: Poedit 3.5\n"
 
 #. module: mail_forward
 #. odoo-python
@@ -23,6 +23,16 @@ msgstr ""
 #, python-format
 msgid "---------- Forwarded message ---------"
 msgstr "---------- Mensaje reenviado ---------"
+
+#. module: mail_forward
+#: model:ir.model.fields.selection,name:mail_forward.selection__mail_compose_message__forward_type__another_thread
+msgid "Another thread"
+msgstr "Otro hilo"
+
+#. module: mail_forward
+#: model:ir.model.fields.selection,name:mail_forward.selection__mail_compose_message__forward_type__current_thread
+msgid "Current thread"
+msgstr "Hilo actual"
 
 #. module: mail_forward
 #. odoo-python
@@ -39,7 +49,22 @@ msgstr "Hilo de correos electrónicos"
 #. module: mail_forward
 #: model:ir.model,name:mail_forward.model_mail_compose_message
 msgid "Email composition wizard"
-msgstr "Asistente de composición de correos electrónicos"
+msgstr "Asistente de redacción de correo electrónico"
+
+#. module: mail_forward
+#: model:ir.model.fields,field_description:mail_forward.field_ir_model__enable_forward_to
+msgid "Enable Forward To"
+msgstr "Habilitar reenvío a"
+
+#. module: mail_forward
+#: model:ir.model.fields,help:mail_forward.field_ir_model__enable_forward_to
+msgid "Enable forwarding messages to records of this model."
+msgstr "Habilita el reenvío de mensajes a registros de este modelo."
+
+#. module: mail_forward
+#: model_terms:ir.ui.view,arch_db:mail_forward.mail_compose_message_forward_form
+msgid "Followers to notify"
+msgstr "Seguidores a notificar"
 
 #. module: mail_forward
 #. odoo-javascript
@@ -47,7 +72,7 @@ msgstr "Asistente de composición de correos electrónicos"
 #: code:addons/mail_forward/static/src/core/common/message_actions.esm.js:0
 #, python-format
 msgid "Forward"
-msgstr ""
+msgstr "Reenviar"
 
 #. module: mail_forward
 #. odoo-javascript
@@ -80,6 +105,11 @@ msgid "Forward Message Right"
 msgstr ""
 
 #. module: mail_forward
+#: model:ir.model.fields,field_description:mail_forward.field_mail_compose_message__forward_type
+msgid "Forward Type"
+msgstr "Tipo de reenvío"
+
+#. module: mail_forward
 #. odoo-python
 #: code:addons/mail_forward/models/mail_message.py:0
 #, python-format
@@ -91,12 +121,17 @@ msgstr "De"
 #: code:addons/mail_forward/wizards/mail_compose_message.py:0
 #, python-format
 msgid "Fwd:"
-msgstr ""
+msgstr "RV:"
 
 #. module: mail_forward
 #: model:ir.model,name:mail_forward.model_mail_message
 msgid "Message"
 msgstr "Mensaje"
+
+#. module: mail_forward
+#: model:ir.model,name:mail_forward.model_ir_model
+msgid "Models"
+msgstr "Modelos"
 
 #. module: mail_forward
 #. odoo-python
@@ -111,6 +146,11 @@ msgstr ""
 #, python-format
 msgid "Subject"
 msgstr "Asunto"
+
+#. module: mail_forward
+#: model:ir.model.fields,field_description:mail_forward.field_mail_compose_message__forward_thread
+msgid "Thread to forward"
+msgstr "Hilo a reenviar"
 
 #. module: mail_forward
 #. odoo-python

--- a/mail_forward/i18n/mail_forward.pot
+++ b/mail_forward/i18n/mail_forward.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-27 17:26+0000\n"
+"PO-Revision-Date: 2025-01-27 17:26+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,6 +20,16 @@ msgstr ""
 #: code:addons/mail_forward/models/mail_message.py:0
 #, python-format
 msgid "---------- Forwarded message ---------"
+msgstr ""
+
+#. module: mail_forward
+#: model:ir.model.fields.selection,name:mail_forward.selection__mail_compose_message__forward_type__another_thread
+msgid "Another thread"
+msgstr ""
+
+#. module: mail_forward
+#: model:ir.model.fields.selection,name:mail_forward.selection__mail_compose_message__forward_type__current_thread
+msgid "Current thread"
 msgstr ""
 
 #. module: mail_forward
@@ -35,6 +47,21 @@ msgstr ""
 #. module: mail_forward
 #: model:ir.model,name:mail_forward.model_mail_compose_message
 msgid "Email composition wizard"
+msgstr ""
+
+#. module: mail_forward
+#: model:ir.model.fields,field_description:mail_forward.field_ir_model__enable_forward_to
+msgid "Enable Forward To"
+msgstr ""
+
+#. module: mail_forward
+#: model:ir.model.fields,help:mail_forward.field_ir_model__enable_forward_to
+msgid "Enable forwarding messages to records of this model."
+msgstr ""
+
+#. module: mail_forward
+#: model_terms:ir.ui.view,arch_db:mail_forward.mail_compose_message_forward_form
+msgid "Followers to notify"
 msgstr ""
 
 #. module: mail_forward
@@ -77,6 +104,11 @@ msgid "Forward Message Right"
 msgstr ""
 
 #. module: mail_forward
+#: model:ir.model.fields,field_description:mail_forward.field_mail_compose_message__forward_type
+msgid "Forward Type"
+msgstr ""
+
+#. module: mail_forward
 #. odoo-python
 #: code:addons/mail_forward/models/mail_message.py:0
 #, python-format
@@ -96,6 +128,11 @@ msgid "Message"
 msgstr ""
 
 #. module: mail_forward
+#: model:ir.model,name:mail_forward.model_ir_model
+msgid "Models"
+msgstr ""
+
+#. module: mail_forward
 #. odoo-python
 #: code:addons/mail_forward/wizards/mail_compose_message.py:0
 #, python-format
@@ -107,6 +144,11 @@ msgstr ""
 #: code:addons/mail_forward/models/mail_message.py:0
 #, python-format
 msgid "Subject"
+msgstr ""
+
+#. module: mail_forward
+#: model:ir.model.fields,field_description:mail_forward.field_mail_compose_message__forward_thread
+msgid "Thread to forward"
 msgstr ""
 
 #. module: mail_forward

--- a/mail_forward/models/__init__.py
+++ b/mail_forward/models/__init__.py
@@ -1,2 +1,3 @@
+from . import ir_model
 from . import mail_message
 from . import mail_thread

--- a/mail_forward/models/ir_model.py
+++ b/mail_forward/models/ir_model.py
@@ -1,0 +1,9 @@
+from odoo import fields, models
+
+
+class IrModel(models.Model):
+    _inherit = "ir.model"
+
+    enable_forward_to = fields.Boolean(
+        help="Enable forwarding messages to records of this model."
+    )

--- a/mail_forward/models/mail_message.py
+++ b/mail_forward/models/mail_message.py
@@ -19,8 +19,6 @@ class MailMessage(models.Model):
             "default_model": self.model,
             "default_res_ids": [self.res_id],
             "default_composition_mode": "comment",
-            "default_body": self._build_message_body_for_forward(),
-            "default_attachment_ids": self.attachment_ids.ids,
             "default_is_log": False,
             "default_notify": True,
             "force_email": True,

--- a/mail_forward/models/mail_thread.py
+++ b/mail_forward/models/mail_thread.py
@@ -9,7 +9,10 @@ class MailThread(models.AbstractModel):
     def _notify_get_recipients(self, message, msg_vals, **kwargs):
         recipients_data = super()._notify_get_recipients(message, msg_vals, **kwargs)
         # only notify to explicit partners, remove others(followers).
-        if self.env.context.get("message_forwarded_id"):
+        if (
+            self.env.context.get("message_forwarded_id")
+            and self.env.context.get("forward_type", "") == "current_thread"
+        ):
             current_partners_ids = message.partner_ids.ids
             new_recipeints = []
             for recipeint in recipients_data:

--- a/mail_forward/readme/CONFIGURE.md
+++ b/mail_forward/readme/CONFIGURE.md
@@ -1,0 +1,5 @@
+To enable a model to forward messages to another thread:
+
+- With debug mode activated, go to `Settings -> Technical -> Database Structure -> Models`.
+- Search for the model you wish to enable. 
+- Mark the option `Enable Forward To` and save. Transient models or those without mail thread won't have this check visible.

--- a/mail_forward/readme/DESCRIPTION.md
+++ b/mail_forward/readme/DESCRIPTION.md
@@ -1,3 +1,3 @@
-This module allows users to forward messages from the chatter of any
-document to other users, adding them as followers of the document
-without notifying the current followers.
+This module allows users to forward messages from the chatter of any document to:
+- Other users in the same thread, adding them as followers of the document without notifying the current followers.
+- Another thread, but not adding them as followers—only notifying the current followers of the other thread.

--- a/mail_forward/readme/USAGE.md
+++ b/mail_forward/readme/USAGE.md
@@ -5,6 +5,7 @@ To use this module, follow these steps:
   notes).
 - A Forward icon will appear next to the message.
 - Click the button to display a wizard with the message.
-- Select the users to forward the message to.
-- Click the 'Send Mail' button to send the message to the selected
-  users.
+- Select the forward type (current thread or another thread).
+- Select the users to forward the message to, or select the other thread according to the previous step.
+- Click the 'Send Mail' button to send the message to the selected users or thread.
+  

--- a/mail_forward/static/description/index.html
+++ b/mail_forward/static/description/index.html
@@ -371,23 +371,40 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/social/tree/17.0/mail_forward"><img alt="OCA/social" src="https://img.shields.io/badge/github-OCA%2Fsocial-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/social-17-0/social-17-0-mail_forward"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/social&amp;target_branch=17.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module allows users to forward messages from the chatter of any
-document to other users, adding them as followers of the document
-without notifying the current followers.</p>
+document to:</p>
+<ul class="simple">
+<li>Other users in the same thread, adding them as followers of the
+document without notifying the current followers.</li>
+<li>Another thread, but not adding them as followers—only notifying the
+current followers of the other thread.</li>
+</ul>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
+<p>To enable a model to forward messages to another thread:</p>
+<ul class="simple">
+<li>With debug mode activated, go to
+<tt class="docutils literal">Settings <span class="pre">-&gt;</span> Technical <span class="pre">-&gt;</span> Database Structure <span class="pre">-&gt;</span> Models</tt>.</li>
+<li>Search for the model you wish to enable.</li>
+<li>Mark the option <tt class="docutils literal">Enable Forward To</tt> and save. Transient models or
+those without mail thread won’t have this check visible.</li>
+</ul>
+</div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
 <p>To use this module, follow these steps:</p>
 <ul class="simple">
 <li>Navigate to the chatter of any document.</li>
@@ -395,13 +412,15 @@ without notifying the current followers.</p>
 notes).</li>
 <li>A Forward icon will appear next to the message.</li>
 <li>Click the button to display a wizard with the message.</li>
-<li>Select the users to forward the message to.</li>
-<li>Click the ‘Send Mail’ button to send the message to the selected
-users.</li>
+<li>Select the forward type (current thread or another thread).</li>
+<li>Select the users to forward the message to, or select the other thread
+according to the previous step.</li>
+<li>Click the ‘Send Mail’ button to send the message to the selected users
+or thread.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/social/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -409,15 +428,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Carlos López</li>
@@ -426,7 +445,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
@@ -434,6 +453,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/carlos-lopez-tecnativa"><img alt="carlos-lopez-tecnativa" src="https://github.com/carlos-lopez-tecnativa.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/social/tree/17.0/mail_forward">OCA/social</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/mail_forward/views/ir_model_views.xml
+++ b/mail_forward/views/ir_model_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="view_ir_model_form" model="ir.ui.view">
+        <field name="name">view.ir.model.form</field>
+        <field name="model">ir.model</field>
+        <field name="inherit_id" ref="mail.model_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='is_mail_blacklist']" position="after">
+                <field
+                    name="enable_forward_to"
+                    groups="base.group_no_one"
+                    invisible="transient or not is_mail_thread"
+                />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/mail_forward/wizards/mail_compose_message.py
+++ b/mail_forward/wizards/mail_compose_message.py
@@ -1,10 +1,167 @@
 # Copyright 2024 Tecnativa - Carlos Lopez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-from odoo import Command, _, api, models
+from odoo import _, api, fields, models
 
 
 class MailComposeMessage(models.TransientModel):
     _inherit = "mail.compose.message"
+
+    forward_type = fields.Selection(
+        [
+            ("current_thread", "Current thread"),
+            ("another_thread", "Another thread"),
+        ],
+        default="current_thread",
+    )
+    forward_thread = fields.Reference(
+        selection="_selection_forward_thread", string="Thread to forward"
+    )
+
+    @api.model
+    def _selection_forward_thread(self):
+        # Get all models available to be selected by the user.
+        # Only consider models that support posted messages and are not transient.
+        models = (
+            self.env["ir.model"]
+            .sudo()
+            .search(
+                [
+                    ("transient", "=", False),
+                    ("is_mail_thread", "=", True),
+                    ("enable_forward_to", "=", True),
+                ],
+                order="name asc",
+            )
+        )
+        selection_values = []
+        for model in models:
+            if (
+                model.model in self.env and self.env[model.model]._auto
+            ):  # No Abstract models or reports
+                selection_values.append((model.model, model.name))
+        return selection_values
+
+    @api.depends(
+        "composition_mode",
+        "model",
+        "res_domain",
+        "res_ids",
+        "template_id",
+        "forward_type",
+    )
+    @api.depends_context("message_forwarded_id")
+    def _compute_attachment_ids(self):
+        # Save the attachments before calling super() to avoid losing them
+        # because when template_id is not set,
+        # attachment_ids is set to False in the super() call.
+        old_attachments = {composer.id: composer.attachment_ids for composer in self}
+        res = super()._compute_attachment_ids()
+        if self.env.context.get("message_forwarded_id"):
+            # Add the attachments from the original message.
+            message_forwarded = self.env["mail.message"].browse(
+                self.env.context["message_forwarded_id"]
+            )
+            for composer in self:
+                composer.attachment_ids |= old_attachments[composer.id]
+                for attachment in message_forwarded.attachment_ids:
+                    composer.attachment_ids |= attachment
+        return res
+
+    @api.depends(
+        "composition_mode",
+        "model",
+        "res_domain",
+        "res_ids",
+        "template_id",
+        "forward_type",
+        "forward_thread",
+    )
+    @api.depends_context("message_forwarded_id")
+    def _compute_body(self):
+        res = super()._compute_body()
+        if self.env.context.get("message_forwarded_id"):
+            # Set the body by default, taking it from the original message.
+            message_forwarded = self.env["mail.message"].browse(
+                self.env.context["message_forwarded_id"]
+            )
+            for composer in self.filtered(lambda c: not c.body):
+                composer.body = message_forwarded._build_message_body_for_forward()
+        return res
+
+    @api.depends(
+        "composition_mode",
+        "model",
+        "parent_id",
+        "record_name",
+        "res_domain",
+        "res_ids",
+        "template_id",
+        "forward_type",
+        "forward_thread",
+    )
+    @api.depends_context("message_forwarded_id")
+    def _compute_subject(self):
+        res = super()._compute_subject()
+        if self.env.context.get("message_forwarded_id"):
+            # Set the subject by default,
+            # because when change the model and res_ids,
+            # the subject is taken from the new record.
+            message_forwarded = self.env["mail.message"].browse(
+                self.env.context["message_forwarded_id"]
+            )
+            for composer in self:
+                composer.subject = f"{_('Fwd:')} {message_forwarded.subject}"
+        return res
+
+    @api.depends("composition_mode", "parent_id", "forward_type", "forward_thread")
+    @api.depends_context("message_forwarded_id")
+    def _compute_model(self):
+        res = super()._compute_model()
+        if self.env.context.get("message_forwarded_id"):
+            # Set the model to the record to be forwarded
+            # if the composer is set to forward a record
+            # it sends the message to the record to be forwarded
+            for composer in self.filtered(
+                lambda c: c.forward_type == "another_thread" and c.forward_thread
+            ):
+                composer.model = composer.forward_thread._name
+        return res
+
+    @api.depends("composition_mode", "parent_id", "forward_type", "forward_thread")
+    @api.depends_context("message_forwarded_id")
+    def _compute_res_ids(self):
+        res = super()._compute_res_ids()
+        if self.env.context.get("message_forwarded_id"):
+            # Set res_ids to the record to be forwarded
+            # if the composer is set to forward a record
+            # it sends the message to the record to be forwarded
+            for composer in self.filtered(
+                lambda c: c.forward_type == "another_thread" and c.forward_thread
+            ):
+                composer.res_ids = composer.forward_thread.ids
+        return res
+
+    @api.depends(
+        "composition_mode",
+        "model",
+        "parent_id",
+        "res_domain",
+        "res_ids",
+        "template_id",
+        "forward_type",
+    )
+    @api.depends_context("message_forwarded_id")
+    def _compute_partner_ids(self):
+        # Save the partner_ids before calling super() to avoid losing them
+        # because when template_id is not set,
+        # partner_ids is set to False in the super() call.
+        old_partners = {composer.id: composer.partner_ids for composer in self}
+        res = super()._compute_partner_ids()
+        if self.env.context.get("message_forwarded_id"):
+            # Add the attachments from the original message.
+            for composer in self:
+                composer.partner_ids |= old_partners[composer.id]
+        return res
 
     @api.model
     def get_record_data(self, values):
@@ -20,20 +177,6 @@ class MailComposeMessage(models.TransientModel):
         return result
 
     def _action_send_mail(self, auto_commit=False):
-        # duplicate attachments from original message
-        message_forwarded_id = self.env.context.get("message_forwarded_id")
-        if message_forwarded_id:
-            message_forwarded = self.env["mail.message"].browse(message_forwarded_id)
-            for wizard in self:
-                new_attachment_ids = []
-                for attachment in wizard.attachment_ids:
-                    if attachment in message_forwarded.attachment_ids:
-                        new_attachment = attachment.copy(
-                            {"res_model": "mail.compose.message", "res_id": wizard.id}
-                        )
-                        new_attachment_ids.append(new_attachment.id)
-                    else:
-                        new_attachment_ids.append(attachment.id)
-                new_attachment_ids.reverse()
-                wizard.write({"attachment_ids": [Command.set(new_attachment_ids)]})
-        return super()._action_send_mail(auto_commit=auto_commit)
+        return super(
+            MailComposeMessage, self.with_context(forward_type=self.forward_type)
+        )._action_send_mail(auto_commit=auto_commit)

--- a/mail_forward/wizards/mail_compose_message_view.xml
+++ b/mail_forward/wizards/mail_compose_message_view.xml
@@ -7,8 +7,25 @@
         <field name="priority" eval="100" />
         <field name="inherit_id" ref="mail.email_compose_message_wizard_form" />
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='email_from']" position="before">
+                <field
+                    name="forward_type"
+                    widget="radio"
+                    options="{'horizontal': true}"
+                    required="1"
+                />
+                <field
+                    name="forward_thread"
+                    options="{'no_create': True}"
+                    required="forward_type == 'another_thread'"
+                    invisible="forward_type != 'another_thread'"
+                />
+            </xpath>
             <xpath expr="//field[@name='partner_ids']" position="attributes">
-                <attribute name="required">1</attribute>
+                <attribute name="required">forward_type == 'current_thread'</attribute>
+            </xpath>
+            <xpath expr="//label[@for='partner_ids']" position="attributes">
+                <attribute name="string">Followers to notify</attribute>
             </xpath>
             <xpath expr="//span[@name='document_followers_text']" position="attributes">
                 <attribute name="invisible">1</attribute>


### PR DESCRIPTION
This option posts a new message in the other thread, including the attachments, but does not add them as followers—only notifying the current followers of the other thread.

TT54602
@Tecnativa @pedrobaeza @chienandalu 