### PR TITLE
[16.0][IMP] mail_post_defer: Add notes to readme

### DIFF
--- a/mail_post_defer/README.rst
+++ b/mail_post_defer/README.rst
@@ -51,7 +51,11 @@ you can still delete the message and start again.
 Configuration
 =============
 
-You need to do nothing. The module is configured appropriately out of the box.
+You usually don't need to do anything. The module is configured appropriately out of the box.
+Just make sure the following scheduled actions are active:
+
+- Mail: Email Queue Manager (mail.ir_cron_mail_scheduler_action)
+- Notification: Send scheduled message notifications (mail.ir_cron_send_scheduled_message)
 
 The mail queue processing is made by a cron job. This is normal Odoo behavior,
 not specific to this module. However, since you will start using that queue for

--- a/mail_post_defer/readme/CONFIGURE.rst
+++ b/mail_post_defer/readme/CONFIGURE.rst
@@ -1,4 +1,8 @@
-You need to do nothing. The module is configured appropriately out of the box.
+You usually don't need to do anything. The module is configured appropriately out of the box.
+Just make sure the following scheduled actions are active:
+
+- Mail: Email Queue Manager (mail.ir_cron_mail_scheduler_action)
+- Notification: Send scheduled message notifications (mail.ir_cron_send_scheduled_message)
 
 The mail queue processing is made by a cron job. This is normal Odoo behavior,
 not specific to this module. However, since you will start using that queue for

--- a/mail_post_defer/static/description/index.html
+++ b/mail_post_defer/static/description/index.html
@@ -399,7 +399,12 @@ Only for development or testing purpose, do not use in production.
 </div>
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
-<p>You need to do nothing. The module is configured appropriately out of the box.</p>
+<p>You usually don’t need to do anything. The module is configured appropriately out of the box.
+Just make sure the following scheduled actions are active:</p>
+<ul class="simple">
+<li>Mail: Email Queue Manager (mail.ir_cron_mail_scheduler_action)</li>
+<li>Notification: Send scheduled message notifications (mail.ir_cron_send_scheduled_message)</li>
+</ul>
 <p>The mail queue processing is made by a cron job. This is normal Odoo behavior,
 not specific to this module. However, since you will start using that queue for
 every message posted by any user in any thread, this module configures that job


### PR DESCRIPTION
We encounter an issue where scheduled messages are not sent because the cron job "Notification: Send scheduled message notifications" (mail.ir_cron_send_scheduled_message) is inactive.

The cron record is triggered here:
https://github.com/OCA/OCB/blob/16.0/addons/mail/models/mail_message_schedule.py#L39

and it's ignored if not active:
https://github.com/OCA/OCB/blob/16.0/odoo/addons/base/models/ir_cron.py#L486C9-L492C67

@qrtl
QT4601