### PR TITLE
[17.0][FIX] mail_tracking: create notification with its mandatory type

### DIFF
--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -383,8 +383,20 @@ class MailTrackingEmail(models.Model):
             # If mail_message haven't tracking partner, then
             # add it in order to see his tracking status in chatter
             if mail_message.subtype_id:
-                mail_message.sudo().write(
-                    {"notified_partner_ids": [Command.link(self.partner_id.id)]}
+                # `notified_partner_ids` is a m2m over `mail_notification`, a
+                # table with its own mandatory columns, so linking it emits an
+                # INSERT with no `notification_type` and hits its NOT NULL
+                # constraint. Create the notification explicitly instead: an
+                # IntegrityError here aborts the whole transaction, which in
+                # the mail queue means the mail is re-sent on every cron run
+                # and never leaves the `outgoing` state.
+                self.env["mail.notification"].sudo().create(
+                    {
+                        "mail_message_id": mail_message.id,
+                        "res_partner_id": self.partner_id.id,
+                        "notification_type": "email",
+                        "notification_status": "sent",
+                    }
                 )
             else:
                 mail_message.sudo().write(

--- a/mail_tracking/tests/test_mail_tracking.py
+++ b/mail_tracking/tests/test_mail_tracking.py
@@ -706,3 +706,45 @@ class TestMailTracking(TransactionCase):
             self.assertEqual(
                 "data-odoo-tracking-email not found", tracking.error_description
             )
+
+    def test_message_partners_check_missing_notification(self):
+        """Regression: a tracked recipient with no notification must not abort
+        the transaction, or the mail queue re-sends the mail on every cron run
+        and never leaves the `outgoing` state.
+        """
+        follower = self.env["res.partner"].create(
+            {"name": "Test follower", "email": "follower@example.com"}
+        )
+        message = self.env["mail.message"].create(
+            {
+                "subject": "Message without notification",
+                "author_id": self.sender.id,
+                "email_from": self.sender.email,
+                "message_type": "comment",
+                "subtype_id": self.env.ref("mail.mt_comment").id,
+                "model": "res.partner",
+                "res_id": self.recipient.id,
+                "partner_ids": [Command.link(self.recipient.id)],
+                "body": "<p>This is a test message</p>",
+            }
+        )
+        # The state left behind when a notification goes missing: the tracked
+        # partner is neither an explicit recipient nor a notified partner.
+        self.assertNotIn(follower, message.partner_ids | message.notified_partner_ids)
+        tracking_email = self.env["mail.tracking.email"].create(
+            {
+                "name": message.subject,
+                "mail_message_id": message.id,
+                "partner_id": follower.id,
+                "recipient": follower.email,
+            }
+        )
+        tracking_email._message_partners_check(None, None)
+        notification = self.env["mail.notification"].search(
+            [
+                ("mail_message_id", "=", message.id),
+                ("res_partner_id", "=", follower.id),
+            ]
+        )
+        self.assertEqual(notification.notification_type, "email")
+        self.assertIn(follower, message.notified_partner_ids)


### PR DESCRIPTION
## Problem

`_message_partners_check()` adds a tracked recipient to the message by writing the `notified_partner_ids` m2m:

```python
mail_message.sudo().write(
    {"notified_partner_ids": [Command.link(self.partner_id.id)]}
)
```

`mail.message.notified_partner_ids` is a `Many2many` whose relation table is `mail_notification` — a real model with its own mandatory columns. Linking it emits a bare `INSERT INTO mail_notification (mail_message_id, res_partner_id)`, leaving `notification_type` NULL, and that column is `required=True`:

```
ERROR: null value in column "notification_type" of relation "mail_notification"
violates not-null constraint
```

## Impact

This is reached from `_tracking_sent_prepare()`, which `ir.mail_server.send_email()` calls **after** `super().send_email()` — that is, after the message was already handed to the SMTP server.

So whenever a tracked recipient has no notification (a follower of a chatter comment whose notification is missing, for instance), every delivery attempt:

1. actually delivers the mail;
2. raises `IntegrityError` on the tracking step;
3. aborts the transaction, so the `mail.mail` never leaves `outgoing` — the write marking it as `exception` fails too.

The queue cron then picks it up again on the next run, re-delivering the same mail indefinitely. Worse, it dies on that record, so the rest of the queue is never processed.

## Fix

Create the `mail.notification` explicitly with its mandatory `notification_type='email'` (and `notification_status='sent'`, consistent with what core writes after a successful send).

The `else` branch is left untouched: it writes `partner_ids`, a plain m2m, which is not affected.

## Test plan

Added `test_message_partners_check_missing_notification`: it builds the triggering state — a tracked partner present in neither `partner_ids` nor `notified_partner_ids` — and asserts the notification is created with its type.

Without the fix the test errors with the `NotNullViolation` above; with it, it passes.
