### PR TITLE
[17.0][FIX]``mail_activity_team``: do not systematically remove the user from an activity when a team is set

### DIFF
--- a/mail_activity_team/models/mail_activity.py
+++ b/mail_activity_team/models/mail_activity.py
@@ -35,14 +35,18 @@ class MailActivity(models.Model):
     def create(self, vals_list):
         # Differently from the previous odoo version,
         # the create method is called from (mail.activity.mixin).activity_schedule()
-        # and on this method we are forcing the user_id to be the current user from
-        # odoo import api, fields, models the default one linked to the activity type.
+        # and on this method, if no user is provided, we are forcing the user_id to be
+        # the default one linked to the activity type or the current user.
         # We don't want this behavior because using the team_id, we want to assign the
-        # activity to the whole team.
+        # activity to the whole team, so if no user is provided we want to keep the
+        # field empty.
+        if not self.env.context.get("remove_user_id", False):
+            # If no context key, we keep the standard behavior
+            return super().create(vals_list)
         for vals in vals_list:
             # we need to be sure that we are in a context where the team_id is set,
             # and we don't want to use user_id
-            if "team_id" in vals:
+            if vals.get("team_id"):
                 # using team, we have user_id = team_user_id,
                 # so if we don't have a user_team_id we don't want user_id too
                 if "user_id" in vals and not vals.get("team_user_id", False):

--- a/mail_activity_team/models/mail_activity_mixin.py
+++ b/mail_activity_team/models/mail_activity_mixin.py
@@ -46,6 +46,7 @@ class MailActivityMixin(models.AbstractModel):
         """
         if self.env.context.get("force_activity_team"):
             act_values["team_id"] = self.env.context["force_activity_team"].id
+        user_id = act_values.get("user_id")
         if "team_id" not in act_values:
             if act_type_xmlid:
                 activity_type = self.sudo().env.ref(act_type_xmlid)
@@ -65,7 +66,6 @@ class MailActivityMixin(models.AbstractModel):
                         {"user_id": activity_type.default_team_id.member_ids[:1].id}
                     )
             else:
-                user_id = act_values.get("user_id")
                 if user_id:
                     team = (
                         self.env["mail.activity"]
@@ -75,6 +75,12 @@ class MailActivityMixin(models.AbstractModel):
                         ._get_default_team_id(user_id=user_id)
                     )
                     act_values.update({"team_id": team.id})
+        if not user_id:
+            # In standard, if no user_id is provided, a default one is set by this
+            # method. Here, the user_id is not required anymore, so we don't want to
+            # add a default user if none is set in `act_values`. We manage it by a
+            # context key, checked in the ``create`` method of the mail.activity
+            self = self.with_context(remove_user_id=True)
         return super().activity_schedule(
             act_type_xmlid=act_type_xmlid,
             date_deadline=date_deadline,


### PR DESCRIPTION
In [this PR](https://github.com/OCA/social/pull/1474), we updated the module to follow the v17 changes in standard. However it looks like the changes made are too wide: if no user is set, we indeed want to prevent the standard method to set one by default. But if a user is manually added, we want to keep it. Here we add a context key to determine at the creation of the activity if the user should be kept or erased. We also take [this issue](https://github.com/OCA/social/issues/1655) into account.