### PR TITLE
[FIX] mail_gateway: guard Store.one_id patch against other registries

### DIFF
--- a/mail_gateway/tools/discuss.py
+++ b/mail_gateway/tools/discuss.py
@@ -8,7 +8,14 @@ original_one_id = Store.one_id
 
 def extended_one_id(record, /, *, as_thread=False):
     result = original_one_id(record, as_thread=as_thread)
-    if result and record._name == "res.partner":
+    # This patch is applied at import time, so it is shared by every registry
+    # served by the process, while ``gateway_channel_ids`` only exists in the
+    # registries where this module is installed. Check the actual registry.
+    if (
+        result
+        and record._name == "res.partner"
+        and "gateway_channel_ids" in record._fields
+    ):
         result["gateway_channels"] = record.sudo().gateway_channel_ids.mail_format()
     return result
 


### PR DESCRIPTION
## Problem

`mail_gateway` makes the whole backend unreachable (HTTP 500 on every page, including `/odoo`
and `/web`) for **any database served by the same Odoo process where the module is not
installed**.

The failure happens inside `session_info()`, i.e. before the web client is rendered, so the
affected database is fully locked out: you cannot even reach Settings to uninstall anything.

```
File ".../odoo/addons/web/models/ir_http.py", line 77, in webclient_rendering_context
    'session_info': self.session_info(),
File ".../odoo/addons/mail/models/ir_http.py", line 23, in session_info
    ResUsers._init_store_data(store)
File ".../odoo/addons/mail/models/res_users.py", line 266, in _init_store_data
    store.add(
File ".../odoo/addons/mail/tools/discuss.py", line 149, in _add_values
    target[key] = self.one_id(subrecord, as_thread=as_thread)
File ".../mail_gateway/tools/discuss.py", line 12, in extended_one_id
    result["gateway_channels"] = record.sudo().gateway_channel_ids.mail_format()
AttributeError: 'res.partner' object has no attribute 'gateway_channel_ids'
```

## Steps to reproduce

Multi-database instance (the common case):

1. One Odoo process (any number of workers) serving databases **A** and **B**.
2. `mail_gateway` is installed in **A**, and not installed in **B**.
3. Log into **A** once. This makes the worker import `odoo.addons.mail_gateway`, which applies
   the patch.
4. Log into **B** *through the same worker*. Every backend request returns 500 with the
   traceback above.

Because it depends on which database warmed up each worker, the symptom looks **intermittent**:
some requests to **B** succeed (workers that never touched **A**) and some fail.

Single-database variant: uninstall `mail_gateway` without restarting the server. The database is
locked out until the process is restarted, since uninstalling cannot undo an import-time patch.

## Root cause

`mail_gateway/tools/discuss.py` replaces `Store.one_id` at **import time**, and the replacement
assumes the field is always there:

```python
def extended_one_id(record, /, *, as_thread=False):
    result = original_one_id(record, as_thread=as_thread)
    if result and record._name == "res.partner":
        result["gateway_channels"] = record.sudo().gateway_channel_ids.mail_format()
    return result


Store.one_id = staticmethod(extended_one_id)
```

This mixes two different scopes:

* **The patch is per process.** `odoo.modules.module.load_openerp_module()` imports
  `odoo.addons.<module>` at most once per process — it returns early if the qualified name is
  already in `sys.modules`. Its own docstring is explicit that what happens at import time is
  *"server-wide (instead of registry-specific)"*. Once **any** registry loads `mail_gateway`,
  `Store.one_id` stays patched for every database that process serves, for the lifetime of the
  worker.
* **The field is per registry.** `gateway_channel_ids` is added to `res.partner` by
  `mail_gateway/models/res_partner.py`, so it only exists in the registries of the databases
  where the module is actually installed.

`Store.one_id` is called for every `res.partner` pushed into the store, including the current
user's partner during `_init_store_data`, so the mismatch is hit on the very first backend
request.

## Fix

Check the registry the call actually runs against:

```python
    if (
        result
        and record._name == "res.partner"
        and "gateway_channel_ids" in record._fields
    ):
```

`record._fields` is the field dict of the model **in the current registry**, so the check has
the same scope as the thing it guards. It is a plain dict lookup, which matters on a path called
once per partner in the store. Behaviour in databases where the module *is* installed is
unchanged, and the existing tests keep passing untouched.

`hasattr(record, "gateway_channel_ids")` would work too, but on a recordset `hasattr` swallows
any `AttributeError` raised while computing, which could mask unrelated bugs.

## A question for the maintainers

Is `Store.one_id()` where this data should live at all?

It builds the *relation reference* to a record (`{"id": ..., "type": "partner"}`) rather than
its content, and its docstring says that it does not add the result to the store, that
*"calling it manually should be avoided"*, and that it is *"kept as a public method until all
remaining occurrences can be removed"*.

Would you rather have the channels sent from a `res.partner._to_store()` override, the way
`hr_holidays` and `im_livechat` extend partner store data? That would make this class of bug
impossible by construction, since a model override only exists in the registries where its
module is installed.

I have not attempted it here, because it is not a small change and it did not seem mine to
decide:

* `mail_thread._thread_to_store()` reads the channels back out of the follower references
  returned by `message_get_followers()` (`if f["partner"]["gateway_channels"]`), and passes
  those raw references on as `gateway_followers` without ever adding the partners to the store.
  The client gets the channels from those reference dicts, so the patch is currently load
  bearing for that flow, which would have to be reworked with `Store.many()`.
* `_to_store()` does not run for relations flagged `only_id=True`, where core deliberately sends
  a partner reference without its data, while the patched `one_id` does.
* `test_messaging` in `mail_gateway_telegram` asserts the patched contract through
  `Store.one_id()` and would need updating.

If that is the direction you want, I am glad to open it as a separate PR.

## Testing

Reproduced on Odoo 18.0 with two databases served by one process, the module installed in only
one of them: 500 on every backend request before the change, both databases loading normally
after it.

Ran on the same build, all green:

* `mail_gateway_telegram` and `mail_gateway_instagram` test suites.
* `mail`: `TestThreadController`, `TestPartner`, `TestDiscussTools`.

## Notes

* `__manifest__.py` version is left untouched, for the OCA bot to bump on merge.
