### PR TITLE
[18.0][IMP] mail_gateway: Enhance the flow for leaving and inviting people to gateway channels

### DIFF
--- a/mail_gateway/models/ir_websocket.py
+++ b/mail_gateway/models/ir_websocket.py
@@ -14,8 +14,10 @@ class IrWebsocket(models.AbstractModel):
         result = super()._build_bus_channel_list(channels)
         if req.session.uid:
             if req.env.user.has_group("mail_gateway.gateway_user"):
+                # Only notify gateway channels that the user is still a member of
+                # otherwise, bus notifications keep arriving after leaving the channel.
                 for channel in req.env["discuss.channel"].search(
-                    [("channel_type", "=", "gateway")]
+                    [("channel_type", "=", "gateway"), ("is_member", "=", True)]
                 ):
                     result.append(channel)
         return result

--- a/mail_gateway/models/res_partner.py
+++ b/mail_gateway/models/res_partner.py
@@ -2,6 +2,10 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
+from odoo.osv import expression
+from odoo.tools import SQL
+
+from odoo.addons.mail.tools.discuss import Store
 
 
 class ResPartner(models.Model):
@@ -12,6 +16,48 @@ class ResPartner(models.Model):
     gateway_channel_ids = fields.One2many(
         "res.partner.gateway.channel", inverse_name="partner_id"
     )
+
+    @api.readonly
+    @api.model
+    def search_for_channel_invite(self, search_term, channel_id=None, limit=30):
+        channel = (
+            self.env["discuss.channel"].browse(int(channel_id)) if channel_id else None
+        )
+        if not channel or channel.channel_type != "gateway":
+            return super().search_for_channel_invite(
+                search_term, channel_id=channel_id, limit=limit
+            )
+        gateway_group = self.env.ref("mail_gateway.gateway_user")
+        domain = expression.AND(
+            [
+                expression.OR(
+                    [
+                        [("name", "ilike", search_term)],
+                        [("email", "ilike", search_term)],
+                    ]
+                ),
+                [("active", "=", True)],
+                [("user_ids", "!=", False)],
+                [("user_ids.active", "=", True)],
+                [("user_ids.share", "=", False)],
+                [("channel_ids", "not in", channel.id)],
+                # only users allowed to access gateway channels can be invited to them
+                [("user_ids.groups_id", "in", gateway_group.id)],
+            ]
+        )
+        query = self._search(domain, limit=limit)
+        # bypass lack of support for case insensitive order in search()
+        query.order = SQL(
+            'LOWER(%s), "res_partner"."id"', self._field_to_sql(self._table, "name")
+        )
+        store = Store()
+        self.env["res.partner"].browse(query)._search_for_channel_invite_to_store(
+            store, channel
+        )
+        return {
+            "count": self.env["res.partner"].search_count(domain),
+            "data": store.get_result(),
+        }
 
     def _get_channels_as_member(self):
         channels = super()._get_channels_as_member()

--- a/mail_gateway/static/src/core/common/thread_model_patch.esm.js
+++ b/mail_gateway/static/src/core/common/thread_model_patch.esm.js
@@ -23,6 +23,18 @@ patch(Thread.prototype, {
         this.gateway_notifications = [];
         this.gateway_followers = Record.many("Persona");
     },
+    get canLeave() {
+        // Allow leaving the thread if it is a gateway channel.
+        // Core only allows this if ["channel", "group"].includes(this.channel_type)
+        if (this.channel_type === "gateway") {
+            return (
+                !this.message_needaction_counter &&
+                !this.group_based_subscription &&
+                this.store.self?.type === "partner"
+            );
+        }
+        return super.canLeave;
+    },
     get isChatChannel() {
         return this.channel_type === "gateway" || super.isChatChannel;
     },

--- a/mail_gateway/tests/__init__.py
+++ b/mail_gateway/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_res_partner_search_for_channel_invite

--- a/mail_gateway/tests/test_res_partner_search_for_channel_invite.py
+++ b/mail_gateway/tests/test_res_partner_search_for_channel_invite.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Tecnativa - Carlos Lopez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import new_test_user
+
+from odoo.addons.base.tests.common import BaseCommon
+
+
+class TestResPartnerSearchForChannelInvite(BaseCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.gateway_user = new_test_user(
+            cls.env,
+            login="test_gateway_user",
+            groups="base.group_user,mail_gateway.gateway_user",
+            name="Test Gateway Agent",
+        )
+        cls.regular_user = new_test_user(
+            cls.env,
+            login="test_regular_user",
+            groups="base.group_user",
+            name="Test Regular Agent",
+        )
+        cls.gateway_channel = cls.env["discuss.channel"].create(
+            {"name": "Gateway Channel", "channel_type": "gateway"}
+        )
+        cls.regular_channel = cls.env["discuss.channel"].create(
+            {"name": "Regular Channel", "channel_type": "channel"}
+        )
+
+    def test_only_gateway_users_are_suggested_on_gateway_channels(self):
+        result = self.env["res.partner"].search_for_channel_invite(
+            "Test", channel_id=self.gateway_channel.id
+        )
+        suggested_ids = {p["id"] for p in result["data"].get("res.partner", [])}
+        self.assertIn(self.gateway_user.partner_id.id, suggested_ids)
+        self.assertNotIn(self.regular_user.partner_id.id, suggested_ids)
+
+    def test_regular_channels_are_not_restricted(self):
+        result = self.env["res.partner"].search_for_channel_invite(
+            "Test", channel_id=self.regular_channel.id
+        )
+        suggested_ids = {p["id"] for p in result["data"].get("res.partner", [])}
+        self.assertIn(self.gateway_user.partner_id.id, suggested_ids)
+        self.assertIn(self.regular_user.partner_id.id, suggested_ids)


### PR DESCRIPTION
See each commit for more details.

**In short:**
[[IMP] mail_gateway: Allow leaving the thread if it is a gateway channel.
](https://github.com/OCA/social/commit/d23d8449945cfc1610c82b15e8b655143674f1f7)
Before
<img width="311" height="459" alt="image" src="https://github.com/user-attachments/assets/082c783b-249b-481b-a5b5-d1c8ba63d7db" />
After
<img width="421" height="489" alt="image" src="https://github.com/user-attachments/assets/56f4545e-d4e8-4c20-9afa-96813ef4b3b0" />

[[FIX] mail_gateway: Only notify gateway channels that the user is still a member
](https://github.com/OCA/social/commit/553a9b86a6bf1bb6fabd1ab640b42d138fd485ac)
<img width="1627" height="796" alt="image" src="https://github.com/user-attachments/assets/60493e0a-9a47-421d-a1c6-548fed05ec5a" />

[[FIX] mail_gateway: Only allow inviting members of the mail_gateway.gateway_user security group
](https://github.com/OCA/social/commit/97b1d57a07bd6620f20aa38c60e74e62e85dfe98)
<img width="599" height="315" alt="image" src="https://github.com/user-attachments/assets/8490454b-e939-4c5d-83ca-6ba86455fe2d" />


TT61380
@Tecnativa @pedrobaeza @CarlosRoca13 @eduezerouali-tecnativa @etobella Could you please review this?
