### PR TITLE
[16.0][FIX] mail_composer_cc_bcc: email_to must be a list, not a joined string

### DIFF
--- a/mail_composer_cc_bcc/models/mail_mail.py
+++ b/mail_composer_cc_bcc/models/mail_mail.py
@@ -17,16 +17,15 @@ _logger = logging.getLogger(__name__)
 
 
 def format_emails(partners):
-    emails = [
-        tools.formataddr(
-            (
-                p.name or "False",
-                p.email and tools.mail._normalize_email(p.email) or "False",
-            )
-        )
+    return [
+        tools.formataddr((p.name or "", tools.mail._normalize_email(p.email)))
         for p in partners
+        if p.email
     ]
-    return ", ".join(emails)
+
+
+def format_emails_str(partners):
+    return ", ".join(format_emails(partners))
 
 
 class MailMail(models.Model):
@@ -294,10 +293,12 @@ class MailMail(models.Model):
         partner_to_ids = [r.id for r in self.recipient_ids if r not in partners_cc_bcc]
         partner_to = self.env["res.partner"].browse(partner_to_ids)
         res["email_to"] = format_emails(partner_to)
-        res["email_cc"] = format_emails(self.recipient_cc_ids)
-        res["email_bcc"] = format_emails(self.recipient_bcc_ids)
+        res["email_cc"] = format_emails_str(self.recipient_cc_ids)
+        res["email_bcc"] = format_emails_str(self.recipient_bcc_ids)
         if res.get("email_to"):
-            res["email_to_normalized"] += tools.email_normalize_all(res["email_to"])
+            res["email_to_normalized"] += tools.email_normalize_all(
+                format_emails_str(partner_to)
+            )
         if res.get("email_cc"):
             res["email_to_normalized"] += tools.email_normalize_all(res["email_cc"])
         if res.get("email_bcc"):

--- a/mail_composer_cc_bcc/models/mail_thread.py
+++ b/mail_composer_cc_bcc/models/mail_thread.py
@@ -3,7 +3,7 @@
 
 from odoo import models
 
-from .mail_mail import format_emails
+from .mail_mail import format_emails_str
 
 
 class MailThread(models.AbstractModel):
@@ -32,10 +32,10 @@ class MailThread(models.AbstractModel):
         )
         partners_cc = context.get("partner_cc_ids", None)
         if partners_cc:
-            res["email_cc"] = format_emails(partners_cc)
+            res["email_cc"] = format_emails_str(partners_cc)
         partners_bcc = context.get("partner_bcc_ids", None)
         if partners_bcc:
-            res["email_bcc"] = format_emails(partners_bcc)
+            res["email_bcc"] = format_emails_str(partners_bcc)
         return res
 
     def _notify_get_recipients(self, message, msg_vals, **kwargs):


### PR DESCRIPTION
When sending an email from the mail composer (with `mail_composer_cc_bcc` and `mail_tracking` both installed), the recipient list shown in the chatter's "To:" line renders each character of the formatted address separately:
<img width="1328" height="142" alt="Captura de pantalla 2026-07-23 100259" src="https://github.com/user-attachments/assets/90daa0fe-0ca1-4171-a274-e7a49d08db33" />