### PR TITLE
[18.0][FIX] mail_gateway_whatsapp: Display an audio player on incoming audios 

### DIFF
--- a/mail_gateway_whatsapp/models/mail_gateway_whatsapp.py
+++ b/mail_gateway_whatsapp/models/mail_gateway_whatsapp.py
@@ -139,6 +139,10 @@ class MailGatewayWhatsappService(models.AbstractModel):
                     proxies=self._get_proxies(),
                 )
                 image_request.raise_for_status()
+                attachment_info = {}
+                if "audio/" in image_info["mime_type"]:
+                    # Tell discuss to treat this attachment as voice.
+                    attachment_info["voice"] = True
                 attachments.append(
                     (
                         "{}{}".format(
@@ -146,6 +150,7 @@ class MailGatewayWhatsappService(models.AbstractModel):
                             mimetypes.guess_extension(image_info["mime_type"]),
                         ),
                         image_request.content,
+                        attachment_info,
                     )
                 )
         if message.get("location"):

--- a/mail_gateway_whatsapp/tests/test_mail_gateway_whatsapp.py
+++ b/mail_gateway_whatsapp/tests/test_mail_gateway_whatsapp.py
@@ -120,6 +120,42 @@ class TestMailGatewayWhatsApp(MailGatewayTestCase):
                 }
             ],
         }
+        cls.audio_message = {
+            "object": "whatsapp_business_account",
+            "entry": [
+                {
+                    "id": "WHATSAPP_BUSINESS_ACCOUNT_ID",
+                    "changes": [
+                        {
+                            "value": {
+                                "messaging_product": "whatsapp",
+                                "metadata": {
+                                    "display_phone_number": "1234",
+                                    "phone_number_id": "1234",
+                                },
+                                "contacts": [
+                                    {"profile": {"name": "NAME"}, "wa_id": "1234"}
+                                ],
+                                "messages": [
+                                    {
+                                        "from": "1234",
+                                        "id": "wamid.ID",
+                                        "timestamp": "1234",
+                                        "type": "audio",
+                                        "audio": {
+                                            "mime_type": "audio/oga",
+                                            "sha256": "IMAGE_HASH",
+                                            "id": "12356",
+                                        },
+                                    }
+                                ],
+                            },
+                            "field": "messages",
+                        }
+                    ],
+                }
+            ],
+        }
 
     def test_webhook_management(self):
         self.gateway.webhook_key = self.webhook
@@ -207,6 +243,22 @@ class TestMailGatewayWhatsApp(MailGatewayTestCase):
         with patch("requests.get") as get_mock:
             get_mock.return_value = GetImageResponse()
             self.receive_message(self.message_02)
+
+    def test_receive_audio_message(self):
+        class GetAudioResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"url": "http://demo.url", "mime_type": "audio/oga"}
+
+            content = b"binary_data"
+
+        with patch("requests.get") as get_mock:
+            get_mock.return_value = GetAudioResponse()
+            message = self.receive_message(self.audio_message)
+            # Check that the attachment is marked as voice
+            self.assertTrue(message.attachment_ids.voice_ids)
 
     @mute_logger("odoo.addons.mail_gateway.controllers.gateway")
     def test_post_no_signature_no_message(self):


### PR DESCRIPTION
Right now, incoming whatsapp audios are shown as a regular attachment. That means that the only option is to download them and using an external app to reproduce them.

This small patch places a record (`voice: True`) in the attachment info so that, when processed by discuss, it recognizes it as a voice attachment and makes the necessary adjustments.

In short, this will convert this:
 
<img width="309" height="93" alt="image" src="https://github.com/user-attachments/assets/2baf9a48-d660-4a3c-b07e-3be6e8ce4dfd" />

Into this:
<img width="274" height="88" alt="image" src="https://github.com/user-attachments/assets/0857734c-2731-4156-a1d5-d6240e168900" />

