### PR TITLE
[14.0] FIX mail_outbound_static: Align maximum length of TLD to DNS limit (63 chars)

### DIFF
--- a/mail_outbound_static/models/ir_mail_server.py
+++ b/mail_outbound_static/models/ir_mail_server.py
@@ -45,7 +45,7 @@ class IrMailServer(models.Model):
         if self.smtp_from:
             match = re.match(
                 r"^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\."
-                r"[a-z]{2,4})$",
+                r"[a-z]{2,63})$",
                 self.smtp_from,
             )
             if match is None:


### PR DESCRIPTION
From https://github.com/OCA/social/pull/1123