### PR TITLE
[16.0][IMP] email_template_qweb: copy view together with template

### DIFF
--- a/email_template_qweb/README.rst
+++ b/email_template_qweb/README.rst
@@ -69,7 +69,11 @@ Authors
 Contributors
 ~~~~~~~~~~~~
 
-* Holger Brunn <hbrunn@therp.nl>
+* `Therp BV <https://www.therp.nl>`_:
+
+    * Holger Brunn <hbrunn@therp.nl>
+    * Ronald Portier <ronald@therp.nl>
+
 * Dave Lasley <dave@laslabs.com>
 * Carlos Lopez Mite <celm1990@gmail.com>
 * `Tecnativa <https://www.tecnativa.com>`_:

--- a/email_template_qweb/__init__.py
+++ b/email_template_qweb/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2016 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from . import models

--- a/email_template_qweb/__manifest__.py
+++ b/email_template_qweb/__manifest__.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Therp BV <http://therp.nl>
+# Copyright 2016,2025 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "QWeb for email templates",

--- a/email_template_qweb/models/__init__.py
+++ b/email_template_qweb/models/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2016 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from . import mail_template

--- a/email_template_qweb/models/mail_template.py
+++ b/email_template_qweb/models/mail_template.py
@@ -1,6 +1,6 @@
-# Copyright 2016 Therp BV <http://therp.nl>
+# Copyright 2016,2025 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from odoo import fields, models, tools
+from odoo import _, api, fields, models, tools
 
 
 class MailTemplate(models.Model):
@@ -13,7 +13,39 @@ class MailTemplate(models.Model):
         required=True,
     )
     body_view_id = fields.Many2one("ir.ui.view", domain=[("type", "=", "qweb")])
-    body_view_arch = fields.Text(related="body_view_id.arch")
+    body_view_arch = fields.Text(
+        compute="_compute_body_view_arch",
+        inverse="_inverse_body_view_arch",
+        readonly=False,
+    )
+    edit_language = fields.Selection(
+        selection="_get_edit_language_selection",
+        default="en_US",
+        help="Set the language to edit template",
+    )
+
+    def _get_edit_language_selection(self):
+        """Selection for language to edit template."""
+        active_languages = self.env["res.lang"].search(
+            [("active", "=", True), ("code", "!=", "en_US")]
+        )
+        selection = [("en_US", "English (US)")] + [
+            (lang.code, lang.name) for lang in active_languages
+        ]
+        return selection
+
+    @api.depends("edit_language", "body_view_id.arch")
+    def _compute_body_view_arch(self):
+        for this in self:
+            this.body_view_arch = this.body_view_id.with_context(
+                lang=this.edit_language
+            ).arch
+
+    def _inverse_body_view_arch(self):
+        for this in self:
+            this.body_view_id.with_context(
+                lang=this.edit_language
+            ).arch = this.body_view_arch
 
     def generate_email(self, res_ids, fields):
         multi_mode = True
@@ -50,3 +82,25 @@ class MailTemplate(models.Model):
                             result[res_id]["body_html"]
                         )
         return result if multi_mode else result[res_ids[0]]
+
+    def copy_data(self, default=None):
+        """Copy template view together with template.
+
+        Users copy an email template usually to give it new contents. They
+        consider the content they see (the body_view_arch) as an integral
+        part of the email template.
+        """
+        self.ensure_one()
+        if not default or "body_view_id" not in default:
+            # There is no specific body_view_id already set in default.
+            if self.body_view_id:
+                # There is a body_view_id that can be copied.
+                body_default = dict(
+                    name=_("%s (copy)", self.body_view_id.name or ""),
+                )
+                new_view = self.body_view_id.copy(default=body_default)
+                default = dict(
+                    default or {},
+                    body_view_id=new_view.id,
+                )
+        return super().copy_data(default=default)

--- a/email_template_qweb/models/mail_template.py
+++ b/email_template_qweb/models/mail_template.py
@@ -15,6 +15,7 @@ class MailTemplate(models.Model):
     body_view_id = fields.Many2one("ir.ui.view", domain=[("type", "=", "qweb")])
     body_view_arch = fields.Text(
         compute="_compute_body_view_arch",
+        compute_sudo=True,
         inverse="_inverse_body_view_arch",
         readonly=False,
     )
@@ -42,7 +43,7 @@ class MailTemplate(models.Model):
             ).arch
 
     def _inverse_body_view_arch(self):
-        for this in self:
+        for this in self.sudo():
             this.body_view_id.with_context(
                 lang=this.edit_language
             ).arch = this.body_view_arch

--- a/email_template_qweb/readme/CONTRIBUTORS.rst
+++ b/email_template_qweb/readme/CONTRIBUTORS.rst
@@ -1,4 +1,8 @@
-* Holger Brunn <hbrunn@therp.nl>
+* `Therp BV <https://www.therp.nl>`_:
+
+    * Holger Brunn <hbrunn@therp.nl>
+    * Ronald Portier <ronald@therp.nl>
+
 * Dave Lasley <dave@laslabs.com>
 * Carlos Lopez Mite <celm1990@gmail.com>
 * `Tecnativa <https://www.tecnativa.com>`_:

--- a/email_template_qweb/static/description/index.html
+++ b/email_template_qweb/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -417,7 +416,13 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="contributors">
 <h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
 <ul>
-<li><p class="first">Holger Brunn &lt;<a class="reference external" href="mailto:hbrunn&#64;therp.nl">hbrunn&#64;therp.nl</a>&gt;</p>
+<li><p class="first"><a class="reference external" href="https://www.therp.nl">Therp BV</a>:</p>
+<blockquote>
+<ul class="simple">
+<li>Holger Brunn &lt;<a class="reference external" href="mailto:hbrunn&#64;therp.nl">hbrunn&#64;therp.nl</a>&gt;</li>
+<li>Ronald Portier &lt;<a class="reference external" href="mailto:ronald&#64;therp.nl">ronald&#64;therp.nl</a>&gt;</li>
+</ul>
+</blockquote>
 </li>
 <li><p class="first">Dave Lasley &lt;<a class="reference external" href="mailto:dave&#64;laslabs.com">dave&#64;laslabs.com</a>&gt;</p>
 </li>

--- a/email_template_qweb/tests/__init__.py
+++ b/email_template_qweb/tests/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2016 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from . import test_mail_template_qweb

--- a/email_template_qweb/tests/test_mail_template_qweb.py
+++ b/email_template_qweb/tests/test_mail_template_qweb.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Therp BV <http://therp.nl>
+# Copyright 2016,2025 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo.tests.common import TransactionCase
 
@@ -21,3 +21,29 @@ class TestMailTemplateQweb(TransactionCase):
             "Did not receive rendered template in response. Got: \n%s\n"
             % (mail_values["body_html"]),
         )
+
+    def test_editing(self):
+        template = self.env.ref("email_template_qweb.email_template_demo1")
+        template.edit_language = "en_US"
+        self.assertIn("Dear", template.body_view_id.arch)
+        self.assertIn("Dear", template.body_view_arch)
+        template.body_view_arch = template.body_view_arch.replace("Dear", "Estimated")
+        self.assertIn("Estimated", template.body_view_arch)
+        self.assertIn("Estimated", template.body_view_id.arch)
+
+    def test_copy(self):
+        template = self.env.ref("email_template_qweb.email_template_demo1")
+        template.edit_language = "en_US"
+        self.assertIn("Dear", template.body_view_id.arch)
+        self.assertIn("Dear", template.body_view_arch)
+        copied_template = template.copy()
+        self.assertNotEqual(template.body_view_id, copied_template.body_view_id)
+        copied_template.body_view_arch = template.body_view_arch.replace(
+            "Dear", "Beloved"
+        )
+        # Originals should not have changed.
+        self.assertIn("Dear", template.body_view_id.arch)
+        self.assertIn("Dear", template.body_view_arch)
+        # Copied records should be changed now.
+        self.assertIn("Beloved", copied_template.body_view_arch)
+        self.assertIn("Beloved", copied_template.body_view_id.arch)

--- a/email_template_qweb/views/mail_template.xml
+++ b/email_template_qweb/views/mail_template.xml
@@ -10,13 +10,20 @@
             <field name="body_html" position="before">
                 <group attrs="{'invisible': [('body_type', '!=', 'qweb_view')]}">
                     <field
+                        name="edit_language"
+                        attrs="{'required': [('body_type', '=', 'qweb_view')]}"
+                    />
+                    <field
                         name="body_view_id"
                         attrs="{'required': [('body_type', '=', 'qweb_view')]}"
                     />
                     <field
                         name="body_view_arch"
                         widget="ace"
-                        attrs="{'required': [('body_type', '=', 'qweb_view')], 'invisible': [('body_view_id', '=', False)]}"
+                        context="{'lang': edit_language}"
+                        options="{'mode': 'xml'}"
+                        attrs="{'required': [('body_type', '=', 'qweb_view')],
+                        'invisible': [('body_view_id', '=', False)]}"
                     />
                 </group>
             </field>


### PR DESCRIPTION
Also edit the copied template inline to enhance the usability of the module. This is done with visible language selection.

This commits prevents two common errors:
- After copy and editing the qweb template from the copy, the original template is changed (as there was no copied template);
- The user edits the template, which by default shows en_US, but nothing really changes in the customer language, leading to 'weeping and gnashing of teeth'.