### PR TITLE
[16.0][FIX] mail_activity_done: fix test failing between 22:00 and 00:00 utc

### DIFF
--- a/mail_activity_done/tests/test_mail_activity_done.py
+++ b/mail_activity_done/tests/test_mail_activity_done.py
@@ -5,65 +5,64 @@ from odoo.tests.common import TransactionCase
 
 
 class TestMailActivityDoneMethods(TransactionCase):
-    def setUp(self):
-        super(TestMailActivityDoneMethods, self).setUp()
-        self.employee = self.env["res.users"].create(
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.employee = cls.env["res.users"].create(
             {
-                "company_id": self.env.ref("base.main_company").id,
+                "company_id": cls.env.ref("base.main_company").id,
                 "name": "Test User",
                 "login": "testuser@testuser.local",
                 "email": "testuser@testuser.local",
                 "tz": "Europe/Brussels",
                 "groups_id": [
-                    (
-                        6,
-                        0,
+                    fields.Command.set(
                         [
-                            self.env.ref("base.group_user").id,
-                            self.env.ref("base.group_partner_manager").id,
-                        ],
+                            cls.env.ref("base.group_user").id,
+                            cls.env.ref("base.group_partner_manager").id,
+                        ]
                     )
                 ],
             }
         )
-        self.partner = (
-            self.env["res.partner"]
-            .with_user(self.employee)
+        cls.partner = (
+            cls.env["res.partner"]
+            .with_user(cls.employee)
             .create({"name": "test partner"})
         )
-        activity_type = self.env["mail.activity.type"].create(
+        activity_type = cls.env["mail.activity.type"].create(
             {"name": "test activity type"}
         )
-        today = fields.Date.context_today(self.employee)
-        self.act1 = (
-            self.env["mail.activity"]
-            .with_user(self.employee)
+        today = fields.Date.context_today(cls.employee)
+        cls.act1 = (
+            cls.env["mail.activity"]
+            .with_user(cls.employee)
             .create(
                 {
                     "activity_type_id": activity_type.id,
-                    "res_id": self.partner.id,
+                    "res_id": cls.partner.id,
                     "res_model": "res.partner",
-                    "res_model_id": self.env["ir.model"]._get("res.partner").id,
-                    "user_id": self.employee.id,
+                    "res_model_id": cls.env["ir.model"]._get("res.partner").id,
+                    "user_id": cls.employee.id,
                     "date_deadline": today,
                 }
             )
         )
-        self.act2 = (
-            self.env["mail.activity"]
-            .with_user(self.employee)
+        cls.act2 = (
+            cls.env["mail.activity"]
+            .with_user(cls.employee)
             .create(
                 {
                     "activity_type_id": activity_type.id,
-                    "res_id": self.partner.id,
+                    "res_id": cls.partner.id,
                     "res_model": "res.partner",
-                    "res_model_id": self.env["ir.model"]._get("res.partner").id,
-                    "user_id": self.employee.id,
+                    "res_model_id": cls.env["ir.model"]._get("res.partner").id,
+                    "user_id": cls.employee.id,
                     "date_deadline": today,
                 }
             )
         )
-        self.activities = self.act1 + self.act2
+        cls.activities = cls.act1 + cls.act2
 
     def _set_activities_done(self):
         self.activities._action_done()

--- a/mail_activity_done/tests/test_mail_activity_done.py
+++ b/mail_activity_done/tests/test_mail_activity_done.py
@@ -1,7 +1,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from datetime import date
-
+from odoo import fields
 from odoo.tests.common import TransactionCase
 
 
@@ -35,6 +34,7 @@ class TestMailActivityDoneMethods(TransactionCase):
         activity_type = self.env["mail.activity.type"].create(
             {"name": "test activity type"}
         )
+        today = fields.Date.context_today(self.employee)
         self.act1 = (
             self.env["mail.activity"]
             .with_user(self.employee)
@@ -45,7 +45,7 @@ class TestMailActivityDoneMethods(TransactionCase):
                     "res_model": "res.partner",
                     "res_model_id": self.env["ir.model"]._get("res.partner").id,
                     "user_id": self.employee.id,
-                    "date_deadline": date.today(),
+                    "date_deadline": today,
                 }
             )
         )
@@ -59,7 +59,7 @@ class TestMailActivityDoneMethods(TransactionCase):
                     "res_model": "res.partner",
                     "res_model_id": self.env["ir.model"]._get("res.partner").id,
                     "user_id": self.employee.id,
-                    "date_deadline": date.today(),
+                    "date_deadline": today,
                 }
             )
         )


### PR DESCRIPTION
`date.today()` returns the day in utc, while `mail.activity.mixin.activity_state`'s `"today"` value means the current date in the user's timezone. this made a test fail between 22:00 and 00:00 utc (when brussels uses the cest timezone (utc+2), otherwise between 23:00 and 00:00 utc when it uses the cet timezone (utc+1)).

a second commit improves the test code somewhat.