### PR TITLE
[16.0][FIX] mail_activity_team: proper field naming for activity_team…

### DIFF
--- a/mail_activity_team/models/mail_activity_mixin.py
+++ b/mail_activity_team/models/mail_activity_mixin.py
@@ -8,7 +8,7 @@ class MailActivityMixin(models.AbstractModel):
 
     activity_team_user_ids = fields.Many2many(
         comodel_name="res.users",
-        string="test field",
+        string="Activity Team Member",
         compute="_compute_activity_team_user_ids",
         search="_search_activity_team_user_ids",
     )


### PR DESCRIPTION
Just giving a proper naming for field `activity_team_user_ids`.