### PR TITLE
[16.0][FIX] mass_mailing_custom_unsubscribe: portal user permissions

### DIFF
--- a/mail_composer_cc_bcc/models/mail_mail.py
+++ b/mail_composer_cc_bcc/models/mail_mail.py
@@ -197,9 +197,12 @@ class MailMail(models.Model):
                     {"state": "sent", "message_id": res, "failure_reason": False}
                 )
                 _logger.info(
-                    "Mail with ID %r and Message-Id %r successfully sent",
+                    "Mail with ID %r and Message-Id %r from %r to (redacted) %r "
+                    "successfully sent",
                     mail.id,
                     mail.message_id,
+                    tools.email_normalize(msg["from"]),
+                    tools.mail.email_anonymize(tools.email_normalize(msg["to"])),
                 )
                 # /!\ can't use mail.state here, as mail.refresh() will cause an error
                 # see revid:odo@openerp.com-20120622152536-42b2s28lvdv3odyr in 6.1

--- a/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
+++ b/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
@@ -16,6 +16,7 @@ VALID_HASHES = [
     "5d1ab352416f5074e131f35f20098d5b",
     "46172c91183f2cb50b22a6b3b5e3869b",
     "8f26c4084cc7fc300e64d19ccdc944fe",
+    "db6cc0d3513a0c85bd716e4cb0a4d09c",
 ]
 
 

--- a/mass_mailing_custom_unsubscribe/security/ir.model.access.csv
+++ b/mass_mailing_custom_unsubscribe/security/ir.model.access.csv
@@ -1,5 +1,6 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 read_unsubscription_reason_public,Public users can read unsubscription reasons,model_mail_unsubscription_reason,base.group_public,1,0,0,0
+read_unsubscription_reason_portal,Portal users can read unsubscription reasons,model_mail_unsubscription_reason,base.group_portal,1,0,0,0
 read_unsubscription_reason_employee,Employee users can read unsubscription reasons,model_mail_unsubscription_reason,base.group_user,1,0,0,0
 write_unsubscription_reason,Mass mailing managers can manage unsubscription reasons,model_mail_unsubscription_reason,mass_mailing.group_mass_mailing_user,1,1,1,1
 read_unsubscription,Marketing users can read unsubscriptions,model_mail_unsubscription,mass_mailing.group_mass_mailing_user,1,0,0,0

--- a/mass_mailing_custom_unsubscribe/static/src/js/contact.tour.esm.js
+++ b/mass_mailing_custom_unsubscribe/static/src/js/contact.tour.esm.js
@@ -17,6 +17,10 @@ tour.register(
     },
     [
         {
+            content: "Confirm unsubscribe",
+            trigger: "button:contains('Unsubscribe')",
+        },
+        {
             content: "Choose other reason",
             trigger: ".radio:contains('Other reason') :radio:not(:checked)",
             extra_trigger: "#reason_form #custom_div_feedback",

--- a/mass_mailing_custom_unsubscribe/static/src/js/partner.tour.esm.js
+++ b/mass_mailing_custom_unsubscribe/static/src/js/partner.tour.esm.js
@@ -17,6 +17,10 @@ tour.register(
     },
     [
         {
+            content: "Confirm unsubscribe",
+            trigger: "button:contains('Unsubscribe')",
+        },
+        {
             content: "Choose other reason",
             trigger: ".radio:contains('Other reason') :radio:not(:checked)",
             extra_trigger: "#reason_form #custom_div_feedback",


### PR DESCRIPTION
Portal users need the same permissions as public ones to read the unsubscribe reasons.

cc @Tecnativa TT54814

please review @pilarvargas-tecnativa @pedrobaeza 