### PR TITLE
[18.0][IMP] mail_gateway: Simplify button label from 'Gateway message' to 'Gateway'

### DIFF
--- a/mail_gateway/i18n/es.po
+++ b/mail_gateway/i18n/es.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
 "PO-Revision-Date: 2024-05-28 16:26+0000\n"
 "Last-Translator: Anna Martínez <anna080678@gmail.com>\n"
@@ -131,17 +131,21 @@ msgid "Find a gateway channel..."
 msgstr ""
 
 #. module: mail_gateway
+#. odoo-javascript
+#: code:addons/mail_gateway/static/src/components/chatter/chatter.xml:0
+#: code:addons/mail_gateway/static/src/core/common/discuss_app_model_patch.esm.js:0
 #: model:ir.actions.act_window,name:mail_gateway.mail_gateway_act_window
-#: model:ir.model.fields,field_description:mail_gateway.field_mail_channel__gateway_id
+#: model:ir.model.fields,field_description:mail_gateway.field_discuss_channel__gateway_id
 #: model:ir.model.fields,field_description:mail_gateway.field_mail_guest__gateway_id
 #: model:ir.model.fields,field_description:mail_gateway.field_res_partner_gateway_channel__gateway_id
 #: model:ir.model.fields,field_description:mail_gateway.field_res_users__gateway_ids
-#: model:ir.model.fields.selection,name:mail_gateway.selection__mail_channel__channel_type__gateway
+#: model:ir.model.fields.selection,name:mail_gateway.selection__discuss_channel__channel_type__gateway
 #: model:ir.model.fields.selection,name:mail_gateway.selection__mail_notification__notification_type__gateway
 #: model:ir.module.category,name:mail_gateway.module_category_gateway
 #: model:ir.ui.menu,name:mail_gateway.mail_gateway_menu
+#, python-format
 msgid "Gateway"
-msgstr ""
+msgstr "Pasarela"
 
 #. module: mail_gateway
 #: model:ir.model.fields,field_description:mail_gateway.field_mail_mail__gateway_channel_ids
@@ -214,7 +218,7 @@ msgstr ""
 
 #. module: mail_gateway
 #. odoo-javascript
-#: code:addons/mail_gateway/static/src/components/chatter/chatter.xml:0
+#: code:addons/mail_gateway/static/src/components/composer/composer.esm.js:0
 #, python-format
 msgid "Gateway message"
 msgstr ""

--- a/mail_gateway/i18n/mail_gateway.pot
+++ b/mail_gateway/i18n/mail_gateway.pot
@@ -230,6 +230,7 @@ msgstr ""
 
 #. module: mail_gateway
 #. odoo-javascript
+#: code:addons/mail_gateway/static/src/components/chatter/chatter.xml:0
 #: code:addons/mail_gateway/static/src/core/common/discuss_app_model_patch.esm.js:0
 #: model:ir.actions.act_window,name:mail_gateway.mail_gateway_act_window
 #: model:ir.model.fields,field_description:mail_gateway.field_discuss_channel__gateway_id
@@ -319,7 +320,6 @@ msgstr ""
 
 #. module: mail_gateway
 #. odoo-javascript
-#: code:addons/mail_gateway/static/src/components/chatter/chatter.xml:0
 #: code:addons/mail_gateway/static/src/components/composer/composer.esm.js:0
 msgid "Gateway message"
 msgstr ""

--- a/mail_gateway/static/src/components/chatter/chatter.xml
+++ b/mail_gateway/static/src/components/chatter/chatter.xml
@@ -19,7 +19,7 @@
                 data-hotkey="shift+w"
             >
                 <i class="fa fa-plane" role="img" aria-label="gateway" />
-                <span> Gateway message</span>
+                <span> Gateway</span>
             </button>
         </xpath>
         <xpath


### PR DESCRIPTION
The purpose is to reduce spacing so that all icons and buttons fit within the window without having to scroll.

Before

<img width="671" height="92" alt="image" src="https://github.com/user-attachments/assets/c3723036-bb80-4fe7-a85f-e6ef1ea6346f" />

After
<img width="668" height="79" alt="image" src="https://github.com/user-attachments/assets/13b07884-d9a9-4a3d-9a34-f7c28f464625" />

Forward-port of https://github.com/OCA/social/pull/1738
TT57968
@Tecnativa @pedrobaeza @pilarvargas-tecnativa @CarlosRoca13 could you please review this?