### PR TITLE
[15.0[FIX] mail_composer_cc_bcc fix type error

### DIFF
--- a/mail_composer_cc_bcc/wizards/mail_compose_message.py
+++ b/mail_composer_cc_bcc/wizards/mail_compose_message.py
@@ -80,5 +80,5 @@ class MailComposeMessage(models.TransientModel):
         }
         context.update(self.env.context)
         self_super = super(MailComposeMessage, self.with_context(**context))
-        res = self_super._action_send_mail(auto_commit)
+        res = self_super._action_send_mail(auto_commit=auto_commit)
         return res


### PR DESCRIPTION
This fixes the following error.

```
>       picking._action_done()

_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/tmp/addons/mrp_subcontracting_dropshipping/models/stock_picking.py:29: in _action_done
    res = super()._action_done()
/tmp/addons/sale_stock/models/stock.py:84: in _action_done
    res = super()._action_done()
/tmp/addons/purchase_reception_notify/models/stock_picking.py:34: in _action_done
    res = super()._action_done()
/tmp/addons/mrp_subcontracting/models/stock_picking.py:44: in _action_done
    res = super(StockPicking, self)._action_done()
/tmp/addons/quality_control_stock_oca/models/stock_picking.py:60: in _action_done
    res = super()._action_done()
/tmp/addons/stock/models/stock_picking.py:847: in _action_done
    self._send_confirmation_email()
src/addons/nitrokey_reports/models/stock_picking.py:8: in _send_confirmation_email
    super()._send_confirmation_email()
/tmp/addons/delivery/models/stock_picking.py:185: in _send_confirmation_email
    return super(StockPicking, self)._send_confirmation_email()
/tmp/addons/stock/models/stock_picking.py:853: in _send_confirmation_email
    stock_pick.with_context(force_send=True).message_post_with_template(delivery_template_id, email_layout_xmlid='mail.mail_notification_light')
/tmp/addons/mass_mailing/models/mail_thread.py:37: in message_post_with_template
    return super(MailThread, no_massmail).message_post_with_template(template_id, **kwargs)
/tmp/addons/mail/models/mail_thread.py:2032: in message_post_with_template
    return composer._action_send_mail(auto_commit=auto_commit)
/tmp/addons/website_sale/models/mail_compose_message.py:19: in _action_send_mail
    return super(MailComposeMessage, self)._action_send_mail(auto_commit=auto_commit)
/tmp/addons/sale/wizard/mail_compose_message.py:15: in _action_send_mail
    return super(MailComposeMessage, self)._action_send_mail(auto_commit=auto_commit)
/tmp/addons/purchase/models/mail_compose_message.py:15: in _action_send_mail
    return super(MailComposeMessage, self)._action_send_mail(auto_commit=auto_commit)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = mail.compose.message(104,), auto_commit = False

    def _action_send_mail(self, auto_commit=False):
        # don't impact mass_mailing that also uses mail.compose.message
        if self.composition_mode == "mass_mail":
            return super()._action_send_mail(auto_commit)
        context = {
            "is_from_composer": True,
            "partner_cc_ids": self.partner_cc_ids,
            "partner_bcc_ids": self.partner_bcc_ids,
        }
        context.update(self.env.context)
        self_super = super(MailComposeMessage, self.with_context(**context))
>       res = self_super._action_send_mail(auto_commit)
E       TypeError: _action_send_mail() takes 1 positional argument but 2 were given

```