### PR TITLE
[17.0][FIX] mail_gateway: Adapt onFocusIn signature

### DIFF
--- a/mail_gateway/static/src/components/composer/composer.esm.js
+++ b/mail_gateway/static/src/components/composer/composer.esm.js
@@ -28,8 +28,8 @@ patch(Composer.prototype, {
         }
         return isSendButtonDisabled || !this.thread?.gateway_notifications.length;
     },
-    onFocusin() {
-        super.onFocusin();
+    onFocusin(ev) {
+        super.onFocusin(ev);
         if (this.props.type !== "gateway" && this.thread) {
             this.thread.gateway_notifications = [];
         }


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/83c9c6168c7b40cee7329bf7c4cd0, Odoo has changed the signature of the JS method `onFocusIn`, provoking that the override on this module crashes.

Let's adapt the override to the new signature.

@Tecnativa TT61993