### PR TITLE
[FIX][17.0] mass_mailing_custom_unsubscribe: Ensure mailing contact exists

### DIFF
--- a/mass_mailing_custom_unsubscribe/migrations/17.0.1.0.0/post-migration.py
+++ b/mass_mailing_custom_unsubscribe/migrations/17.0.1.0.0/post-migration.py
@@ -53,6 +53,8 @@ def migrate(env, version):
         FROM mail_unsubscription mu
         JOIN mail_unsubscription_mailing_list_rel rel
             ON mu.id = rel.mail_unsubscription_id
+        JOIN mailing_contact mc
+            ON mc.id = CAST(SPLIT_PART(mu.unsubscriber_id, ',', 2) AS INTEGER)
         WHERE
             mu.unsubscriber_id LIKE 'mailing.contact,%'
             AND SPLIT_PART(mu.unsubscriber_id, ',', 2) ~ '^[0-9]+$'


### PR DESCRIPTION
Ensure mailing contact exists to avoid violating foreign key constraint

This error has been raised on an upgrade:

```
2025-10-16 13:22:37,087 1 ERROR prod OpenUpgrade: insert or update on table "mailing_subscription" violates foreign key constraint "mailing_contact_list_rel_contact_id_fkey"
DETAIL:  Key (contact_id)=(956572) is not present in table "mailing_contact".
```

MT-12213 @moduon @pedrobaeza @yajo please review if you want :)