### PR TITLE
[17.0][FIX] mail_gateway: Messages are not being sent using the email messaging thread

### DIFF
--- a/mail_gateway/models/mail_thread.py
+++ b/mail_gateway/models/mail_thread.py
@@ -37,7 +37,7 @@ class MailThread(models.AbstractModel):
             )
 
     def _notify_get_recipients(self, message, msg_vals, **kwargs):
-        if "gateway_notifications" in kwargs:
+        if kwargs.get("gateway_notifications"):
             result = []
             for notification in kwargs["gateway_notifications"]:
                 if not notification.get("channel_type"):


### PR DESCRIPTION
cc @Tecnativa TT57738

Before these changes, the messages sent using the email thread were not being delivered.

![error_envio](https://github.com/user-attachments/assets/fcfa5db4-dfca-4463-9e2c-d438e5659c31)

After making these changes, since the gateway_notifications key is empty, the super is called and the process continues normally.

![envio realizado](https://github.com/user-attachments/assets/e2a7187a-609c-4db2-a439-ca837a7b132b)

ping @carlos-lopez-tecnativa @pedrobaeza 