### PR TITLE
[18.0][FIX] mail_gateway_whatsapp: Include attachment caption in message body

### DIFF
--- a/mail_gateway_whatsapp/models/mail_gateway_whatsapp.py
+++ b/mail_gateway_whatsapp/models/mail_gateway_whatsapp.py
@@ -143,6 +143,7 @@ class MailGatewayWhatsappService(models.AbstractModel):
                 if "audio/" in image_info["mime_type"]:
                     # Tell discuss to treat this attachment as voice.
                     attachment_info["voice"] = True
+                body += message.get(key).get("caption", "")
                 attachments.append(
                     (
                         "{}{}".format(

--- a/mail_gateway_whatsapp/tests/test_mail_gateway_whatsapp.py
+++ b/mail_gateway_whatsapp/tests/test_mail_gateway_whatsapp.py
@@ -242,7 +242,8 @@ class TestMailGatewayWhatsApp(MailGatewayTestCase):
 
         with patch("requests.get") as get_mock:
             get_mock.return_value = GetImageResponse()
-            self.receive_message(self.message_02)
+            message = self.receive_message(self.message_02)
+            self.assertEqual(message.body, "<p>CAPTION</p>")
 
     def test_receive_audio_message(self):
         class GetAudioResponse:


### PR DESCRIPTION
Currently, attachment captions are disregarded.
This small patch adds the attachment caption into the message body.

