### PR TITLE
[17.0][FIX] mail_tracking: Prevent singleton error when trying to resend a failed message

### DIFF
--- a/mail_tracking/wizards/mail_resend_message.py
+++ b/mail_tracking/wizards/mail_resend_message.py
@@ -29,7 +29,10 @@ class MailResendMessage(models.TransientModel):
                 )
                 if existing_resend_partner:
                     rec["partner_ids"].extend(
-                        [Command.link(existing_resend_partner.id)]
+                        [
+                            Command.link(resend_partner.id)
+                            for resend_partner in existing_resend_partner
+                        ]
                     )
                     continue
                 # Create only resends that mail.notification didn't prepare already


### PR DESCRIPTION
In the `mail` module, a new resend record is always created https://github.com/odoo/odoo/blob/c956c154755e2630da2f464a88f5c3545d7733e3/addons/mail/wizard/mail_resend_message.py#L44 so this search is limited to 1 to prevent the issue.

<img width="682" height="112" alt="image" src="https://github.com/user-attachments/assets/4e3e042f-3128-4271-90cc-a7f93ca4a19f" />

TT59301
@Tecnativa @pedrobaeza @CarlosRoca13 could you please review this?