### PR TITLE
[17.0][FIX] mail_activity_cancel_tracking: Allow to delete a record (with activities)

### DIFF
--- a/mail_activity_cancel_tracking/models/mail_activity.py
+++ b/mail_activity_cancel_tracking/models/mail_activity.py
@@ -22,6 +22,9 @@ class MailActivity(models.Model):
             for record_sudo, activity in zip(
                 records_sudo, activity_data["activities"], strict=True
             ):
+                # Use exists() to avoid creating messages linked to deleted records
+                if not record_sudo.exists():
+                    continue
                 record_sudo.message_post_with_source(
                     "mail_activity_cancel_tracking.message_activity_cancel",
                     author_id=self.env.user.partner_id.id,

--- a/mail_activity_cancel_tracking/tests/test_mail_activity_cancel_tracking.py
+++ b/mail_activity_cancel_tracking/tests/test_mail_activity_cancel_tracking.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo.tests import new_test_user
 from odoo.tests.common import HttpCase, tagged
+from odoo.tools import mute_logger
 
 
 @tagged("-at_install", "post_install")
@@ -32,3 +33,8 @@ class TestMailActivityCancelTracking(HttpCase):
             "mail_activity_cancel_tracking_cancel",
             login="test-user",
         )
+
+    @mute_logger("odoo.models.unlink")
+    def test_record_unlink(self):
+        # This process should not fail
+        self.partner.unlink()


### PR DESCRIPTION
Allow to delete a record (with activities)

Example use case:
- Create a partner
- Create some activity to the partner
- Delete the partner
- The partner has been successfully deleted

Please @pedrobaeza can you review it?

@Tecnativa TT55313