### PR TITLE
[17.0][FIX] mail_activity_reminder : test error (CheckViolation)

### DIFF
--- a/mail_activity_reminder/tests/test_mail_activity_reminder.py
+++ b/mail_activity_reminder/tests/test_mail_activity_reminder.py
@@ -31,9 +31,7 @@ class TestMailActivityReminder(common.TransactionCase):
         cls.model_res_partner = cls.env["ir.model"].search(
             [("model", "=", "res.partner")], limit=1
         )
-        cls.partner_DecoAddict = cls.env["res.partner"].search(
-            [("name", "ilike", "Deco Addict")], limit=1
-        )
+        cls.partner_DecoAddict = cls.env["res.partner"].create({"name": "Deco Addict"})
 
     def test_none_reminders(self):
         activity_type = self.MailActivityType.create({"name": "Activity Type"})


### PR DESCRIPTION
When trying to merge this PR: https://github.com/OCA/social/pull/1560, OCA-git-bot aborted due to failing checks. After rebasing, the following error appeared in the tests:

<img width="2068" height="545" alt="image" src="https://github.com/user-attachments/assets/d073bede-e943-40c7-8103-c5dda4b31362" />

I’ve reviewed it and the issue is that the existing search does not find the partner. To test it i added the following code while running the tests, and the result is an empty res.partner recordset.

Code added in the test function:
+ print("partner = ", self.env["res.partner"].search( [("name", "ilike", "Deco Addict")], limit=1))

Terminal output:
+  partner =  res.partner()


I modified the partner lookup to search by reference instead.