### PR TITLE
[17.0][FIX] mail_gateway: Users without technical access rights can't link a message

### DIFF
--- a/mail_gateway/wizards/mail_message_gateway_link.py
+++ b/mail_gateway/wizards/mail_message_gateway_link.py
@@ -15,7 +15,14 @@ class MailMessageGatewayLink(models.TransientModel):
 
     @api.model
     def _selection_target_model(self):
-        models = self.env["ir.model"].search([("is_mail_thread", "=", True)])
+        allowed_models = self.env["ir.model.access"]._get_allowed_models(mode="write")
+        models = (
+            self.sudo()
+            .env["ir.model"]
+            .search(
+                [("model", "in", list(allowed_models)), ("is_mail_thread", "=", True)]
+            )
+        )
         return [(model.model, model.name) for model in models]
 
     def link_message(self):


### PR DESCRIPTION
Before this change, when a user tried to link a message to a record, the system threw an error because they did not have enough access rights to see the ir.model records.

![error_link](https://github.com/user-attachments/assets/77f83de1-1758-417e-acf8-2c10b9bae25e)

With this change, the error is no longer raised, and the user can link messages only to the models for which they have write access rights.

![no_error_link](https://github.com/user-attachments/assets/e24e7e9f-b501-4387-8ca1-b753c81d91c7)

cc @Tecnativa TT58073

ping @pedrobaeza @victoralmau 