### PR TITLE
[18.0][FIX] mail_gateway: webhook followup

### DIFF
--- a/mail_gateway/controllers/gateway.py
+++ b/mail_gateway/controllers/gateway.py
@@ -57,10 +57,11 @@ class GatewayController(Controller):
             or "utf-8"
         )
         jsonrequest = json.loads(request.httprequest.get_data().decode(charset))
-        dispatcher = (
-            request.env[f"mail.gateway.{usage}"]
-            .with_user(bot_data["webhook_user_id"])
-            .with_context(no_gateway_notification=True)
+        # Do not set no_gateway_notification on this env: inbound posts
+        # pass that flag on message_post so later replies in this request
+        # (automations, AI) can still be sent to the gateway.
+        dispatcher = request.env[f"mail.gateway.{usage}"].with_user(
+            bot_data["webhook_user_id"]
         )
         if not dispatcher._verify_update(bot_data, jsonrequest):
             _logger.warning(

--- a/mail_gateway/models/discuss_channel.py
+++ b/mail_gateway/models/discuss_channel.py
@@ -61,16 +61,28 @@ class MailChannel(models.Model):
 
     @api.returns("mail.message", lambda value: value.id)
     def message_post(
-        self, *, message_type="notification", gateway_type=False, **kwargs
+        self,
+        *,
+        message_type="notification",
+        gateway_type=False,
+        no_gateway_notification=False,
+        **kwargs,
     ):
         message = super().message_post(
             message_type=message_type,
             gateway_type=gateway_type or self.gateway_id.gateway_type,
             **kwargs,
         )
+        # Incoming webhook posts pass no_gateway_notification to avoid an
+        # echo. The flag is per call: later message_post in the same request
+        # (automations, AI replies) must still reach the gateway.
+        # Context is kept for backward compatibility.
+        skip_gateway = no_gateway_notification or self.env.context.get(
+            "no_gateway_notification", False
+        )
         if (
             self.gateway_id
-            and not self.env.context.get("no_gateway_notification", False)
+            and not skip_gateway
             and message.message_type != "notification"
         ):
             self.env["mail.notification"].create(

--- a/mail_gateway/models/mail_thread.py
+++ b/mail_gateway/models/mail_thread.py
@@ -18,7 +18,13 @@ class MailThread(models.AbstractModel):
 
     def _get_notify_valid_parameters(self):
         notify_valid_parameters = super()._get_notify_valid_parameters()
-        return notify_valid_parameters | {"gateway_notifications"}
+        # Incoming replies linked to a document call message_post on
+        # mail.thread, not discuss.channel. Accept the per-post skip flag
+        # so notify kwargs are not rejected.
+        return notify_valid_parameters | {
+            "gateway_notifications",
+            "no_gateway_notification",
+        }
 
     def _notify_thread_by_email(self, message, recipients_data, **kwargs):
         partners_data = [r for r in recipients_data if r["notif"] == "gateway"]
@@ -131,5 +137,5 @@ class MailThread(models.AbstractModel):
 
     def _get_allowed_message_post_params(self):
         result = super()._get_allowed_message_post_params()
-        result.add("gateway_notifications")
+        result.update({"gateway_notifications", "no_gateway_notification"})
         return result

--- a/mail_gateway_telegram/models/mail_gateway_telegram.py
+++ b/mail_gateway_telegram/models/mail_gateway_telegram.py
@@ -208,6 +208,7 @@ class MailGatewayTelegramService(models.AbstractModel):
                 subtype_xmlid="mail.mt_comment",
                 message_type="comment",
                 attachments=attachments,
+                no_gateway_notification=True,
             )
             self._post_process_message(new_message, chat)
             related_message_id = (
@@ -237,6 +238,7 @@ class MailGatewayTelegramService(models.AbstractModel):
                             subtype_xmlid="mail.mt_comment",
                             message_type="comment",
                             attachments=attachments,
+                            no_gateway_notification=True,
                         )
                     )
                     new_message.gateway_message_id = new_related_message

--- a/mail_gateway_telegram/tests/test_mail_gateway_telegram.py
+++ b/mail_gateway_telegram/tests/test_mail_gateway_telegram.py
@@ -13,6 +13,7 @@ from odoo.tests.common import tagged
 from odoo.tools import file_open, mute_logger
 
 from odoo.addons.mail.tools.discuss import Store
+from odoo.addons.mail_gateway.models.discuss_channel import MailChannel
 from odoo.addons.mail_gateway.tests.common import MailGatewayTestCase
 
 
@@ -434,6 +435,91 @@ class TestMailGatewayTelegram(MailGatewayTestCase):
                 subtype_xmlid="mail.mt_comment",
                 message_type="comment",
             )
+        self.assertTrue(
+            self.env["mail.notification"].search(
+                [("gateway_channel_id", "=", channel.id)]
+            )
+        )
+
+    def test_no_gateway_notification_is_per_post(self):
+        self.gateway.webhook_key = self.webhook
+        self.gateway.flush_recordset()
+        with patch.object(telegram, "Bot", getMyBot()):
+            self.gateway.set_webhook()
+        with patch.object(telegram, "Bot", getMyBot()):
+            self.set_message(self.message_02, self.webhook)
+        channel = self.env["discuss.channel"].search(
+            [("gateway_id", "=", self.gateway.id)]
+        )
+        self.assertFalse(
+            self.env["mail.notification"].search(
+                [("gateway_channel_id", "=", channel.id)]
+            )
+        )
+        with patch.object(telegram, "Bot", getMyBot()):
+            channel.message_post(
+                body="Inbound echo must be skipped",
+                subtype_xmlid="mail.mt_comment",
+                message_type="comment",
+                no_gateway_notification=True,
+            )
+        self.assertFalse(
+            self.env["mail.notification"].search(
+                [("gateway_channel_id", "=", channel.id)]
+            )
+        )
+        with patch.object(telegram, "Bot", getMyBot()):
+            channel.message_post(
+                body="Follow-up must be sent",
+                subtype_xmlid="mail.mt_comment",
+                message_type="comment",
+            )
+        self.assertTrue(
+            self.env["mail.notification"].search(
+                [("gateway_channel_id", "=", channel.id)]
+            )
+        )
+
+    def test_webhook_followup_is_sent(self):
+        """Replies posted during webhook handling must still be sent.
+
+        Incoming updates skip the echo with a per-call flag. Automations
+        that reply in the same request (for example AI) must reach Telegram.
+        """
+        self.gateway.webhook_key = self.webhook
+        self.gateway.flush_recordset()
+        with patch.object(telegram, "Bot", getMyBot()):
+            self.gateway.set_webhook()
+        with patch.object(telegram, "Bot", getMyBot()):
+            self.set_message(self.message_02, self.webhook)
+        channel = self.env["discuss.channel"].search(
+            [("gateway_id", "=", self.gateway.id)]
+        )
+        self.assertFalse(
+            self.env["mail.notification"].search(
+                [("gateway_channel_id", "=", channel.id)]
+            )
+        )
+
+        original = MailChannel.message_post
+
+        def message_post_with_followup(self, **kwargs):
+            message = original(self, **kwargs)
+            if self.env.context.get("mail_gateway_test_followup"):
+                return message
+            if self.gateway_id and kwargs.get("no_gateway_notification"):
+                self.with_context(mail_gateway_test_followup=True).message_post(
+                    body="Automated reply",
+                    subtype_xmlid="mail.mt_comment",
+                    message_type="comment",
+                )
+            return message
+
+        with (
+            patch.object(telegram, "Bot", getMyBot()),
+            patch.object(MailChannel, "message_post", message_post_with_followup),
+        ):
+            self.set_message(self.message_01, self.webhook)
         self.assertTrue(
             self.env["mail.notification"].search(
                 [("gateway_channel_id", "=", channel.id)]

--- a/mail_gateway_whatsapp/models/mail_gateway_whatsapp.py
+++ b/mail_gateway_whatsapp/models/mail_gateway_whatsapp.py
@@ -178,6 +178,7 @@ class MailGatewayWhatsappService(models.AbstractModel):
                 subtype_xmlid="mail.mt_comment",
                 message_type="comment",
                 attachments=attachments,
+                no_gateway_notification=True,
             )
             self._post_process_message(new_message, chat)
             related_message_id = message.get("context", {}).get("id", False)
@@ -208,6 +209,7 @@ class MailGatewayWhatsappService(models.AbstractModel):
                             subtype_xmlid="mail.mt_comment",
                             message_type="comment",
                             attachments=attachments,
+                            no_gateway_notification=True,
                         )
                     )
                     self._post_process_reply(related_message)


### PR DESCRIPTION
This pull request refines how gateway notifications are managed for inbound messages, especially for Telegram and WhatsApp integrations. The main improvement is the introduction of a per-call `no_gateway_notification` flag that prevents echoing incoming webhook messages back to the gateway, while ensuring that follow-up or automated replies in the same request are still sent. This makes notification control more precise and prevents unwanted message loops. The changes also include tests to validate this behavior and support for the new flag in core message posting methods.

**Gateway Notification Control Improvements:**

* Added a per-call `no_gateway_notification` parameter to `message_post` in `discuss_channel.py` and ensured it is checked correctly to suppress gateway notifications only for the intended message, not for subsequent replies in the same request.
* Updated Telegram and WhatsApp gateway handlers to pass `no_gateway_notification=True` when posting inbound messages, preventing echoing these messages back to the gateway. [[1]](diffhunk://#diff-c5540271510cc5b3919d1a4115a579967a89fe0534994f49f0141e6ef44607aeR211) [[2]](diffhunk://#diff-c5540271510cc5b3919d1a4115a579967a89fe0534994f49f0141e6ef44607aeR241) [[3]](diffhunk://#diff-501090c685204095192e694c0e71c1aef33a0edbe11be4ba79d24a9834c072e5R181) [[4]](diffhunk://#diff-501090c685204095192e694c0e71c1aef33a0edbe11be4ba79d24a9834c072e5R212)
* Modified `gateway.py` to avoid setting the `no_gateway_notification` context globally, so that only the initial inbound message skips notification, but later replies (e.g., from automations or AI) are still sent to the gateway.

**Core Framework Support:**

* Allowed the new `no_gateway_notification` flag as a valid parameter in mail thread notification and message posting methods, ensuring it is accepted and handled properly. [[1]](diffhunk://#diff-c841c532d6556bd9c24dfb6f28461f05b402a82efc863970fcdb0fa00c11ed37L21-R27) [[2]](diffhunk://#diff-c841c532d6556bd9c24dfb6f28461f05b402a82efc863970fcdb0fa00c11ed37L134-R140)

**Testing and Validation:**

* Added tests to confirm that `no_gateway_notification` is respected per message, and that follow-up or automated replies during webhook handling are still sent to the gateway as expected.

These changes collectively improve the reliability and flexibility of gateway notifications, especially in scenarios involving webhooks and automated replies.