### PR TITLE
[17.0][OU-FIX] mass_mailing_custom_unsubscribe: Set next sequence val on reasons

### DIFF
--- a/mass_mailing_custom_unsubscribe/migrations/17.0.1.0.0/post-migration.py
+++ b/mass_mailing_custom_unsubscribe/migrations/17.0.1.0.0/post-migration.py
@@ -16,6 +16,14 @@ def migrate(env, version):
 
     """,
     )
+    # Adjust sequence
+    env.cr.execute("SELECT max(id) FROM mailing_subscription_optout")
+    maxid = env.cr.fetchone()[0]
+    openupgrade.logged_query(
+        env.cr,
+        "SELECT setval('mailing_subscription_optout_id_seq', %s, true)",
+        (maxid,),
+    )
     # For mailing lists, get the last unsubscription for every mail and create
     # a proper mailing.subscription record
     openupgrade.logged_query(


### PR DESCRIPTION
Doing an INSERT with id included lets the sequence with an incorrect value that may conflict in future inserts, so we need to adjust it to next following value.

@Tecnativa TT62916