### PR TITLE
[16.0][IMP] mail_gateway: add no_create partner on mail_guest_manage wizard

### DIFF
--- a/mail_gateway/wizards/mail_guest_manage.xml
+++ b/mail_gateway/wizards/mail_guest_manage.xml
@@ -9,7 +9,7 @@
             <form>
                 <group>
                     <field name="guest_id" force_save="1" readonly="1" />
-                    <field name="partner_id" />
+                    <field name="partner_id" options="{'no_create': 1}" />
                 </group>
                 <footer>
                     <button


### PR DESCRIPTION
This pull request makes a minor update to the guest management wizard form. The change restricts the creation of new `partner_id` entries directly from the form, ensuring users can only select from existing partners.

* Set the `options="{'no_create': 1}"` attribute on the `partner_id` field in `mail_gateway/wizards/mail_guest_manage.xml` to prevent creating new partners from the wizard form.