### PR TITLE
[17.0][FIX] mail_activity_team: open team activities from systray

### DIFF
--- a/mail_activity_team/models/mail_activity_mixin.py
+++ b/mail_activity_team/models/mail_activity_mixin.py
@@ -98,3 +98,27 @@ class MailActivityMixin(models.AbstractModel):
                 ),
                 False,
             )
+
+    @api.model
+    def web_search_read(
+        self, domain, specification, offset=0, limit=None, order=None, count_limit=None
+    ):
+        # Intercept the queries from the systray widget and apply team search.
+        # This allows the frontend widget to direct the user to their team activities
+        # Late/Today/Future.
+        if self.env.context.get("team_activities"):
+            orig_domain = domain
+            domain = []
+            for clause in orig_domain:
+                if isinstance(clause, list | tuple) and clause[0] == "activity_user_id":
+                    domain.append(("activity_team_user_ids", clause[1], clause[2]))
+                else:
+                    domain.append(clause)
+        return super().web_search_read(
+            domain,
+            specification,
+            offset=offset,
+            limit=limit,
+            order=order,
+            count_limit=count_limit,
+        )

--- a/mail_activity_team/tests/test_mail_activity_team.py
+++ b/mail_activity_team/tests/test_mail_activity_team.py
@@ -343,3 +343,59 @@ class TestMailActivityTeam(TransactionCase):
         )
         self.assertEqual(partner, self.partner_client)
         self.assertEqual(partner.my_activity_date_deadline, today)
+
+    def _web_search_read_to_ids(self, domain, context=None):
+        """Return web_search_read results as a set of ids"""
+        if context is None:
+            context = {}
+        res = (
+            self.env["res.partner"]
+            .with_context(**context)
+            .web_search_read(
+                domain,
+                {"id": {}},
+            )
+        )
+        return set(record["id"] for record in res["records"])
+
+    def test_web_search_read(self):
+        """Test the domain mangling of web_search_read"""
+        # Create a non-team activity for our second employee, for a second partner
+        self.team1.member_ids |= self.employee2
+        partner2 = self.partner_client.copy()
+        self.employee2.groups_id += self.env.ref("base.group_partner_manager")
+
+        # Craft the activity without a team
+        act3 = (
+            self.env["mail.activity"]
+            .with_user(self.employee2)
+            .create(
+                {
+                    "activity_type_id": self.activity1.id,
+                    "note": "Partner activity 3.",
+                    "res_id": partner2.id,
+                    "res_model_id": self.partner_ir_model.id,
+                    "team_user_id": self.employee2.id,
+                    "user_id": self.employee2.id,
+                    "team_id": False,
+                }
+            )
+        )
+        self.assertFalse(act3.team_id)
+
+        # A regular search retrieves this activity
+        self.assertEqual(
+            self._web_search_read_to_ids(
+                [("activity_user_id", "=", self.employee2.id)]
+            ),
+            set(partner2.ids),
+        )
+
+        # Searching with magic context key retrieves team activities.
+        self.assertEqual(
+            self._web_search_read_to_ids(
+                [("activity_user_id", "=", self.employee2.id)],
+                {"team_activities": True},
+            ),
+            set(self.partner_client.ids),
+        )


### PR DESCRIPTION
_To Reproduce_

1. Create an activity for a team of the current user but with no specific user of for another user in the team.
2. Go to the systray activity widget. Switch to tab Team Activities.
3. Click on `1 Future`.

_Actual outcome_

The activity kanban view opens without any records.

_Expected_ behavior_

The activity kanban view opens with the team activity that was created in step 1.

_Technical description of the fix_

The systray widget will open the view with a domain that selects the users's activities. Thanks to a context key that is already set, we can intercept the domain and replace it with a domain on the user's teams' activities.

Backported from https://github.com/OCA/mail/pull/38