### PR TITLE
[17.0][FIX] mail_forward: Avoid error when forwarding a message while readireading the view

### DIFF
--- a/mail_forward/models/mail_message.py
+++ b/mail_forward/models/mail_message.py
@@ -8,7 +8,7 @@ class MailMessage(models.Model):
     _inherit = "mail.message"
 
     def action_wizard_forward(self):
-        view = self.env.ref("mail_forward.mail_compose_message_forward_form")
+        view = self.env.ref("mail_forward.mail_compose_message_forward_form").sudo()
         action = self.env["ir.actions.actions"]._for_xml_id(
             "mail.action_email_compose_message_wizard"
         )


### PR DESCRIPTION
`ir.ui.view` requires `base.group_system` permission to read, so sudo is used instead.

TT55074
@Tecnativa @pedrobaeza could you please review this?
This error is also present in V15. I can backport this PR to V15 if that’s OK for you.