### PR TITLE
[17.0][FIX] mail_activity_team: singleton in _compute_activity_team_id()

### DIFF
--- a/mail_activity_team/readme/CONTRIBUTORS.md
+++ b/mail_activity_team/readme/CONTRIBUTORS.md
@@ -12,3 +12,5 @@
 - [Camptocamp] (https://camptocamp.com):
   - Vincent Van Rossem <vincent.vanrossem@camptocamp.com>
   - Italo Lopes <italo.lopes@camptocamp.com>
+- [CorporateHub](https://corporatehub.eu/)
+  - Alexey Pelykh <alexey.pelykh@corphub.eu>

--- a/mail_activity_team/wizard/mail_activity_schedule.py
+++ b/mail_activity_team/wizard/mail_activity_schedule.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Camptocamp SA
+# Copyright 2024 CorporateHub
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
@@ -26,7 +27,7 @@ class MailActivitySchedule(models.TransientModel):
             elif not scheduler.activity_team_id:
                 scheduler.activity_team_id = (
                     self.env["mail.activity"]
-                    .with_context(default_res_model=self.sudo().res_model_id.model)
+                    .with_context(default_res_model=scheduler.sudo().res_model_id.model)
                     ._get_default_team_id(user_id=scheduler.activity_team_user_id.id)
                 )
 


### PR DESCRIPTION
Otherwise:

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/service/server.py", line 1326, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-16>", line 2, in new
  File "/home/odoo/src/odoo/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/odoo/modules/registry.py", line 110, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/odoo/modules/loading.py", line 481, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "/home/odoo/src/odoo/odoo/modules/loading.py", line 365, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/home/odoo/src/odoo/odoo/modules/loading.py", line 206, in load_module_graph
    registry.init_models(env.cr, model_names, {'module': package.name}, new_install)
  File "/home/odoo/src/odoo/odoo/modules/registry.py", line 582, in init_models
    func()
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_model.py", line 1948, in _reflect_relation
    self.env.invalidate_all()
  File "/home/odoo/src/odoo/odoo/api.py", line 711, in invalidate_all
    self.flush_all()
  File "/home/odoo/src/odoo/odoo/api.py", line 721, in flush_all
    self._recompute_all()
  File "/home/odoo/src/odoo/odoo/api.py", line 717, in _recompute_all
    self[field.model_name]._recompute_field(field)
  File "/home/odoo/src/odoo/odoo/models.py", line 6949, in _recompute_field
    field.recompute(records)
  File "/home/odoo/src/odoo/odoo/fields.py", line 1367, in recompute
    apply_except_missing(self.compute_value, recs)
  File "/home/odoo/src/odoo/odoo/fields.py", line 1340, in apply_except_missing
    func(records)
  File "/home/odoo/src/odoo/odoo/fields.py", line 1389, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/src/odoo/odoo/models.py", line 4913, in _compute_field_value
    fields.determine(field.compute, self)
  File "/home/odoo/src/odoo/odoo/fields.py", line 102, in determine
    return needle(*args)
  File "/home/odoo/src/user/mail_activity_team/wizard/mail_activity_schedule.py", line 29, in _compute_activity_team_id
    .with_context(default_res_model=self.sudo().res_model_id.model)
  File "/home/odoo/src/odoo/odoo/fields.py", line 1148, in __get__
    record.ensure_one()
  File "/home/odoo/src/odoo/odoo/models.py", line 5890, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
```