### PR TITLE
[16.0][FIX] mail_gateway: Messages are not being sent using the email messaging thread

### DIFF
--- a/mail_gateway/models/mail_thread.py
+++ b/mail_gateway/models/mail_thread.py
@@ -25,7 +25,7 @@ class MailThread(models.AbstractModel):
             )
 
     def _notify_get_recipients(self, message, msg_vals, **kwargs):
-        if "gateway_notifications" in kwargs:
+        if kwargs.get("gateway_notifications"):
             result = []
             for notification in kwargs["gateway_notifications"]:
                 if not notification.get("channel_type"):


### PR DESCRIPTION
Backport of #1706

Before these changes, the messages sent using the email thread were not being delivered.

After making these changes, since the gateway_notifications key is empty, the super is called and the process continues normally.

@Tecnativa