### PR TITLE
[16.0][FIX] mail_activity_done: handle SQL queries without .replace()

### DIFF
--- a/mail_activity_done/models/mail_activity.py
+++ b/mail_activity_done/models/mail_activity.py
@@ -91,17 +91,41 @@ class MailActivityMixin(models.AbstractModel):
         execute_org = self._cr.execute
 
         def execute(query, params=None, log_exceptions=True):
+            # Convert to string according to query type
+            if hasattr(query, 'as_string'):
+                # psycopg2 SQL object
+                try:
+                    query_str = query.as_string(self._cr._cnx)
+                except Exception:
+                    query_str = str(query)
+            elif isinstance(query, str):
+                query_str = query
+            else:
+                # Composite SQL object - leave as is if no pattern
+                query_str = str(query) if hasattr(query, '__str__') else query
+            
             original_where = "WHERE res_model = '{}'".format(self._name)
-            replace_where = (
-                "WHERE res_model = '{}' AND mail_activity.done = FALSE".format(
-                    self._name
+            
+            # Only modify if the pattern exists in the query
+            if isinstance(query_str, str) and original_where in query_str:
+                replace_where = (
+                    "WHERE res_model = '{}' AND mail_activity.done = FALSE".format(
+                        self._name
+                    )
                 )
-            )
-            return execute_org(
-                query.replace(original_where, replace_where),
-                params=params,
-                log_exceptions=log_exceptions,
-            )
+                modified_query = query_str.replace(original_where, replace_where)
+                return execute_org(
+                    modified_query,
+                    params=params,
+                    log_exceptions=log_exceptions,
+                )
+            else:
+                # Pass the original query without modification
+                return execute_org(
+                    query,
+                    params=params,
+                    log_exceptions=log_exceptions,
+                )
 
         self._cr.execute = execute
         try:
@@ -113,15 +137,40 @@ class MailActivityMixin(models.AbstractModel):
         execute_org = self._cr.execute
 
         def execute(query, params=None, log_exceptions=True):
-            return execute_org(
-                query.replace(
-                    "WHERE mail_activity.res_model = %(res_model_table)s",
+            # Convert to string according to query type
+            if hasattr(query, 'as_string'):
+                # psycopg2 SQL object
+                try:
+                    query_str = query.as_string(self._cr._cnx)
+                except Exception:
+                    query_str = str(query)
+            elif isinstance(query, str):
+                query_str = query
+            else:
+                # Composite SQL object - leave as is if no pattern
+                query_str = str(query) if hasattr(query, '__str__') else query
+            
+            pattern = "WHERE mail_activity.res_model = %(res_model_table)s"
+            
+            # Only modify if the pattern exists in the query
+            if isinstance(query_str, str) and pattern in query_str:
+                modified_query = query_str.replace(
+                    pattern,
                     "WHERE mail_activity.res_model = %(res_model_table)s AND "
                     "mail_activity.done = FALSE",
-                ),
-                params=params,
-                log_exceptions=log_exceptions,
-            )
+                )
+                return execute_org(
+                    modified_query,
+                    params=params,
+                    log_exceptions=log_exceptions,
+                )
+            else:
+                # Pass the original query without modification
+                return execute_org(
+                    query,
+                    params=params,
+                    log_exceptions=log_exceptions,
+                )
 
         self._cr.execute = execute
         try:

--- a/mail_activity_done/models/mail_activity.py
+++ b/mail_activity_done/models/mail_activity.py
@@ -92,7 +92,7 @@ class MailActivityMixin(models.AbstractModel):
 
         def execute(query, params=None, log_exceptions=True):
             # Convert to string according to query type
-            if hasattr(query, 'as_string'):
+            if hasattr(query, "as_string"):
                 # psycopg2 SQL object
                 try:
                     query_str = query.as_string(self._cr._cnx)
@@ -102,10 +102,10 @@ class MailActivityMixin(models.AbstractModel):
                 query_str = query
             else:
                 # Composite SQL object - leave as is if no pattern
-                query_str = str(query) if hasattr(query, '__str__') else query
-            
+                query_str = str(query) if hasattr(query, "__str__") else query
+
             original_where = "WHERE res_model = '{}'".format(self._name)
-            
+
             # Only modify if the pattern exists in the query
             if isinstance(query_str, str) and original_where in query_str:
                 replace_where = (
@@ -138,7 +138,7 @@ class MailActivityMixin(models.AbstractModel):
 
         def execute(query, params=None, log_exceptions=True):
             # Convert to string according to query type
-            if hasattr(query, 'as_string'):
+            if hasattr(query, "as_string"):
                 # psycopg2 SQL object
                 try:
                     query_str = query.as_string(self._cr._cnx)
@@ -148,10 +148,10 @@ class MailActivityMixin(models.AbstractModel):
                 query_str = query
             else:
                 # Composite SQL object - leave as is if no pattern
-                query_str = str(query) if hasattr(query, '__str__') else query
-            
+                query_str = str(query) if hasattr(query, "__str__") else query
+
             pattern = "WHERE mail_activity.res_model = %(res_model_table)s"
-            
+
             # Only modify if the pattern exists in the query
             if isinstance(query_str, str) and pattern in query_str:
                 modified_query = query_str.replace(


### PR DESCRIPTION
Description
-----------
Fix `AttributeError: 'SQL' object has no attribute 'replace'` when using
`mail_activity_done` on Odoo 16.0 and accessing views with activity
progress bars (e.g. project task Kanban with activities).

Root cause
----------
In Odoo 16.0, SQL queries are `psycopg.sql.SQL` / `Composed` objects
instead of plain strings, so calling `.replace()` on them fails.

Technical details
-----------------
In `mail_activity_done/models/mail_activity.py`:

* In `_read_progress_bar()`, override `execute()` to:
  * convert the SQL object to a string via `as_string(self._cr._cnx)`
    when available, or fallback to `str(query)`,
  * only perform `replace()` on the string when the expected pattern
    (`WHERE res_model = ...`) is present,
  * otherwise, call the original `execute()` with the unmodified `query`.

* Apply the same pattern in `_search_activity_state()` for its own
  SQL pattern, avoiding `.replace()` on the raw SQL object.

This preserves behaviour on earlier versions while making the module
compatible with Odoo 16.0.

Related issue
-------------
Fixes #1747