### PR TITLE
[17.0][FIX] mail_gateway_whatsapp: find existing template buttons 

### DIFF
--- a/mail_gateway_whatsapp/models/mail_whatsapp_template.py
+++ b/mail_gateway_whatsapp/models/mail_whatsapp_template.py
@@ -327,7 +327,7 @@ class MailWhatsAppTemplate(models.Model):
             "gateway_id": gateway.id,
         }
         is_supported = True
-        template = self.search([("template_uid","=", json_data.get("id"))])
+        template = self.search([("template_uid", "=", json_data.get("id"))])
         for component in json_data.get("components", []):
             if component["type"] == "HEADER" and component["format"] == "TEXT":
                 vals["header"] = component["text"]

--- a/mail_gateway_whatsapp/models/mail_whatsapp_template.py
+++ b/mail_gateway_whatsapp/models/mail_whatsapp_template.py
@@ -327,6 +327,7 @@ class MailWhatsAppTemplate(models.Model):
             "gateway_id": gateway.id,
         }
         is_supported = True
+        template = self.search( [("template_uid","=", json_data.get("id"))])
         for component in json_data.get("components", []):
             if component["type"] == "HEADER" and component["format"] == "TEXT":
                 vals["header"] = component["text"]
@@ -345,7 +346,7 @@ class MailWhatsAppTemplate(models.Model):
                             "website_url": button.get("url"),
                         }
                         vals.setdefault("button_ids", [])
-                        button = self.button_ids.filtered(
+                        button = template.button_ids.filtered(
                             lambda btn, button=button: btn.name == button["text"]
                         )
                         if button:

--- a/mail_gateway_whatsapp/models/mail_whatsapp_template.py
+++ b/mail_gateway_whatsapp/models/mail_whatsapp_template.py
@@ -327,7 +327,7 @@ class MailWhatsAppTemplate(models.Model):
             "gateway_id": gateway.id,
         }
         is_supported = True
-        template = self.search( [("template_uid","=", json_data.get("id"))])
+        template = self.search([("template_uid","=", json_data.get("id"))])
         for component in json_data.get("components", []):
             if component["type"] == "HEADER" and component["format"] == "TEXT":
                 vals["header"] = component["text"]


### PR DESCRIPTION
The method `mail.whatsapp.template._prepare_values_to_import()` is a model method (@api.model), so using **self** to search for existing buttons always returns an empty list.

When attempting to update templates from Meta, if a template with buttons already exists in the gateway configuration, the import process will fail because it cannot find the existing buttons and attempts to create them (again), causing the SQL constraint `unique_name_for_template` to fail.

This was resolved by searching for the buttons in the original template (using the UID).

The fix is based on 17.0 but it seems that it can be ported seamlessly to 18.0 also.
