### PR TITLE
[16.0][IMP] mass_mailing_partner: display list of duplicate e-mails

### DIFF
--- a/mass_mailing_partner/models/mailing_list.py
+++ b/mass_mailing_partner/models/mailing_list.py
@@ -28,7 +28,20 @@ class MailingList(models.Model):
                 ["partner_id"],
                 ["partner_id"],
             )
-            if len(list(filter(lambda r: r["partner_id_count"] > 1, data))):
+            duplicates = list(filter(lambda r: r["partner_id_count"] > 1, data))
+            if len(duplicates):
+                duplicates_list = "\n".join(
+                    [
+                        f'({dup["partner_id_count"]}) [{dup["partner_id"][0]}] \
+                        {str(dup["partner_id"][1])}'
+                        for dup in duplicates
+                    ]
+                )
                 raise ValidationError(
-                    _("A partner cannot be multiple times " "in the same list")
+                    _(
+                        "A partner cannot be multiple times in the same list\n"
+                        "Duplicate contacts found:\n"
+                        "%s",
+                        duplicates_list,
+                    )
                 )


### PR DESCRIPTION
When you try to sync a dynamic list and that would create duplicate contacts, you get a validation error.
On big lists, it is not so easy to find out which partners / e-mails are causing this ValidationError.

This PR proposes to list e-mails causing this ValidationError in the message displayed to user, so that partners could be deduplicated or dynamic list domain could be reworked.