### PR TITLE
[18.0][FIX] mail_gateway_whatsapp: Use the existing template to process imported data.

### DIFF
--- a/mail_gateway_whatsapp/models/mail_gateway.py
+++ b/mail_gateway_whatsapp/models/mail_gateway.py
@@ -58,7 +58,7 @@ class MailGateway(models.Model):
             ws_template = templates_by_id.get(template_data["id"])
             if ws_template:
                 ws_template.write(
-                    WhatsappTemplate._prepare_values_to_import(self, template_data)
+                    ws_template._prepare_values_to_import(self, template_data)
                 )
             else:
                 create_vals.append(


### PR DESCRIPTION
When attempting to update templates from Meta, if a template with buttons already exists in the gateway configuration, the import process will fail because it cannot find the existing buttons and attempts to create them (again), causing the SQL constraint unique_name_for_template to fail.
The reason being that even if the imported template exists, the code calls the update method using an empty recordset instead of the actual existing template.

It was fixed in 17.0 by #1833. This is a forward-port to 18.0