### PR TITLE
[17.0][FIX] mail_tracking_mailgun: Markup link

### DIFF
--- a/mail_tracking_mailgun/models/res_partner.py
+++ b/mail_tracking_mailgun/models/res_partner.py
@@ -7,6 +7,7 @@
 from urllib.parse import urljoin
 
 import requests
+from markupsafe import Markup
 
 from odoo import SUPERUSER_ID, _, models
 from odoo.exceptions import UserError
@@ -27,16 +28,15 @@ class ResPartner(models.Model):
             if not partner.email:
                 continue
             event = event or self.env["mail.tracking.event"]
-            event_str = (
-                f'<a href="#" data-oe-model="mail.tracking.event"'
-                f'data-oe-id="{event.id or 0}">{event.id or _("unknown")}</a>'
-            )
-            body = _(
-                "Email has been bounced: %(email)s\nReason: "
-                "%(reason)s\nEvent: %(event_str)s",
-                email=partner.email,
-                reason=reason,
-                event_str=event_str,
+            event_str = event._get_html_link(title=event.id) if event else _("unknown")
+            body = Markup(
+                _(
+                    "Email has been bounced: %(email)s\nReason: "
+                    "%(reason)s\nEvent: %(event_str)s",
+                    email=partner.email,
+                    reason=reason,
+                    event_str=event_str,
+                )
             )
             # This function can be called by the non user via the callback_method set in
             # /mail/tracking/mailgun/all/. A sudo() is not enough to succesfully send


### PR DESCRIPTION
Correct link message on the chatter, using also the provided native method instead of building it manually.

Before:
![imagen](https://github.com/user-attachments/assets/3456d703-bc76-470c-b63c-eba763f47a10)

After:
![imagen](https://github.com/user-attachments/assets/caa1bd7c-25cc-452d-b3c6-50673f73526b)

@Tecnativa 