### PR TITLE
[16.0][FIX] email_template_qweb: use language-aware env for rendering QWeb

### DIFF
--- a/email_template_qweb/models/mail_template.py
+++ b/email_template_qweb/models/mail_template.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Therp BV <http://therp.nl>
+# Copyright 2016-2026 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import fields, models, tools
 
@@ -17,36 +17,28 @@ class MailTemplate(models.Model):
 
     def generate_email(self, res_ids, fields):
         multi_mode = True
-        IrQweb = self.env["ir.qweb"]
-
         if isinstance(res_ids, int):
             res_ids = [res_ids]
             multi_mode = False
-        result = super(MailTemplate, self).generate_email(res_ids, fields=fields)
-        for lang, (_template, _template_res_ids) in self._classify_per_lang(
+        result = super().generate_email(res_ids, fields=fields)
+        if self.body_type != "qweb_view" or (fields and "body_html" not in fields):
+            return result if multi_mode else result[res_ids[0]]
+        for lang, (_template, template_res_ids) in self._classify_per_lang(
             res_ids
         ).items():
             self_with_lang = self.with_context(lang=lang)
-            for res_id in res_ids:
-                if self.body_type == "qweb_view" and (
-                    not fields or "body_html" in fields
-                ):
-                    for record in self_with_lang.env[self.model].browse(res_id):
-                        body_html = IrQweb._render(
-                            self_with_lang.body_view_id.id,
-                            {"object": record, "email_template": self_with_lang},
-                        )
-                        # Some wizards, like when sending a sales order, need this
-                        # fix to display accents correctly
-                        body_html = tools.ustr(body_html)
-                        result[res_id][
-                            "body_html"
-                        ] = self_with_lang._render_template_postprocess(
-                            {res_id: body_html}
-                        )[
-                            res_id
-                        ]
-                        result[res_id]["body"] = tools.html_sanitize(
-                            result[res_id]["body_html"]
-                        )
+            IrQweb = self_with_lang.env["ir.qweb"]
+            for res_id in template_res_ids:
+                record = self_with_lang.env[self_with_lang.model].browse(res_id)
+                result_res_id = result[res_id]
+                body_html = IrQweb._render(
+                    self_with_lang.body_view_id.id,
+                    {"object": record, "email_template": self_with_lang},
+                )
+                body_html = tools.ustr(body_html)
+                rendered_post_temp = self_with_lang._render_template_postprocess(
+                    {res_id: body_html}
+                )
+                result_res_id["body_html"] = rendered_post_temp[res_id]
+                result_res_id["body"] = tools.html_sanitize(result_res_id["body_html"])
         return result if multi_mode else result[res_ids[0]]


### PR DESCRIPTION
fix bug where in email_template_qweb module: the QWeb renderer (ir.qweb) is instantiated once from the original environment (self.env) before the code switches into the per-language context:

- Subject is rendered via the "normal" mail.template rendering path that uses the per-language self_with_lang context -> it follows template.lang.
- Body is rendered by ir.qweb._render(...) using an IrQweb recordset created before lang was applied -> it keeps whatever env.lang was at the moment generate_email() started (e.g. the website request language, current user language, etc.), which explains the "random" English/Dutch mix.