### PR TITLE
[16.0][IMP] base_search_mail_content: Use the GIN index correctly

### DIFF
--- a/base_search_mail_content/README.rst
+++ b/base_search_mail_content/README.rst
@@ -77,6 +77,9 @@ to internal users only, addressing the issue faced by project collaborators (por
 as described in https://github.com/OCA/social/issues/1204. Consequently, portal users no
 longer have the ability to search within mail content.
 
+This module's usability is severely limited for languages that don't separate words with spaces (e.g., Chinese, Japanese, Korean, Thai, etc.), 
+because `pg_trgm` needs three-character tokens and a similarity score above the default cutoff
+
 Bug Tracker
 ===========
 

--- a/base_search_mail_content/models/mail_thread.py
+++ b/base_search_mail_content/models/mail_thread.py
@@ -52,7 +52,9 @@ class MailThread(models.AbstractModel):
             doc = etree.XML(res["arch"])
             for node in doc.xpath("/search/field[last()]"):
                 # Add message_content in search view
-                elem = etree.Element("field", {"name": "message_content"})
+                elem = etree.Element(
+                    "field", {"name": "message_content", "operator": "%"}
+                )
                 node.addnext(elem)
                 res["arch"] = etree.tostring(doc)
         return res

--- a/base_search_mail_content/readme/ROADMAP.rst
+++ b/base_search_mail_content/readme/ROADMAP.rst
@@ -2,3 +2,6 @@ This module restricts the message_content search functionality
 to internal users only, addressing the issue faced by project collaborators (portal users)
 as described in https://github.com/OCA/social/issues/1204. Consequently, portal users no
 longer have the ability to search within mail content.
+
+This module's usability is severely limited for languages that don't separate words with spaces (e.g., Chinese, Japanese, Korean, Thai, etc.), 
+because `pg_trgm` needs three-character tokens and a similarity score above the default cutoff

--- a/base_search_mail_content/static/description/index.html
+++ b/base_search_mail_content/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -417,6 +418,8 @@ for content in field ‘Message Content’.</p>
 to internal users only, addressing the issue faced by project collaborators (portal users)
 as described in <a class="reference external" href="https://github.com/OCA/social/issues/1204">https://github.com/OCA/social/issues/1204</a>. Consequently, portal users no
 longer have the ability to search within mail content.</p>
+<p>This module’s usability is severely limited for languages that don’t separate words with spaces (e.g., Chinese, Japanese, Korean, Thai, etc.),
+because <cite>pg_trgm</cite> needs three-character tokens and a similarity score above the default cutoff</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h1>
@@ -453,7 +456,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/base_search_mail_content/tests/test_base_search_mail_content.py
+++ b/base_search_mail_content/tests/test_base_search_mail_content.py
@@ -23,3 +23,14 @@ class TestBaseSearchMailContent(TransactionCase):
             res["models"]["mail.channel"],
             "message_content field was not detected",
         )
+
+    def test_base_search_mail_content_3(self):
+        Partner = self.env["res.partner"]
+        partner = Partner.create({"name": "Test Partner"})
+        partner.message_post(
+            body="Hello World",
+        )
+        partner_find = Partner.search([("message_content", "ilike", "world hell")])
+        self.assertFalse(partner_find)
+        partner_find = Partner.search([("message_content", "%", "world hell")])
+        self.assertEqual(partner, partner_find)


### PR DESCRIPTION
The purpose of the GIN index is for full-text search, but without specifying the operator, Odoo does not use the index and instead searches using LIKE. This commit explicitly adds the % operator.

TT51245

@Tecnativa @pedrobaeza could you please review this?