### PR TITLE
[17.0][FIX] mail_gateway: Fix charset error for Werkzeug 2.3+

### DIFF
--- a/mail_gateway/controllers/gateway.py
+++ b/mail_gateway/controllers/gateway.py
@@ -51,9 +51,12 @@ class GatewayController(Controller):
                     ("Content-Type", "application/json"),
                 ],
             )
-        jsonrequest = json.loads(
-            request.httprequest.get_data().decode(request.httprequest.charset)
+        charset = (
+            hasattr(request.httprequest, "charset")
+            and request.httprequest.charset
+            or "utf-8"
         )
+        jsonrequest = json.loads(request.httprequest.get_data().decode(charset))
         dispatcher = (
             request.env["mail.gateway.%s" % usage]
             .with_user(bot_data["webhook_user_id"])


### PR DESCRIPTION
Add hasattr() check for charset attribute before usage with fallback to 'utf-8' for compatibility with Werkzeug 2.3+ where the attribute was removed.

Werkzeug 2.3.0:

https://werkzeug.palletsprojects.com/en/stable/changes/#version-2-3-0

For odoo 17 requirements:
```
Werkzeug==2.0.2 ; python_version <= '3.10' 
Werkzeug==2.2.2 ; python_version > '3.10' and python_version < '3.12'
Werkzeug==3.0.1 ; python_version >= '3.12'  # (Noble) Avoid deprecation warnings
```