### PR TITLE
[16.0][FIX] mail_compose_cc_bcc allow to send cc to follower

### DIFF
--- a/mail_composer_cc_bcc/__manifest__.py
+++ b/mail_composer_cc_bcc/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Email CC and BCC",
     "summary": "This module enables sending mail to CC and BCC partners in mail composer form.",
-    "version": "16.0.2.0.5",
+    "version": "16.0.2.0.6",
     "development_status": "Alpha",
     "category": "Social",
     "website": "https://github.com/OCA/social",

--- a/mail_composer_cc_bcc/models/mail_thread.py
+++ b/mail_composer_cc_bcc/models/mail_thread.py
@@ -62,6 +62,7 @@ class MailThread(models.AbstractModel):
         recipients_cc_bcc = MailFollowers._get_recipient_data(
             None, message_type, subtype_id, partners_cc_bcc.ids
         )
+        existing_recipients = list([recipient["id"] for recipient in rdata])
         for _, value in recipients_cc_bcc.items():
             for _, data in value.items():
                 if not data.get("id"):
@@ -79,6 +80,9 @@ class MailThread(models.AbstractModel):
                     "type": msg_type,
                     "is_follower": data.get("is_follower"),
                 }
+                if pdata["id"] in existing_recipients:
+                    continue
+                existing_recipients.append(pdata["id"])
                 rdata.append(pdata)
         return rdata
 

--- a/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
+++ b/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
@@ -23,6 +23,7 @@ VALID_HASHES = [
     "8f26c4084cc7fc300e64d19ccdc944fe",
     "db6cc0d3513a0c85bd716e4cb0a4d09c",
     "458982c6cb3a347b13008f7d8130f633",  # 2025-04-08, odoo commit 3af276804101
+    "2e0c730330ae3bdf00c6bfd956b0527b",
 ]
 
 


### PR DESCRIPTION
This PR fixes the following error that occurs when a contact who is already a follower of a record (e.g. sale.order) is also added as a CC recipient when sending a message:

Example use case:

1. Create sale order
2. Add contact as follower
3. Click send by email
4. Select the same contact in the CC field
Result before fix:
Error is raised due to a duplicate entry in mail.notification: `The Operation cannot be completed: duplicate key value violates unique constraint "unique_mail_message_id_res_partner_id_if_set"`
Result after fix:
Email is sent successfully, and the notification is created only once.