### PR TITLE
[17.0][IMP] mail_gateway_whatsapp: Handle errors when the message is not sent to the API

### DIFF
--- a/mail_gateway_whatsapp/models/mail_gateway_whatsapp.py
+++ b/mail_gateway_whatsapp/models/mail_gateway_whatsapp.py
@@ -288,7 +288,11 @@ class MailGatewayWhatsappService(models.AbstractModel):
             else:
                 _logger.warning(f"Issue sending message with id {record.id}: {exc}")
                 record.sudo().write(
-                    {"notification_status": "exception", "failure_reason": exc}
+                    {
+                        "notification_status": "exception",
+                        "failure_reason": exc,
+                        "failure_type": "unknown",
+                    }
                 )
         if message:
             record.sudo().write(


### PR DESCRIPTION
In the previous PR https://github.com/OCA/social/pull/1717 we handled the notification via webhook when Meta returns an error. However, when the error occurs in the communication with Meta, the message is displayed as delivered. After this commit, the message is displayed as error when applicable.

The failure details are only written when `failure_type = 'unknown'`. See: https://github.com/OCA/social/blob/695efd6fa3401614118c6a52f58453b40a9f0842/mail_gateway/models/mail_message.py#L114 So, in exception cases, we write this field to ensure it is processed correctly.

TT59775

@Tecnativa @pedrobaeza @CarlosRoca13 @etobella could you please review this?
