### PR TITLE
[IMP][17.0] mass_mailing_partner: add index on partner_id

### DIFF
--- a/mass_mailing_partner/README.rst
+++ b/mass_mailing_partner/README.rst
@@ -99,6 +99,10 @@ Contributors
 
       -  Nguyễn Minh Chiến <chien@trobz.com>
 
+-  `Stesi Consulting <https://www.stesi.consulting>`__:
+
+   -  Michele Di Croce <dicroce.m@stesi.consulting>
+
 Other credits
 -------------
 

--- a/mass_mailing_partner/models/mailing_trace.py
+++ b/mass_mailing_partner/models/mailing_trace.py
@@ -9,7 +9,7 @@ class MailingTrace(models.Model):
     _inherit = "mailing.trace"
 
     partner_id = fields.Many2one(
-        string="Partner", comodel_name="res.partner", readonly=True
+        string="Partner", comodel_name="res.partner", readonly=True, index=True
     )
 
     @api.model

--- a/mass_mailing_partner/readme/CONTRIBUTORS.md
+++ b/mass_mailing_partner/readme/CONTRIBUTORS.md
@@ -16,3 +16,5 @@
 - [Trobz](https://trobz.com):
 
   > - Nguyễn Minh Chiến \<<chien@trobz.com>\>
+- [Stesi Consulting](https://www.stesi.consulting):
+  - Michele Di Croce \<<dicroce.m@stesi.consulting>\>

--- a/mass_mailing_partner/static/description/index.html
+++ b/mass_mailing_partner/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -447,6 +448,11 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </blockquote>
 </li>
+<li><p class="first"><a class="reference external" href="https://www.stesi.consulting">Stesi Consulting</a>:</p>
+<ul class="simple">
+<li>Michele Di Croce &lt;<a class="reference external" href="mailto:dicroce.m&#64;stesi.consulting">dicroce.m&#64;stesi.consulting</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="other-credits">
@@ -457,7 +463,9 @@ by Camptocamp</p>
 <div class="section" id="maintainers">
 <h1>Maintainers</h1>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
This PR speed up the search and delete on mailing.trace using partner_id Without this PR if the mailing.trace is big, the delete or search is slow It is because the index is missing on partner_id