### PR TITLE
[16.0][FIX] mass_mailing_partner: avoid changing partner unnecessarily

### DIFF
--- a/mass_mailing_partner/models/mailing_contact.py
+++ b/mass_mailing_partner/models/mailing_contact.py
@@ -104,6 +104,8 @@ class MailingContact(models.Model):
         m_partner = self.env["res.partner"]
         # Look for a partner with that email
         email = self.email.strip()
+        if email == self.partner_id.email:
+            return
         partner = m_partner.search([("email", "=ilike", email)], limit=1)
         if partner:
             if partner == self.partner_id:

--- a/mass_mailing_partner/tests/test_res_partner.py
+++ b/mass_mailing_partner/tests/test_res_partner.py
@@ -54,6 +54,15 @@ class ResPartnerCase(base.BaseCase):
             self.create_mailing_contact(
                 {"partner_id": partner.id, "list_ids": [[6, 0, [self.mailing_list.id]]]}
             )
+        # We want to check that the partner isn't overwritten unnecessarily: when the
+        # contact's partner checks are run, it could happen that:
+        # - the partner's email already matches the contact's email
+        # - there are two contacts with the same email, and the first one is chosen
+        contact = self.mailing_list.contact_ids.filtered(
+            lambda x: x.partner_id == partner2
+        )
+        contact.write({})
+        self.assertEqual(contact.partner_id, partner2)
         self.env["res.partner"].search(
             [("id", "in", (self.partner.id, partner2.id))]
         ).write({"category_id": [(4, self.category_3.id)]})


### PR DESCRIPTION
When a contact is written, this module checks that the partner's email fits the contact one. In a scenario where several partner share the same email address we could end having that partner changed depending on the searching order prevalence.

cc @moduon @yajo @fcvalgar MT-9835