### PR TITLE
[16.0][FIX]mail_activity_team: correctly count only active activities

### DIFF
--- a/mail_activity_team/models/res_users.py
+++ b/mail_activity_team/models/res_users.py
@@ -31,7 +31,7 @@ class ResUsers(models.Model):
                         SELECT mail_activity_team_id
                         FROM mail_activity_team_users_rel
                         WHERE res_users_id = %(user_id)s
-                    )
+                    ) AND act.active = True
                     GROUP BY m.id, states, act.res_model, act.user_id;"""
         user = self.env.uid
         self.env.cr.execute(


### PR DESCRIPTION
There is a discrepancy between the activity count shown in the systray and the actual number of pending activities.

The systray counter was incorrectly including activities that have already been marked as done. This caused confusion as the badge number did not match the number of items in the activity list after clicking on it.

<img width="631" height="132" alt="image" src="https://github.com/user-attachments/assets/a6d50235-028f-48bf-adcd-1d825dfcf1a1" />
<img width="1810" height="204" alt="image" src="https://github.com/user-attachments/assets/8cfc0fe8-477f-464d-bf2b-5471a2d99561" />
