### PR TITLE
[17.0][IMP] mail_history_mark_unread: enable marking notifications as unread from search panel

### DIFF
--- a/mail_history_mark_unread/README.rst
+++ b/mail_history_mark_unread/README.rst
@@ -29,9 +29,13 @@ Mail History Mark as Unread
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module introduces a "Mark as Unread" button for messages in the
-History mailbox of the Discuss App. When done the message is restored
-back to the Inbox, just like if it were a new unread message, and
-disappears from the History mailbox.
+History mailbox and Search results of the Discuss App. When done the
+message is restored back to the Inbox, just like if it were a new unread
+message, and disappears from the History mailbox.
+
+The button is also available in the Search Messages panel (accessible
+via the search icon in Discuss), allowing users to mark any searched
+message as unread directly from the search results.
 
 **Table of contents**
 

--- a/mail_history_mark_unread/__manifest__.py
+++ b/mail_history_mark_unread/__manifest__.py
@@ -1,7 +1,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Mail History Mark as Unread",
-    "summary": "Add 'Mark as Unread' action to messages in History mailbox",
+    "summary": """Add 'Mark as Unread' action to messages in History mailbox
+    and Search results""",
     "version": "17.0.1.0.0",
     "category": "Social Network",
     "website": "https://github.com/OCA/social",
@@ -14,6 +15,7 @@
             "mail_history_mark_unread/static/src/message_actions_patch.esm.js",
             "mail_history_mark_unread/static/src/message_service_patch.esm.js",
             "mail_history_mark_unread/static/src/mail_core_web_service_patch.esm.js",
+            "mail_history_mark_unread/static/src/message_card_list.xml",
         ],
     },
 }

--- a/mail_history_mark_unread/readme/DESCRIPTION.md
+++ b/mail_history_mark_unread/readme/DESCRIPTION.md
@@ -1,2 +1,4 @@
-This module introduces a "Mark as Unread" button for messages in the History mailbox of the Discuss App.
+This module introduces a "Mark as Unread" button for messages in the History mailbox and Search results of the Discuss App.
 When done the message is restored back to the Inbox, just like if it were a new unread message, and disappears from the History mailbox.
+
+The button is also available in the Search Messages panel (accessible via the search icon in Discuss), allowing users to mark any searched message as unread directly from the search results.

--- a/mail_history_mark_unread/static/description/index.html
+++ b/mail_history_mark_unread/static/description/index.html
@@ -371,9 +371,12 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/social/tree/17.0/mail_history_mark_unread"><img alt="OCA/social" src="https://img.shields.io/badge/github-OCA%2Fsocial-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/social-17-0/social-17-0-mail_history_mark_unread"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/social&amp;target_branch=17.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module introduces a “Mark as Unread” button for messages in the
-History mailbox of the Discuss App. When done the message is restored
-back to the Inbox, just like if it were a new unread message, and
-disappears from the History mailbox.</p>
+History mailbox and Search results of the Discuss App. When done the
+message is restored back to the Inbox, just like if it were a new unread
+message, and disappears from the History mailbox.</p>
+<p>The button is also available in the Search Messages panel (accessible
+via the search icon in Discuss), allowing users to mark any searched
+message as unread directly from the search results.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/mail_history_mark_unread/static/src/message_actions_patch.esm.js
+++ b/mail_history_mark_unread/static/src/message_actions_patch.esm.js
@@ -3,19 +3,35 @@
 import {_t} from "@web/core/l10n/translation";
 import {messageActionsRegistry} from "@mail/core/common/message_actions";
 
-// Add "Mark as Unread" action for messages in History mailbox
+// Add "Mark as Unread" action for messages in History mailbox and Search results
 messageActionsRegistry.add("mark-as-unread-history", {
     condition: (component) => {
-        return (
-            component.props.message?.isHistory &&
-            component.store.user &&
-            component.props.message.persistent
-        );
+        const message = component.props.message;
+        if (!message?.persistent || !component.store.user) {
+            return false;
+        }
+        if (message.isHistory) {
+            return true;
+        }
+        if (component.env.messageCard && !message.isNeedaction) {
+            return true;
+        }
+        return false;
     },
     icon: "fa-eye-slash",
     title: _t("Mark as Unread"),
-    onClick: (component) => {
-        component.messageService.setUndone(component.props.message);
+    onClick: async (component) => {
+        const message = component.props.message;
+        await component.messageService.setUndone(message);
+        // Remove from search results if in search mode
+        const messageSearch = component.props.messageSearch;
+        if (messageSearch?.messages) {
+            const index = messageSearch.messages.findIndex((m) => m.id === message.id);
+            if (index !== -1) {
+                messageSearch.messages.splice(index, 1);
+                messageSearch.count = Math.max(0, messageSearch.count - 1);
+            }
+        }
     },
     sequence: 15,
 });

--- a/mail_history_mark_unread/static/src/message_card_list.xml
+++ b/mail_history_mark_unread/static/src/message_card_list.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <!-- Override MessageCardList to enable actions for search mode -->
+    <t t-inherit="mail.MessageCardList" t-inherit-mode="extension">
+        <xpath expr="//Message" position="attributes">
+            <attribute name="hasActions">props.mode === 'search'</attribute>
+        </xpath>
+    </t>
+</templates>


### PR DESCRIPTION
Enable a button from the Search Messages panel (accessible via the search icon in Discuss), allowing users to mark any searched message as unread directly from the search results.

<img width="1541" height="863" alt="image" src="https://github.com/user-attachments/assets/8dd2efe6-ff7e-4787-ae40-d30cd66c5a8c" />