### PR TITLE
[18.0][FIX] mail_gateway: Fix channel member duplicates

### DIFF
--- a/mail_gateway/models/mail_gateway_abstract.py
+++ b/mail_gateway/models/mail_gateway_abstract.py
@@ -47,16 +47,26 @@ class MailGatewayAbstract(models.AbstractModel):
 
     def _get_channel_vals(self, gateway, token, update):
         author = self._get_author(gateway, update)
+        member_pids = set(gateway.member_ids.mapped("partner_id").ids)
         members = [
-            Command.create({"partner_id": partner.id, "unpin_dt": False})
-            for partner in gateway.member_ids.partner_id
+            Command.create({"partner_id": partner_id, "unpin_dt": False})
+            for partner_id in member_pids
         ]
-        if author:
+        if author and author._name == "res.partner" and author.id not in member_pids:
             members.append(
                 Command.create(
                     {
-                        "partner_id": author._name == "res.partner" and author.id,
-                        "guest_id": author._name == "mail.guest" and author.id,
+                        "partner_id": author.id,
+                        "guest_id": False,
+                    }
+                )
+            )
+        elif author and author._name == "mail.guest":
+            members.append(
+                Command.create(
+                    {
+                        "partner_id": False,
+                        "guest_id": author.id,
                     }
                 )
             )


### PR DESCRIPTION
**Module**: `mail_gateway`

When a webhook is received and the `author` (sender) happens to be one of the users already configured in `gateway.member_ids`, the previous logic resulted in the `author`'s `partner_id` being appended to the `members` list even though it was already iterated over from `gateway.member_ids.partner_id`. 

This caused Odoo's `discuss.channel.create` to fail with `psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "discuss_channel_member_partner_id_channel_id_uniq"`. 

**Fix**: Using a `set` for the member partner IDs and explicitly verifying that `author.id not in member_pids` before appending ensures `partner_id` is unique.