### PR TITLE
[18.0][FIX] mail_gateway: Stop using RecordCapturer

### DIFF
--- a/mail_gateway/models/mail_message.py
+++ b/mail_gateway/models/mail_message.py
@@ -3,7 +3,6 @@
 
 
 from odoo import api, fields, models
-from odoo.tests import RecordCapturer
 
 from odoo.addons.mail.tools.discuss import Store
 
@@ -118,10 +117,10 @@ class MailMessage(models.Model):
             gateway_channel_id.gateway_token
         )
         channel = self.env["discuss.channel"].browse(chat_id)
-        with RecordCapturer(
-            self.env["mail.notification"], [("gateway_channel_id", "=", channel.id)]
-        ) as capt:
-            channel.message_post(**self._get_gateway_thread_message_vals())
+        messages = channel.message_post(**self._get_gateway_thread_message_vals())
+        notification = messages.notification_ids.filtered(
+            lambda n: n.gateway_channel_id == channel
+        )
         if not self.gateway_type:
             self.gateway_type = gateway_channel_id.gateway_id.gateway_type
         notification_vals = {
@@ -131,7 +130,6 @@ class MailMessage(models.Model):
             "notification_type": "gateway",
             "gateway_type": gateway_channel_id.gateway_id.gateway_type,
         }
-        notification = capt.records
         if notification:
             # Set the same gateway_message_id for both notifications.
             # When the webhook is received, both notifications must be updated.


### PR DESCRIPTION
RecordCapturer is only available in tests; it must be avoided in business models. Adapt the code to use a similar feature.

Closes https://github.com/OCA/social/issues/1812

@Tecnativa @pedrobaeza @percevaq @diegonc could you please review this?