### PR TITLE
[18.0][FIX] mail_gateway: sort gateway channels by last interest

### DIFF
--- a/mail_gateway/static/src/core/web/discuss_app_category_model_patch.esm.js
+++ b/mail_gateway/static/src/core/web/discuss_app_category_model_patch.esm.js
@@ -10,8 +10,7 @@ patch(DiscussAppCategory.prototype, {
     sortThreads(t1, t2) {
         if (this.id === "gateway") {
             return (
-                compareDatetime(t2.lastInterestDateTime, t1.lastInterestDateTime) ||
-                t2.id - t1.id
+                compareDatetime(t2.lastInterestDt, t1.lastInterestDt) || t2.id - t1.id
             );
         }
         return super.sortThreads(t1, t2);


### PR DESCRIPTION
The gateway category sort in `discuss_app_category_model_patch.esm.js` still uses the Odoo 17 field name `lastInterestDateTime`. Odoo 18 renamed this Thread record field to `lastInterestDt` — see the core "chats" category sort in [`mail/static/src/core/public_web/discuss_app_category_model.js#L25`](https://github.com/odoo/odoo/blob/18.0/addons/mail/static/src/core/public_web/discuss_app_category_model.js#L25):

```js
return compareDatetime(t2.lastInterestDt, t1.lastInterestDt) || t2.id - t1.id;
```

Because both operands are `undefined`, `compareDatetime()` returns 0 and the comparison silently falls back to `t2.id - t1.id`: gateway channels end up stacked by channel creation order instead of last activity, which makes the sidebar unusable as a messaging inbox once you have more than a handful of conversations.

One-word fix (two occurrences on the same line): use the 18.0 field name, so the gateway category sorts by last interest again — most recent first, same mechanic as the core "Direct messages" category. Reproduced and fixed on a live 18.0 production database.
