### PR TITLE
[18.0][FIX] mail_gateway_whatsapp: never return two authors for one gateway token

### DIFF
--- a/mail_gateway_whatsapp/models/mail_gateway_whatsapp.py
+++ b/mail_gateway_whatsapp/models/mail_gateway_whatsapp.py
@@ -392,7 +392,8 @@ class MailGatewayWhatsappService(models.AbstractModel):
                 [
                     ("gateway_id", "=", gateway.id),
                     ("gateway_token", "=", str(author_id)),
-                ]
+                ],
+                limit=1,
             )
             if gateway_partner:
                 return gateway_partner.partner_id
@@ -413,7 +414,8 @@ class MailGatewayWhatsappService(models.AbstractModel):
                 [
                     ("gateway_id", "=", gateway.id),
                     ("gateway_token", "=", str(author_id)),
-                ]
+                ],
+                limit=1,
             )
             if guest:
                 return guest


### PR DESCRIPTION
Nothing enforces uniqueness on `(gateway_id, gateway_token)`: there is no unique index on `mail.guest` nor on `res.partner.gateway.channel`, and `_get_author` resolves the sender with a plain "search, else create" with no lock in between. Two webhooks delivered in parallel for the same unknown number each create their own record.

From then on the unbounded searches return two records, and every later message of that correspondent fails on `ensure_one()`: the webhook answers 500 and the delivery is lost. Only the inbound path breaks — outbound messages keep being archived, so the conversation looks alive.

`limit=1` bounds both searches. The default `_order` is `id`, so the oldest record wins.

`unique_partner_gateway` does not already cover this: it only forbids the same partner twice on one gateway, so two distinct partners can still carry the same `gateway_token`.
