### PR TITLE
[16.0][IMP] mail_gateway_whatsapp: Update partner mobile when merging guest with WhatsApp gateway

### DIFF
--- a/mail_gateway_whatsapp/wizards/__init__.py
+++ b/mail_gateway_whatsapp/wizards/__init__.py
@@ -1,2 +1,3 @@
 from . import mail_compose_gateway_message
 from . import whatsapp_composer
+from . import mail_guest_manage

--- a/mail_gateway_whatsapp/wizards/mail_guest_manage.py
+++ b/mail_gateway_whatsapp/wizards/mail_guest_manage.py
@@ -1,0 +1,22 @@
+# Copyright 2025 Marcel Savegnago - Escodoo
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class MailGuestManage(models.TransientModel):
+    _inherit = "mail.guest.manage"
+
+    def _merge_partner(self, partner):
+        super()._merge_partner(partner)
+        gateway_channel = self.env["res.partner.gateway.channel"].search(
+            [
+                ("partner_id", "=", partner.id),
+                ("gateway_id.gateway_type", "=", "whatsapp"),
+            ],
+            limit=1,
+        )
+        if gateway_channel:
+            partner.mobile = gateway_channel.gateway_token
+            partner._onchange_mobile_validation()
+        return True


### PR DESCRIPTION
This pull request introduces support for managing WhatsApp gateway information during guest management operations. The most important changes are the addition of a new wizard module and logic to synchronize a partner's mobile number with their WhatsApp gateway token.

**WhatsApp Gateway Integration:**

* Added a new wizard file `mail_guest_manage.py` that extends the `mail.guest.manage` transient model to update the partner's mobile number with the WhatsApp gateway token if a corresponding gateway channel exists. (`[mail_gateway_whatsapp/wizards/mail_guest_manage.pyR1-R25](diffhunk://#diff-d57e0b40c715ca84d1b29618ce6a73267333de0a55fdf5414fd8f1b5bc008d4eR1-R25)`)
* Registered the new wizard module in `__init__.py` to ensure it is loaded by the application. (`[mail_gateway_whatsapp/wizards/__init__.pyR3](diffhunk://#diff-9318e612f101f89d62beb9943f56a81610d515b39d257dd4bf563415de7fae8bR3)`)