### PR TITLE
[16.0][FIX] mass_mailing_list_dynamic: prevent put in queue with errors

### DIFF
--- a/mass_mailing_list_dynamic/models/mailing.py
+++ b/mass_mailing_list_dynamic/models/mailing.py
@@ -8,9 +8,9 @@ from odoo import models
 class MassMailing(models.Model):
     _inherit = "mailing.mailing"
 
-    def _get_remaining_recipients(self):
-        """When evaluating remaining recipients we must resync the list in
-        advance to avoid missing recipients due to domain change or new
-        partners fitting into the conditions"""
+    def action_launch(self):
+        # Do the sync prior to putting the mailing in queue. Otherwise, if an error
+        # raises, the user won't be able to detect it and the Mass Mailing queue cron
+        # will be blocked forever.
         self.contact_list_ids.action_sync()
-        return super()._get_remaining_recipients()
+        return super().action_launch()

--- a/mass_mailing_list_dynamic/tests/test_dynamic_lists.py
+++ b/mass_mailing_list_dynamic/tests/test_dynamic_lists.py
@@ -105,8 +105,9 @@ class DynamicListCase(common.TransactionCase):
             }
         )
         # Mock sending low level method, because an auto-commit happens there
+        self.mail.action_launch()
         with patch("odoo.addons.mail.models.mail_mail.MailMail.send") as s:
-            self.mail.action_send_mail()
+            self.mail._process_mass_mailing_queue()
             self.assertEqual(1, s.call_count)
         self.list.flush_recordset()
         self.assertEqual(6, self.list.contact_count)


### PR DESCRIPTION
A dynamic mailing list syncing could have errors due to constraints or other side effects. But as the syncing is being made by the cron job, the user can't detect and fix (or report) those errors.

So we'll just sync the lists when the user launches the mailing and prior to put it in the mailing queue.

cc @moudon @yajo @fcvalgar MT-9835
