### PR TITLE
[18.0][FIX] mail_gateway: memeber does not have userId

### DIFF
--- a/mail_gateway/readme/CONTRIBUTORS.md
+++ b/mail_gateway/readme/CONTRIBUTORS.md
@@ -3,3 +3,4 @@
 
 - [Tecnativa](https://tecnativa.com)
   - Carlos Roca
+  - Eduardo Ezerouali

--- a/mail_gateway/static/src/core/web/channel_member_list_patch.esm.js
+++ b/mail_gateway/static/src/core/web/channel_member_list_patch.esm.js
@@ -1,0 +1,15 @@
+import {ChannelMemberList} from "@mail/discuss/core/common/channel_member_list";
+import {patch} from "@web/core/utils/patch";
+
+patch(ChannelMemberList.prototype, {
+    onClickAvatar(ev, member) {
+        if (!this.canOpenChatWith(member)) {
+            return;
+        }
+        if (!this.avatarCard.isOpen && member.persona.userId) {
+            this.avatarCard.open(ev.currentTarget, {
+                id: member.persona.userId,
+            });
+        }
+    },
+});


### PR DESCRIPTION
We have notice that when we add a partner to guest through `mail.guest.manage` that makes it clickable on member list, but it throws an error. 

<img width="1019" height="648" alt="Selección_038" src="https://github.com/user-attachments/assets/cf30b9fe-236f-491e-aee3-fa321ae6ee9b" />

This comes from odoo in member list uses userId to get all the information need it to show the AvatarPopCard, but in our case there is no user related just the partner. This fix that behavior and checks if that member has a user or not.

ping @pedrobaeza @christian-ramos-tecnativa @carlos-lopez-tecnativa 