### PR TITLE
[17.0][FIX] mail_thread: Duplicated suggestions when email_cc set

### DIFF
--- a/mail_tracking/models/mail_thread.py
+++ b/mail_tracking/models/mail_thread.py
@@ -6,7 +6,7 @@ from email.utils import getaddresses
 from lxml import etree
 
 from odoo import _, api, fields, models
-from odoo.tools import email_split, email_split_and_format
+from odoo.tools import email_split_and_format
 
 
 class MailThread(models.AbstractModel):
@@ -81,16 +81,15 @@ class MailThread(models.AbstractModel):
             for email in emails_extra:
                 email_extra_formated_list.extend(email_split_and_format(email))
         email_extra_formated_list = set(email_extra_formated_list)
-        email_extra_list = [x[1] for x in getaddresses(email_extra_formated_list)]
-        partners_info = self.sudo()._message_partner_info_from_emails(email_extra_list)
-        for pinfo in partners_info:
+        for email_formated in email_extra_formated_list:
+            email = getaddresses([email_formated])[0][1]
+            pinfo = self.sudo()._message_partner_info_from_emails([email])[0]
+            email = email.lower()
             partner_id = pinfo["partner_id"]
-            email_formed = email_split(pinfo["full_name"])
-            email = email_formed and email_formed[0].lower()
             if not partner_id:
                 if email not in aliases:
                     self._message_add_suggested_recipient(
-                        suggestions, email=email, reason=reason
+                        suggestions, email=email_formated, reason=reason
                     )
             else:
                 partner = ResPartnerObj.browse(partner_id)

--- a/mail_tracking/tests/test_mail_tracking.py
+++ b/mail_tracking/tests/test_mail_tracking.py
@@ -223,7 +223,7 @@ class TestMailTracking(TransactionCase):
         # suggested recipients
         recipients = self.recipient._message_get_suggested_recipients()
         suggested_mails = {email[1] for email in recipients[self.recipient.id]}
-        self.assertIn("unnamed@test.com", suggested_mails)
+        self.assertIn('"Dominique Pinon" <unnamed@test.com>', suggested_mails)
         self.assertEqual(len(recipients[self.recipient.id]), 3)
         # Repeated Cc recipients
         message = self.env["mail.message"].create(
@@ -277,7 +277,7 @@ class TestMailTracking(TransactionCase):
         # suggested recipients
         recipients = self.recipient._message_get_suggested_recipients()
         suggested_mails = {email[1] for email in recipients[self.recipient.id]}
-        self.assertIn("support+unnamed@test.com", suggested_mails)
+        self.assertIn('"Dominique Pinon" <support+unnamed@test.com>', suggested_mails)
         self.assertEqual(len(recipients[self.recipient.id]), 3)
         # Repeated To recipients
         message = self.env["mail.message"].create(
@@ -314,7 +314,9 @@ class TestMailTracking(TransactionCase):
         recipients = self.recipient._message_get_suggested_recipients()
         self.assertEqual(len(recipients[self.recipient.id]), 2)
         suggested_mails = {email[1] for email in recipients[self.recipient.id]}
-        self.assertNotIn("support+unnamed@test.com", suggested_mails)
+        self.assertNotIn(
+            '"Dominique Pinon" <support+unnamed@test.com>', suggested_mails
+        )
 
     def test_failed_message(self):
         MailMessageObj = self.env["mail.message"]


### PR DESCRIPTION
Add the email formated to suggested recipients as odoo does to avoid having repeated suggestions.

See https://github.com/odoo/odoo/blob/bca4a1184d4c1cc7c5e987eb1753886337223f98/addons/mail/models/mail_thread_cc.py#L46C5-L52C26

cc @Tecnativa TT57760

ping @pedrobaeza @carlos-lopez-tecnativa 