### PR TITLE
[18.0][FIX] mail_thread_create_nolog: prevent improper creation of messages

### DIFF
--- a/mail_thread_create_nolog/controllers/thread.py
+++ b/mail_thread_create_nolog/controllers/thread.py
@@ -19,17 +19,20 @@ class ThreadController(mail_thread.ThreadController):
         result = super().mail_thread_messages(
             thread_model, thread_id, search_term, before, after, around, limit
         )
-
-        result["data"].setdefault("mail.message", [])
-
         domain = [
             ("res_id", "=", int(thread_id)),
             ("model", "=", thread_model),
             ("message_type", "!=", "user_notification"),
         ]
-
-        message = request.env["mail.message"]._generate_messsage(domain)
-
+        result_data = result.get("data", {})
+        has_messages = request.env["mail.message"]._has_messages_in_record(domain)
+        if not result_data and has_messages:
+            return result
+        mail_messages = result_data.get("mail.message", [])
+        if len(mail_messages) == 1 and not mail_messages[0].get("body"):
+            return result
+        result["data"].setdefault("mail.message", [])
+        message = request.env["mail.message"]._generate_message(domain)
         if message:
             result["data"]["mail.message"].append(message)
             result["messages"].append(message["id"])

--- a/mail_thread_create_nolog/models/mail_message.py
+++ b/mail_thread_create_nolog/models/mail_message.py
@@ -22,9 +22,9 @@ class MailMessage(models.AbstractModel):
         # In that case there is no specific record implied, so no need to generate the
         # the message.
         record = self._messages_for_record(domain)
-        author = record.create_uid.partner_id
 
         if record and record._log_access:
+            author = record.create_uid.partner_id
             creation_message = record._creation_message()
             create_message_record = self.new(
                 {

--- a/mail_thread_create_nolog/models/mail_message.py
+++ b/mail_thread_create_nolog/models/mail_message.py
@@ -17,7 +17,7 @@ class MailMessage(models.AbstractModel):
         ]
 
     @api.model
-    def _generate_messsage(self, domain):
+    def _generate_message(self, domain):
         # Generate a creation message only if messages are fetched for a record.
         # In that case there is no specific record implied, so no need to generate the
         # the message.
@@ -81,3 +81,7 @@ class MailMessage(models.AbstractModel):
         if model and res_id:
             return self.env[model].browse(res_id).exists()
         return self.browse()
+
+    @api.model
+    def _has_messages_in_record(self, domain):
+        return self.search_count(domain) > 0


### PR DESCRIPTION
Before this commit, when a user added a message or logged a note on any mail thread, the original creation message was being duplicated on each new message.
