### PR TITLE
[18.0][IMP] mail_gateway_whatsapp: convert the text formatting both ways

### DIFF
--- a/mail_gateway_whatsapp/models/mail_gateway_whatsapp.py
+++ b/mail_gateway_whatsapp/models/mail_gateway_whatsapp.py
@@ -10,11 +10,12 @@ from io import StringIO
 
 import requests
 import requests_toolbelt
+from markupsafe import Markup
 
 from odoo import models
 from odoo.exceptions import UserError
 from odoo.http import request
-from odoo.tools import html2plaintext
+from odoo.tools import html2plaintext, plaintext2html
 
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
 
@@ -154,12 +155,12 @@ class MailGatewayWhatsappService(models.AbstractModel):
                         attachment_info,
                     )
                 )
+        body = plaintext2html(body) if body else Markup()
         if message.get("location"):
-            body += (
+            body += Markup(
                 '<a target="_blank" href="https://www.google.com/'
-                f'maps/search/?api=1&query={message["location"]["latitude"]},'
-                f'{message["location"]["longitude"]}">Location</a>'
-            )
+                'maps/search/?api=1&query=%s,%s">Location</a>'
+            ) % (message["location"]["latitude"], message["location"]["longitude"])
         if message.get("contacts"):
             pass
         if len(body) > 0 or attachments:

--- a/mail_gateway_whatsapp/models/mail_gateway_whatsapp.py
+++ b/mail_gateway_whatsapp/models/mail_gateway_whatsapp.py
@@ -4,6 +4,7 @@ import hashlib
 import hmac
 import logging
 import mimetypes
+import re
 import traceback
 from datetime import datetime
 from io import StringIO
@@ -20,6 +21,20 @@ from odoo.tools import html2plaintext, plaintext2html
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
 
 _logger = logging.getLogger(__name__)
+
+# Text formatting of the whatsapp clients, and its html counterpart.
+WHATSAPP_MARKERS = {"*": "strong", "_": "em", "~": "s", "```": "code"}
+HTML_TAGS = {
+    "b": "*",
+    "strong": "*",
+    "i": "_",
+    "em": "_",
+    "s": "~",
+    "del": "~",
+    "code": "```",
+}
+MARKED_TEXT = r"(?<!\w){0}(\S(?:.*?\S)?){0}(?!\w)"
+HTML_TAG = re.compile(r"(<a\b[^>]*>.*?</a>|<[^>]+>)", re.DOTALL)
 
 
 class MailGatewayWhatsappService(models.AbstractModel):
@@ -105,6 +120,19 @@ class MailGatewayWhatsappService(models.AbstractModel):
         # notify user that we have a failure
         notification.mail_message_id._notify_message_notification_update()
 
+    def _whatsapp_to_html(self, body):
+        """Turn the text markers of an incoming body into html tags."""
+        parts = HTML_TAG.split(plaintext2html(body))
+        for index in range(0, len(parts), 2):
+            for marker, tag in WHATSAPP_MARKERS.items():
+                parts[index] = re.sub(
+                    MARKED_TEXT.format(re.escape(marker)),
+                    rf"<{tag}>\1</{tag}>",
+                    parts[index],
+                    flags=re.DOTALL,
+                )
+        return Markup("".join(parts))
+
     def _process_update(self, chat, message, value):
         chat.ensure_one()
         body = ""
@@ -155,7 +183,7 @@ class MailGatewayWhatsappService(models.AbstractModel):
                         attachment_info,
                     )
                 )
-        body = plaintext2html(body) if body else Markup()
+        body = self._whatsapp_to_html(body) if body else Markup()
         if message.get("location"):
             body += Markup(
                 '<a target="_blank" href="https://www.google.com/'
@@ -316,6 +344,13 @@ class MailGatewayWhatsappService(models.AbstractModel):
             # pylint: disable=invalid-commit
             self.env.cr.commit()
 
+    def _html_to_whatsapp(self, body):
+        """Turn the html formatting of an outgoing body into text markers."""
+        pattern = rf"</?({'|'.join(HTML_TAGS)})\b[^>]*>"
+        return html2plaintext(
+            re.sub(pattern, lambda tag: HTML_TAGS[tag.group(1).lower()], body)
+        )
+
     def _send_payload(
         self, channel, body=False, media_id=False, media_type=False, media_name=False
     ):
@@ -345,7 +380,10 @@ class MailGatewayWhatsappService(models.AbstractModel):
                 payload.update(
                     {
                         "type": "text",
-                        "text": {"preview_url": False, "body": html2plaintext(body)},
+                        "text": {
+                            "preview_url": False,
+                            "body": self._html_to_whatsapp(body),
+                        },
                     }
                 )
             return payload

--- a/mail_gateway_whatsapp/tests/test_mail_gateway_whatsapp.py
+++ b/mail_gateway_whatsapp/tests/test_mail_gateway_whatsapp.py
@@ -336,6 +336,17 @@ class TestMailGatewayWhatsApp(MailGatewayTestCase):
         self.assertIn("41.3851,2.1734", body)
         self.assertNotIn("&lt;a", body)
 
+    def test_receive_message_formatting(self):
+        """Whatsapp text markers are rendered as html."""
+        message = copy.deepcopy(self.message_01)
+        content = message["entry"][0]["changes"][0]["value"]["messages"][0]
+        content["text"] = {"body": "*bold* _italic_ https://example.com/a_b_c"}
+        body = self.receive_message(message).body
+        self.assertIn("<strong>bold</strong>", body)
+        self.assertIn("<em>italic</em>", body)
+        # The markers of a link belong to the link.
+        self.assertIn('href="https://example.com/a_b_c"', body)
+
     @mute_logger("odoo.addons.mail_gateway.controllers.gateway")
     def test_post_no_signature_no_message(self):
         self.gateway.webhook_key = self.webhook
@@ -396,6 +407,33 @@ class TestMailGatewayWhatsApp(MailGatewayTestCase):
             )
             post_mock.assert_called()
             self.assertEqual(post_mock.call_count, 2)
+
+    def test_send_message_formatting(self):
+        """Html formatting is sent as whatsapp text markers."""
+        self.gateway.webhook_key = self.webhook
+        self.gateway.set_webhook()
+        self.integrate_webhook()
+        composer = self.env["whatsapp.composer"].create(
+            {
+                "res_model": self.partner._name,
+                "res_id": self.partner.id,
+                "number_field_name": "mobile",
+                "gateway_id": self.gateway.id,
+            }
+        )
+        composer.action_view_whatsapp()
+        channel = self.env["discuss.channel"].search(
+            [("gateway_id", "=", self.gateway.id)]
+        )
+        with patch("requests.post") as post_mock:
+            post_mock.return_value = MagicMock()
+            channel.message_post(
+                body=Markup("<p><strong>bold</strong> and <em>italic</em></p>"),
+                subtype_xmlid="mail.mt_comment",
+                message_type="comment",
+            )
+        payload = post_mock.call_args.kwargs["json"]
+        self.assertEqual(payload["text"]["body"], "*bold* and _italic_")
 
     def test_send_document_error(self):
         self.gateway.webhook_key = self.webhook

--- a/mail_gateway_whatsapp/tests/test_mail_gateway_whatsapp.py
+++ b/mail_gateway_whatsapp/tests/test_mail_gateway_whatsapp.py
@@ -1,6 +1,7 @@
 # Copyright 2022 CreuBlanca
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import copy
 import hashlib
 import hmac
 import json
@@ -317,6 +318,23 @@ class TestMailGatewayWhatsApp(MailGatewayTestCase):
             message = self.receive_message(self.audio_message)
             # Check that the attachment is marked as voice
             self.assertTrue(message.attachment_ids.voice_ids)
+
+    def test_receive_message_keeps_layout(self):
+        """Text keeps its layout, markup stays literal, location stays a link."""
+        message = copy.deepcopy(self.message_01)
+        content = message["entry"][0]["changes"][0]["value"]["messages"][0]
+        # Plain text, brackets included: what a sender typing "<b>" really sends.
+        content["text"] = {
+            "body": "Line 1\n<b>bold</b>\n\nSection 2 https://example.com/track"
+        }
+        content["location"] = {"latitude": "41.3851", "longitude": "2.1734"}
+        body = self.receive_message(message).body
+        self.assertIn("Line 1<br", body)
+        self.assertIn("</p><p>", body)
+        self.assertIn('href="https://example.com/track"', body)
+        self.assertIn("&lt;b&gt;bold&lt;/b&gt;", body)
+        self.assertIn("41.3851,2.1734", body)
+        self.assertNotIn("&lt;a", body)
 
     @mute_logger("odoo.addons.mail_gateway.controllers.gateway")
     def test_post_no_signature_no_message(self):


### PR DESCRIPTION
Follow-up of #1902, as asked there. It builds on the `plaintext2html` call of that PR, so its commit is part of this branch until it is merged.

WhatsApp clients format text with `*bold*`, `_italic_`, `~strikethrough~` and triple backticks for monospace. Incoming, those markers reached Discuss as literal characters. Outgoing, `html2plaintext` sent `<strong>` as `*bold*` — which WhatsApp reads as bold, by chance — but `<em>` as `/italic/`, shown as is, and dropped `<i>`, `<s>`, `<del>` and `<code>`.

Both ways now share one table. Incoming, markers become html tags after `plaintext2html`, leaving the tags and links it just produced alone, so a url holding `_` or `*` is untouched. Outgoing, the formatting tags become markers again before `html2plaintext`.

A marker only counts when it wraps a non-space run and is not glued to a word, so `snake_case`, `2*3*4` and unclosed markers stay as typed.

One test per direction, through the webhook and through `message_post`.
