### PR TITLE
[FIX] Email normalization

### DIFF
--- a/mail_composer_cc_bcc/models/mail_mail.py
+++ b/mail_composer_cc_bcc/models/mail_mail.py
@@ -8,7 +8,11 @@ from odoo.addons.base.models.ir_mail_server import extract_rfc2822_addresses
 
 
 def format_emails(partners):
-    emails = [tools.formataddr((p.name or "", p.email)) for p in partners if p.email]
+    emails = [
+        tools.formataddr((p.name or "", tools.email_normalize(p.email)))
+        for p in partners
+        if p.email
+    ]
     return ", ".join(emails)
 
 


### PR DESCRIPTION
Email addresses are normalized for Odoo base behavior, but this module uses formataddr. It is not allowed to use capital letters in the email address. So now apply the normalization that is used in Odoo Base.