### PR TITLE
[15.0][FIX] mail_forward: Avoid error when forwarding a message while reading the view

### DIFF
--- a/mail_forward/models/mail_message.py
+++ b/mail_forward/models/mail_message.py
@@ -8,7 +8,7 @@ class MailMessage(models.Model):
     _inherit = "mail.message"
 
     def action_wizard_forward(self):
-        view = self.env.ref("mail_forward.mail_compose_message_forward_form")
+        view = self.env.ref("mail_forward.mail_compose_message_forward_form").sudo()
         action = self.env["ir.actions.actions"]._for_xml_id(
             "mail.action_email_compose_message_wizard"
         )

--- a/mail_forward/tests/test_mail_forward.py
+++ b/mail_forward/tests/test_mail_forward.py
@@ -2,8 +2,9 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo.tests import Form, RecordCapturer, tagged
-from odoo.tests.common import HttpCase
+from odoo.tests.common import HttpCase, users
 
+from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.mail.tests.test_mail_composer import TestMailComposer
 
 
@@ -12,6 +13,11 @@ class TestMailForward(TestMailComposer, HttpCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.user_test = mail_new_test_user(
+            cls.env,
+            login="user_test_forward",
+            groups="base.group_user,base.group_partner_manager",
+        )
         cls.partner_follower1 = cls.env["res.partner"].create(
             {"name": "Follower1", "email": "follower1@example.com"}
         )
@@ -22,6 +28,7 @@ class TestMailForward(TestMailComposer, HttpCase):
             {"name": "Forward", "email": "forward@example.com"}
         )
 
+    @users("user_test_forward")
     def test_01_mail_forward(self):
         """
         Send an email to followers
@@ -68,10 +75,14 @@ class TestMailForward(TestMailComposer, HttpCase):
         self.assertIn(self.partner_forward, forward_message.partner_ids)
         self.assertIn("---------- Forwarded message ---------", forward_message.body)
 
+    @users("user_test_forward")
     def test_02_mail_forward_tour(self):
-        self.start_tour("/web", "mail_forward.mail_forward_tour", login="admin")
+        self.start_tour(
+            "/web", "mail_forward.mail_forward_tour", login="user_test_forward"
+        )
 
+    @users("user_test_forward")
     def test_03_mail_note_not_forward_tour(self):
         self.start_tour(
-            "/web", "mail_forward.mail_note_not_forward_tour", login="admin"
+            "/web", "mail_forward.mail_note_not_forward_tour", login="user_test_forward"
         )


### PR DESCRIPTION
`ir.ui.view` requires `base.group_system` permission to read, so sudo is used instead.
TT55074
@Tecnativa @pedrobaeza could you please review this?
Backport of https://github.com/OCA/social/pull/1588