### PR TITLE
[FIX] base_search_mail_content: Bug searching on big messages

### DIFF
--- a/base_search_mail_content/models/mail_thread.py
+++ b/base_search_mail_content/models/mail_thread.py
@@ -17,10 +17,12 @@ class MailThread(models.AbstractModel):
         model_domain = [("model", "=", self._name)]
         if operator not in expression.NEGATIVE_TERM_OPERATORS:
             model_domain += ["|"] * 4
+            model_domain += [("body", "ilike", value)]
+        else:
+            model_domain += [("body", operator, value)]
         model_domain += [
             ("record_name", operator, value),
             ("subject", operator, value),
-            ("body", operator, value),
             ("email_from", operator, value),
             ("reply_to", operator, value),
         ]

--- a/base_search_mail_content/tests/test_base_search_mail_content.py
+++ b/base_search_mail_content/tests/test_base_search_mail_content.py
@@ -28,7 +28,7 @@ class TestBaseSearchMailContent(TransactionCase):
         Partner = self.env["res.partner"]
         partner = Partner.create({"name": "Test Partner"})
         partner.message_post(
-            body="Hello World",
+            subject="Hello World",
         )
         partner_find = Partner.search([("message_content", "ilike", "world hell")])
         self.assertFalse(partner_find)


### PR DESCRIPTION
Before this fix, in long messages, it cannot find the words you are looking for. More contex in the issue https://github.com/OCA/social/issues/1733 .

https://www.loom.com/share/9ba5478d5672459bad447cbb3390395e

MT-10818 @moduon @Andrii9090 @yajo 