### PR TITLE
[18.0][FIX] mail_gateway_whatsapp: preserve incoming text layout

### DIFF
--- a/mail_gateway_whatsapp/models/mail_gateway_whatsapp.py
+++ b/mail_gateway_whatsapp/models/mail_gateway_whatsapp.py
@@ -10,11 +10,12 @@ from io import StringIO
 
 import requests
 import requests_toolbelt
+from markupsafe import Markup
 
 from odoo import models
 from odoo.exceptions import UserError
 from odoo.http import request
-from odoo.tools import html2plaintext
+from odoo.tools import html2plaintext, plaintext2html
 
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
 
@@ -154,12 +155,12 @@ class MailGatewayWhatsappService(models.AbstractModel):
                         attachment_info,
                     )
                 )
+        body = plaintext2html(body) if body else Markup()
         if message.get("location"):
-            body += (
+            body += Markup(
                 '<a target="_blank" href="https://www.google.com/'
-                f'maps/search/?api=1&query={message["location"]["latitude"]},'
-                f'{message["location"]["longitude"]}">Location</a>'
-            )
+                'maps/search/?api=1&query=%s,%s">Location</a>'
+            ) % (message["location"]["latitude"], message["location"]["longitude"])
         if message.get("contacts"):
             pass
         if len(body) > 0 or attachments:

--- a/mail_gateway_whatsapp/tests/test_mail_gateway_whatsapp.py
+++ b/mail_gateway_whatsapp/tests/test_mail_gateway_whatsapp.py
@@ -1,6 +1,7 @@
 # Copyright 2022 CreuBlanca
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import copy
 import hashlib
 import hmac
 import json
@@ -317,6 +318,23 @@ class TestMailGatewayWhatsApp(MailGatewayTestCase):
             message = self.receive_message(self.audio_message)
             # Check that the attachment is marked as voice
             self.assertTrue(message.attachment_ids.voice_ids)
+
+    def test_receive_message_keeps_layout(self):
+        """Text keeps its layout, markup stays literal, location stays a link."""
+        message = copy.deepcopy(self.message_01)
+        content = message["entry"][0]["changes"][0]["value"]["messages"][0]
+        # Plain text, brackets included: what a sender typing "<b>" really sends.
+        content["text"] = {
+            "body": "Line 1\n<b>bold</b>\n\nSection 2 https://example.com/track"
+        }
+        content["location"] = {"latitude": "41.3851", "longitude": "2.1734"}
+        body = self.receive_message(message).body
+        self.assertIn("Line 1<br", body)
+        self.assertIn("</p><p>", body)
+        self.assertIn('href="https://example.com/track"', body)
+        self.assertIn("&lt;b&gt;bold&lt;/b&gt;", body)
+        self.assertIn("41.3851,2.1734", body)
+        self.assertNotIn("&lt;a", body)
 
     @mute_logger("odoo.addons.mail_gateway.controllers.gateway")
     def test_post_no_signature_no_message(self):


### PR DESCRIPTION
## Problem

`_process_update` passes the incoming WhatsApp text straight to `message_post`:

    new_message = chat.sudo().message_post(body=body, ...)   # body is a plain str

The body it assembles only ever comes from two Cloud API fields, `messages[].text.body` and the media `caption`, both plain text. `mail_thread._message_post` only escapes a `str` body (`'body': escape(body)`), and `escape()` does not convert `\n`. A multi-line message is therefore stored as `<p>line1\nline2…</p>`, and in HTML a newline is just a space: the message shows up as a single block, the blank lines that separated its sections are gone, and URLs are not clickable.

The same root cause affects the `location` branch of the same function: the `<a href=…>` is built as a `str`, so `escape()` renders it as literal HTML — a shared location shows the source of the link instead of the link.

## Fix

Convert the assembled body (text + media captions) with `plaintext2html` once, before the `location` branch, so that both `message_post` calls of the function receive `Markup`. This mirrors the outgoing path of the same model, which already sends `html2plaintext(body)`. The location anchor is rebuilt as `Markup` with `%` interpolation, which keeps the coordinates coming from the payload escaped.

`plaintext2html` escapes its input, so the protection `escape()` gave is not lost, only moved: text that looks like markup (`<b>`, `<script>`) still shows literally.

No version bump, left to the OCA tooling.

## Tests

One test added to the module's existing suite, on a multi-line incoming message carrying a location: line breaks rendered, blank line kept as a paragraph break, URL turned into a link, markup-looking text left literal, location anchor kept as a link.

Checked on an 18.0 production instance: incoming messages keep their layout and their links, and previously archived ones were reformatted with the same result.