### PR TITLE
[17.0][IMP] mail_show_follower: Allow using records in mail.mail._build_cc_text

### DIFF
--- a/mail_show_follower/models/mail_mail.py
+++ b/mail_show_follower/models/mail_mail.py
@@ -1,12 +1,11 @@
 from markupsafe import Markup
 
-from odoo import api, models, tools
+from odoo import models, tools
 
 
 class MailMail(models.Model):
     _inherit = "mail.mail"
 
-    @api.model
     def _build_cc_text(self, partners):
         if not partners:
             return ""


### PR DESCRIPTION
Allows using records inside mail.mail._build_cc_text, useful if you need to inherit from this method.
@pedrobaeza @juancarlosonate-tecnativa 
TT58129 @Tecnativa
