### PR TITLE
[FIX][14.0] mail_outbound_static Align maximum length of TLD to DNS limit (63 chars) - backport #1123

### DIFF
--- a/mail_outbound_static/models/ir_mail_server.py
+++ b/mail_outbound_static/models/ir_mail_server.py
@@ -45,7 +45,7 @@ class IrMailServer(models.Model):
         if self.smtp_from:
             match = re.match(
                 r"^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\."
-                r"[a-z]{2,4})$",
+                r"[a-z]{2,63})$",
                 self.smtp_from,
             )
             if match is None:


### PR DESCRIPTION
Backport of #1123 